### PR TITLE
feat(codecs): implement options package and codecs umbrella re-export

### DIFF
--- a/.changeset/options-codecs-umbrella.md
+++ b/.changeset/options-codecs-umbrella.md
@@ -1,0 +1,20 @@
+---
+solana_kit_options: minor
+solana_kit_codecs: minor
+---
+
+Implement options package and codecs umbrella re-export.
+
+**solana_kit_options** (90 tests):
+
+- Rust-like `Option<T>` sealed class with `Some<T>` and `None<T>` subclasses
+- Option codec with 6 encoding modes: prefix-based, zeroes, custom none value,
+  combined prefix+zeroes, combined prefix+custom, and absence-based detection
+- `unwrapOption()` and `unwrapOptionOr()` for extracting values with fallback
+- `wrapNullable()` for converting `T?` to `Option<T>`
+- `unwrapOptionRecursively()` for deep unwrapping of nested Options in Maps/Lists
+
+**solana_kit_codecs** (umbrella):
+
+- Re-exports all codec sub-packages: core, numbers, strings, data structures
+- Re-exports options package (matching TypeScript `@solana/codecs` behavior)

--- a/packages/solana_kit_codecs/lib/solana_kit_codecs.dart
+++ b/packages/solana_kit_codecs/lib/solana_kit_codecs.dart
@@ -1,1 +1,5 @@
-
+export 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+export 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+export 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+export 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+export 'package:solana_kit_options/solana_kit_options.dart';

--- a/packages/solana_kit_codecs/pubspec.yaml
+++ b/packages/solana_kit_codecs/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   solana_kit_codecs_data_structures:
   solana_kit_codecs_numbers:
   solana_kit_codecs_strings:
+  solana_kit_options:
 
 dev_dependencies:
   solana_kit_lints:

--- a/packages/solana_kit_options/lib/solana_kit_options.dart
+++ b/packages/solana_kit_options/lib/solana_kit_options.dart
@@ -1,1 +1,4 @@
-
+export 'src/option.dart';
+export 'src/option_codec.dart';
+export 'src/unwrap_option.dart';
+export 'src/unwrap_option_recursively.dart';

--- a/packages/solana_kit_options/lib/src/option.dart
+++ b/packages/solana_kit_options/lib/src/option.dart
@@ -1,0 +1,112 @@
+import 'package:meta/meta.dart';
+
+/// A Rust-like `Option<T>` type for representing optional values.
+///
+/// In Rust, optional values use `Option<T>`, which is either:
+/// - `Some(T)` — a present value.
+/// - `None` — the absence of a value.
+///
+/// Dart already has nullable types (`T?`), but they fail with nested options.
+/// For example, `Option<Option<T>>` cannot be represented as `T??` because
+/// there is no way to distinguish between `Some(None)` and `None`.
+///
+/// This sealed class hierarchy mirrors Rust's `Option<T>`:
+///
+/// ```dart
+/// final option = some(42); // Some<int>(42)
+/// final empty = none<int>(); // None<int>()
+/// ```
+@immutable
+sealed class Option<T> {
+  /// Creates an [Option].
+  const Option();
+}
+
+/// Represents an [Option] that contains a value.
+///
+/// ```dart
+/// final value = Some(42);
+/// value.value; // 42
+/// ```
+final class Some<T> extends Option<T> {
+  /// Creates a [Some] with the given [value].
+  const Some(this.value);
+
+  /// The contained value.
+  final T value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Some<T> &&
+          runtimeType == other.runtimeType &&
+          value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'Some($value)';
+}
+
+/// Represents an [Option] that contains no value.
+///
+/// ```dart
+/// final empty = const None<int>();
+/// ```
+final class None<T> extends Option<T> {
+  /// Creates a [None].
+  const None();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is None<T> && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'None';
+}
+
+/// Creates a new [Option] containing [value].
+///
+/// ```dart
+/// some(42); // Some<int>(42)
+/// some<int?>(null); // Some<int?>(null)
+/// ```
+Option<T> some<T>(T value) => Some<T>(value);
+
+/// Creates a new [Option] with no value.
+///
+/// ```dart
+/// none<int>(); // None<int>()
+/// ```
+Option<T> none<T>() => None<T>();
+
+/// Returns `true` if [input] is an [Option] (either [Some] or [None]).
+///
+/// ```dart
+/// isOption(some(42)); // true
+/// isOption(none()); // true
+/// isOption(42); // false
+/// isOption(null); // false
+/// ```
+bool isOption(Object? input) => input is Option;
+
+/// Returns `true` if [option] is a [Some].
+///
+/// ```dart
+/// isSome(some(42)); // true
+/// isSome(none()); // false
+/// ```
+bool isSome<T>(Option<T> option) => option is Some<T>;
+
+/// Returns `true` if [option] is a [None].
+///
+/// ```dart
+/// isNone(some(42)); // false
+/// isNone(none()); // true
+/// ```
+bool isNone<T>(Option<T> option) => option is None<T>;

--- a/packages/solana_kit_options/lib/src/option_codec.dart
+++ b/packages/solana_kit_options/lib/src/option_codec.dart
@@ -1,0 +1,361 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_options/src/option.dart';
+
+/// Specifies how [None] values are represented in the encoded data.
+sealed class OptionNoneValue {
+  /// Creates an [OptionNoneValue].
+  const OptionNoneValue();
+}
+
+/// [None] values are omitted from encoding (the default).
+class OmitOptionNoneValue extends OptionNoneValue {
+  /// Creates an omit none value.
+  const OmitOptionNoneValue();
+}
+
+/// The bytes allocated for the value are filled with zeroes.
+/// This requires a fixed-size codec for the item.
+class ZeroesOptionNoneValue extends OptionNoneValue {
+  /// Creates a zeroes none value.
+  const ZeroesOptionNoneValue();
+}
+
+/// [None] values are replaced with a predefined byte sequence.
+class ConstantOptionNoneValue extends OptionNoneValue {
+  /// Creates a constant none value.
+  const ConstantOptionNoneValue(this.bytes);
+
+  /// The byte sequence used to represent [None].
+  final Uint8List bytes;
+}
+
+/// Returns an encoder for optional values using the [Option] type.
+///
+/// This encoder serializes an [Option] or nullable value using a configurable
+/// approach:
+/// - By default, a `u8` prefix is used (`0 = None`, `1 = Some`).
+/// - If [noneValue] is [ZeroesOptionNoneValue], [None] values are encoded as
+///   zeroes.
+/// - If [noneValue] is [ConstantOptionNoneValue], [None] values are replaced
+///   with the provided constant.
+/// - If [hasPrefix] is `false`, no prefix is used.
+///
+/// The input accepts `Option<TFrom>` or `TFrom?` (via `Object?`) for encoding
+/// convenience.
+Encoder<Object?> getOptionEncoder<TFrom>(
+  Encoder<TFrom> item, {
+  Encoder<num>? prefix,
+  bool hasPrefix = true,
+  OptionNoneValue noneValue = const OmitOptionNoneValue(),
+}) {
+  // Determine none value size and encoder.
+  final int noneValueFixedSize;
+  if (noneValue is ZeroesOptionNoneValue) {
+    assertIsFixedSize(item);
+    noneValueFixedSize = (item as FixedSizeEncoder<TFrom>).fixedSize;
+  } else if (noneValue is ConstantOptionNoneValue) {
+    noneValueFixedSize = noneValue.bytes.length;
+  } else {
+    noneValueFixedSize = 0;
+  }
+
+  // Determine if the item is fixed-size.
+  final itemFixedSize = _getFixedSize(item);
+
+  // Determine overall codec size characteristics.
+  final prefixEncoderSize = hasPrefix
+      ? _getFixedSize(prefix ?? getU8Encoder())
+      : 0;
+
+  // Check if this should be fixed-size:
+  // Fixed if all components are fixed AND None + prefix == Some + prefix
+  final bool isFixed;
+  if (prefixEncoderSize != null &&
+      itemFixedSize != null &&
+      noneValueFixedSize == itemFixedSize) {
+    isFixed = true;
+  } else {
+    isFixed = false;
+  }
+
+  int writeImpl(Object? value, Uint8List bytes, int currentOffset) {
+    var pos = currentOffset;
+    final option = _toOption<TFrom>(value);
+    final actualPrefix = prefix ?? getU8Encoder();
+
+    if (isNone(option)) {
+      // Write prefix (0 = None).
+      if (hasPrefix) {
+        pos = actualPrefix.write(0, bytes, pos);
+      }
+      // Write none value.
+      if (noneValue is ZeroesOptionNoneValue) {
+        // Write zeroes for the item's fixed size.
+        for (var i = 0; i < noneValueFixedSize; i++) {
+          bytes[pos + i] = 0;
+        }
+        pos += noneValueFixedSize;
+      } else if (noneValue is ConstantOptionNoneValue) {
+        bytes.setAll(pos, noneValue.bytes);
+        pos += noneValue.bytes.length;
+      }
+      // OmitOptionNoneValue: write nothing extra.
+      return pos;
+    }
+
+    // Some case.
+    final someValue = (option as Some<TFrom>).value;
+    if (hasPrefix) {
+      pos = actualPrefix.write(1, bytes, pos);
+    }
+    return item.write(someValue, bytes, pos);
+  }
+
+  if (isFixed) {
+    final totalFixedSize = (prefixEncoderSize ?? 0) + itemFixedSize!;
+    return FixedSizeEncoder<Object?>(
+      fixedSize: totalFixedSize,
+      write: writeImpl,
+    );
+  }
+
+  return VariableSizeEncoder<Object?>(
+    getSizeFromValue: (Object? value) {
+      final option = _toOption<TFrom>(value);
+      if (isNone(option)) {
+        final pSize = hasPrefix
+            ? getEncodedSize(0, prefix ?? getU8Encoder())
+            : 0;
+        return pSize + noneValueFixedSize;
+      }
+      final someValue = (option as Some<TFrom>).value;
+      final pSize = hasPrefix ? getEncodedSize(1, prefix ?? getU8Encoder()) : 0;
+      return pSize + getEncodedSize(someValue, item);
+    },
+    write: writeImpl,
+    maxSize: _computeMaxSize(
+      hasPrefix ? (prefix ?? getU8Encoder()) : null,
+      item,
+      noneValueFixedSize,
+    ),
+  );
+}
+
+/// Returns a decoder for optional values using the [Option] type.
+///
+/// This decoder deserializes an `Option<TTo>` value using a configurable
+/// approach:
+/// - By default, a `u8` prefix is used (`0 = None`, `1 = Some`).
+/// - If [noneValue] is [ZeroesOptionNoneValue], [None] values are identified
+///   by zeroes.
+/// - If [noneValue] is [ConstantOptionNoneValue], [None] values match the
+///   provided constant.
+/// - If [hasPrefix] is `false`, no prefix is used.
+Decoder<Option<TTo>> getOptionDecoder<TTo>(
+  Decoder<TTo> item, {
+  Decoder<num>? prefix,
+  bool hasPrefix = true,
+  OptionNoneValue noneValue = const OmitOptionNoneValue(),
+}) {
+  // Determine prefix size.
+  final int? prefixDecoderSize;
+  if (!hasPrefix) {
+    prefixDecoderSize = 0;
+  } else {
+    prefixDecoderSize = _getFixedSize(prefix ?? getU8Decoder());
+  }
+
+  // Determine none value size.
+  final int noneValueFixedSize;
+  if (noneValue is ZeroesOptionNoneValue) {
+    assertIsFixedSize(item);
+    noneValueFixedSize = (item as FixedSizeDecoder<TTo>).fixedSize;
+  } else if (noneValue is ConstantOptionNoneValue) {
+    noneValueFixedSize = noneValue.bytes.length;
+  } else {
+    noneValueFixedSize = 0;
+  }
+
+  // Determine if the item is fixed-size.
+  final itemFixedSize = _getFixedSize(item);
+
+  // Check if this should be fixed-size.
+  final bool isFixed;
+  if (prefixDecoderSize != null &&
+      itemFixedSize != null &&
+      noneValueFixedSize == itemFixedSize) {
+    isFixed = true;
+  } else {
+    isFixed = false;
+  }
+
+  (Option<TTo>, int) readImpl(Uint8List bytes, int currentOffset) {
+    var pos = currentOffset;
+    final actualPrefix = prefix ?? getU8Decoder();
+
+    // Determine if the value is present.
+    final bool isPresent;
+    if (!hasPrefix && noneValue is OmitOptionNoneValue) {
+      // No prefix, no none value: present if there are bytes left.
+      isPresent = pos < bytes.length;
+    } else if (!hasPrefix && noneValue is! OmitOptionNoneValue) {
+      // No prefix, but has none value: compare bytes.
+      final Uint8List zeroValue;
+      if (noneValue is ZeroesOptionNoneValue) {
+        zeroValue = Uint8List(noneValueFixedSize);
+      } else {
+        zeroValue = (noneValue as ConstantOptionNoneValue).bytes;
+      }
+      isPresent = !containsBytes(bytes, zeroValue, pos);
+    } else {
+      // Has prefix: read it.
+      final (prefixValue, newOffset) = actualPrefix.read(bytes, pos);
+      isPresent = prefixValue.toInt() != 0;
+      pos = newOffset;
+    }
+
+    if (!isPresent) {
+      // Skip the none value bytes.
+      pos += noneValueFixedSize;
+      return (none<TTo>(), pos);
+    }
+
+    final (value, newOffset) = item.read(bytes, pos);
+    return (some(value), newOffset);
+  }
+
+  if (isFixed) {
+    final totalFixedSize = (prefixDecoderSize ?? 0) + itemFixedSize!;
+    return FixedSizeDecoder<Option<TTo>>(
+      fixedSize: totalFixedSize,
+      read: readImpl,
+    );
+  }
+
+  return VariableSizeDecoder<Option<TTo>>(read: readImpl);
+}
+
+/// Returns a codec for encoding and decoding optional values using the
+/// [Option] type.
+///
+/// This codec serializes and deserializes `Option<T>` values.
+///
+/// See [getOptionEncoder] and [getOptionDecoder] for details on
+/// configuration options.
+Codec<Object?, Option<TTo>> getOptionCodec<TFrom, TTo extends TFrom>(
+  Codec<TFrom, TTo> item, {
+  Codec<num, num>? prefix,
+  bool hasPrefix = true,
+  OptionNoneValue noneValue = const OmitOptionNoneValue(),
+}) {
+  final encoder = getOptionEncoder<TFrom>(
+    encoderFromCodec(item),
+    prefix: prefix != null ? encoderFromCodec(prefix) : null,
+    hasPrefix: hasPrefix,
+    noneValue: noneValue,
+  );
+  final decoder = getOptionDecoder<TTo>(
+    decoderFromCodec(item),
+    prefix: prefix != null ? decoderFromCodec(prefix) : null,
+    hasPrefix: hasPrefix,
+    noneValue: noneValue,
+  );
+
+  // Determine sizes to construct the right codec type.
+  final encoderIsFixed = isFixedSize(encoder);
+  final decoderIsFixed = isFixedSize(decoder);
+
+  if (encoderIsFixed && decoderIsFixed) {
+    final enc = encoder as FixedSizeEncoder<Object?>;
+    return FixedSizeCodec<Object?, Option<TTo>>(
+      fixedSize: enc.fixedSize,
+      write: encoder.write,
+      read: decoder.read,
+    );
+  }
+
+  final maxSize = encoder is VariableSizeEncoder<Object?>
+      ? encoder.maxSize
+      : null;
+
+  return VariableSizeCodec<Object?, Option<TTo>>(
+    getSizeFromValue: (Object? value) {
+      if (encoder case VariableSizeEncoder<Object?>()) {
+        return encoder.getSizeFromValue(value);
+      }
+      return (encoder as FixedSizeEncoder<Object?>).fixedSize;
+    },
+    write: encoder.write,
+    read: decoder.read,
+    maxSize: maxSize,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Converts an input value to an [Option].
+///
+/// Accepts [Option<TFrom>], `TFrom?`, or `null`.
+Option<TFrom> _toOption<TFrom>(Object? value) {
+  if (value is Option<TFrom>) return value;
+  if (value == null) return none<TFrom>();
+  // Treat as a raw value (TFrom).
+  return some(value as TFrom);
+}
+
+/// Returns the fixed size of a codec, encoder, or decoder, or `null` if it
+/// is variable-size.
+int? _getFixedSize(Object codec) {
+  if (codec is FixedSizeEncoder) return codec.fixedSize;
+  if (codec is FixedSizeDecoder) return codec.fixedSize;
+  if (codec is FixedSizeCodec) return codec.fixedSize;
+  return null;
+}
+
+/// Computes the max size for a variable-size option codec.
+int? _computeMaxSize(
+  Encoder<num>? prefix,
+  Object itemCodec,
+  int noneValueSize,
+) {
+  // Get prefix max.
+  final int prefixMax;
+  if (prefix == null) {
+    prefixMax = 0;
+  } else if (prefix is FixedSizeEncoder<num>) {
+    prefixMax = prefix.fixedSize;
+  } else if (prefix is VariableSizeEncoder<num>) {
+    if (prefix.maxSize == null) return null;
+    prefixMax = prefix.maxSize!;
+  } else {
+    return null;
+  }
+
+  // Get item max.
+  final int itemMax;
+  if (itemCodec is FixedSizeEncoder) {
+    itemMax = itemCodec.fixedSize;
+  } else if (itemCodec is VariableSizeEncoder) {
+    if (itemCodec.maxSize == null) return null;
+    itemMax = itemCodec.maxSize!;
+  } else if (itemCodec is FixedSizeDecoder) {
+    itemMax = itemCodec.fixedSize;
+  } else if (itemCodec is VariableSizeDecoder) {
+    if (itemCodec.maxSize == null) return null;
+    itemMax = itemCodec.maxSize!;
+  } else {
+    return null;
+  }
+
+  // Max is the larger of the two branches:
+  // Branch 1 (Some): prefix + item
+  // Branch 2 (None): prefix + noneValue
+  final someSize = prefixMax + itemMax;
+  final noneSize = prefixMax + noneValueSize;
+  return someSize > noneSize ? someSize : noneSize;
+}

--- a/packages/solana_kit_options/lib/src/unwrap_option.dart
+++ b/packages/solana_kit_options/lib/src/unwrap_option.dart
@@ -1,0 +1,48 @@
+import 'package:solana_kit_options/src/option.dart';
+
+/// Unwraps the value of an [Option], returning its contained value or `null`.
+///
+/// - If the option is [Some], returns the contained value `T`.
+/// - If the option is [None], returns `null`.
+///
+/// ```dart
+/// unwrapOption(some(42)); // 42
+/// unwrapOption(none<int>()); // null
+/// ```
+T? unwrapOption<T>(Option<T> option) {
+  return switch (option) {
+    Some<T>(:final value) => value,
+    None<T>() => null,
+  };
+}
+
+/// Unwraps the value of an [Option], returning its contained value or the
+/// result of [fallback].
+///
+/// - If the option is [Some], returns the contained value.
+/// - If the option is [None], calls [fallback] and returns the result.
+///
+/// ```dart
+/// unwrapOptionOr(some(42), () => 0); // 42
+/// unwrapOptionOr(none<int>(), () => 0); // 0
+/// ```
+T unwrapOptionOr<T>(Option<T> option, T Function() fallback) {
+  return switch (option) {
+    Some<T>(:final value) => value,
+    None<T>() => fallback(),
+  };
+}
+
+/// Wraps a nullable value into an [Option].
+///
+/// - If [nullable] is `null`, returns [None].
+/// - Otherwise, returns [Some] containing the value.
+///
+/// ```dart
+/// wrapNullable(42); // Some(42)
+/// wrapNullable<int>(null); // None<int>()
+/// ```
+Option<T> wrapNullable<T>(T? nullable) {
+  if (nullable == null) return none<T>();
+  return some(nullable);
+}

--- a/packages/solana_kit_options/lib/src/unwrap_option_recursively.dart
+++ b/packages/solana_kit_options/lib/src/unwrap_option_recursively.dart
@@ -1,0 +1,60 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_options/src/option.dart';
+
+/// Recursively unwraps all nested [Option] types within a value.
+///
+/// This function traverses a given value and removes all instances
+/// of [Option], replacing them with their contained values.
+///
+/// - If an [Option] is encountered, its value is extracted.
+/// - If a [Map] or [List] is encountered, its elements are traversed
+///   recursively.
+/// - If [None] is encountered, it is replaced with `null` or the result of
+///   [fallback] if provided.
+///
+/// ```dart
+/// unwrapOptionRecursively(some(some('Hello'))); // "Hello"
+/// unwrapOptionRecursively(some(none<String>())); // null
+///
+/// unwrapOptionRecursively({
+///   'a': 'hello',
+///   'b': none<String>(),
+///   'c': [some(42), none<int>()],
+/// });
+/// // {'a': 'hello', 'b': null, 'c': [42, null]}
+/// ```
+Object? unwrapOptionRecursively(Object? input, [Object? Function()? fallback]) {
+  // Null and typed data pass through.
+  if (input == null || input is TypedData) {
+    return input;
+  }
+
+  // Primitive types pass through.
+  if (input is num || input is bool || input is String) {
+    return input;
+  }
+
+  Object? next(Object? x) => unwrapOptionRecursively(x, fallback);
+
+  // Handle Option.
+  if (input is Option) {
+    return switch (input) {
+      Some(:final value) => next(value),
+      None() => fallback != null ? fallback() : null,
+    };
+  }
+
+  // Handle List.
+  if (input is List) {
+    return input.map(next).toList();
+  }
+
+  // Handle Map.
+  if (input is Map) {
+    return input.map((key, value) => MapEntry(key, next(value)));
+  }
+
+  // Everything else passes through.
+  return input;
+}

--- a/packages/solana_kit_options/pubspec.yaml
+++ b/packages/solana_kit_options/pubspec.yaml
@@ -8,8 +8,11 @@ environment:
 resolution: workspace
 
 dependencies:
+  meta: ^1.16.0
   solana_kit_codecs_core:
+  solana_kit_codecs_numbers:
   solana_kit_errors:
 
 dev_dependencies:
   solana_kit_lints:
+  test: ^1.25.0

--- a/packages/solana_kit_options/test/option_codec_test.dart
+++ b/packages/solana_kit_options/test/option_codec_test.dart
@@ -1,0 +1,681 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_options/solana_kit_options.dart';
+import 'package:test/test.dart';
+
+import 'setup.dart';
+
+void main() {
+  group('getOptionCodec', () {
+    group('with prefix', () {
+      test('encodes option numbers', () {
+        final codec = getOptionCodec(getU16Codec());
+        expect(hex(codec.encode(0)), equals('010000'));
+        expect(hex(codec.encode(some(0))), equals('010000'));
+        expect(hex(codec.encode(42)), equals('012a00'));
+        expect(hex(codec.encode(some(42))), equals('012a00'));
+        expect(hex(codec.encode(null)), equals('00'));
+        expect(hex(codec.encode(none<num>())), equals('00'));
+      });
+
+      test('decodes option numbers', () {
+        final codec = getOptionCodec(getU16Codec());
+        expect(codec.decode(b('010000')), equals(some(0)));
+        expect(codec.decode(b('012a00')), equals(some(42)));
+        expect(codec.decode(b('00')), equals(none<int>()));
+      });
+
+      test('encodes option numbers with explicit prefix', () {
+        final codec = getOptionCodec(getU16Codec(), prefix: getU8Codec());
+        expect(hex(codec.encode(0)), equals('010000'));
+        expect(hex(codec.encode(some(0))), equals('010000'));
+        expect(hex(codec.encode(42)), equals('012a00'));
+        expect(hex(codec.encode(some(42))), equals('012a00'));
+        expect(hex(codec.encode(null)), equals('00'));
+        expect(hex(codec.encode(none<num>())), equals('00'));
+      });
+
+      test('decodes option numbers with explicit prefix', () {
+        final codec = getOptionCodec(getU16Codec(), prefix: getU8Codec());
+        expect(codec.decode(b('010000')), equals(some(0)));
+        expect(codec.decode(b('012a00')), equals(some(42)));
+        expect(codec.decode(b('00')), equals(none<int>()));
+      });
+
+      test('encodes option numbers with custom prefix', () {
+        final codec = getOptionCodec(getU16Codec(), prefix: getU32Codec());
+        expect(hex(codec.encode(0)), equals('010000000000'));
+        expect(hex(codec.encode(some(0))), equals('010000000000'));
+        expect(hex(codec.encode(42)), equals('010000002a00'));
+        expect(hex(codec.encode(some(42))), equals('010000002a00'));
+        expect(hex(codec.encode(null)), equals('00000000'));
+        expect(hex(codec.encode(none<num>())), equals('00000000'));
+      });
+
+      test('decodes option numbers with custom prefix', () {
+        final codec = getOptionCodec(getU16Codec(), prefix: getU32Codec());
+        expect(codec.decode(b('010000000000')), equals(some(0)));
+        expect(codec.decode(b('010000002a00')), equals(some(42)));
+        expect(codec.decode(b('00000000')), equals(none<int>()));
+      });
+
+      test('encodes nested option numbers', () {
+        final codec = getOptionCodec(getOptionCodec(getU16Codec()));
+        expect(hex(codec.encode(42)), equals('01012a00'));
+        expect(hex(codec.encode(some(42))), equals('01012a00'));
+        expect(hex(codec.encode(some(some(42)))), equals('01012a00'));
+        expect(hex(codec.encode(some<Object?>(null))), equals('0100'));
+        expect(hex(codec.encode(some(none<int>()))), equals('0100'));
+        expect(hex(codec.encode(null)), equals('00'));
+        expect(hex(codec.encode(none<Object?>())), equals('00'));
+      });
+
+      test('decodes nested option numbers', () {
+        final codec = getOptionCodec(getOptionCodec(getU16Codec()));
+        expect(codec.decode(b('01012a00')), equals(some(some(42))));
+        expect(codec.decode(b('0100')), equals(some(none<int>())));
+        expect(codec.decode(b('00')), equals(none<Option<int>>()));
+      });
+
+      test('pushes the offset forward when writing', () {
+        final codec = getOptionCodec(getU16Codec());
+        expect(codec.write(257, Uint8List(10), 3), equals(6));
+        expect(codec.write(null, Uint8List(10), 3), equals(4));
+      });
+
+      test('pushes the offset forward when reading', () {
+        final codec = getOptionCodec(getU16Codec());
+        expect(codec.read(b('ffff01010100'), 2), equals((some(257), 5)));
+        expect(codec.read(b('ffff00'), 2), equals((none<int>(), 3)));
+      });
+
+      test('returns a variable size codec with max size', () {
+        final codec = getOptionCodec(getU16Codec());
+        expect(codec, isA<VariableSizeCodec<Object?, Option<int>>>());
+        final varCodec = codec as VariableSizeCodec<Object?, Option<int>>;
+        expect(varCodec.getSizeFromValue(null), equals(1));
+        expect(varCodec.getSizeFromValue(42), equals(3));
+        expect(varCodec.maxSize, equals(3));
+      });
+    });
+
+    group('with zeroable none value', () {
+      test('encodes option numbers', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          hasPrefix: false,
+        );
+        expect(hex(codec.encode(42)), equals('2a00'));
+        expect(hex(codec.encode(some(42))), equals('2a00'));
+        expect(hex(codec.encode(null)), equals('0000'));
+        expect(hex(codec.encode(none<num>())), equals('0000'));
+      });
+
+      test('decodes option numbers', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          hasPrefix: false,
+        );
+        expect(codec.decode(b('2a00')), equals(some(42)));
+        expect(codec.decode(b('0000')), equals(none<int>()));
+      });
+
+      test('can end up encoding the none value', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          hasPrefix: false,
+        );
+        expect(hex(codec.encode(0)), equals('0000'));
+      });
+
+      test('encodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(
+            getU16Codec(),
+            noneValue: const ZeroesOptionNoneValue(),
+            hasPrefix: false,
+          ),
+          noneValue: const ZeroesOptionNoneValue(),
+          hasPrefix: false,
+        );
+        expect(hex(codec.encode(42)), equals('2a00'));
+        expect(hex(codec.encode(some(42))), equals('2a00'));
+        expect(hex(codec.encode(some(some(42)))), equals('2a00'));
+        expect(hex(codec.encode(some<Object?>(null))), equals('0000'));
+        expect(hex(codec.encode(some(none<int>()))), equals('0000'));
+        expect(hex(codec.encode(null)), equals('0000'));
+        expect(hex(codec.encode(none<Object?>())), equals('0000'));
+      });
+
+      test('decodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(
+            getU16Codec(),
+            noneValue: const ZeroesOptionNoneValue(),
+            hasPrefix: false,
+          ),
+          noneValue: const ZeroesOptionNoneValue(),
+          hasPrefix: false,
+        );
+        expect(codec.decode(b('2a00')), equals(some(some(42))));
+        expect(codec.decode(b('0000')), equals(none<Option<int>>()));
+      });
+
+      test('pushes the offset forward when writing', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          hasPrefix: false,
+        );
+        expect(codec.write(257, Uint8List(10), 3), equals(5));
+        expect(codec.write(null, Uint8List(10), 3), equals(5));
+      });
+
+      test('pushes the offset forward when reading', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          hasPrefix: false,
+        );
+        expect(codec.read(b('ffff010100'), 2), equals((some(257), 4)));
+        expect(codec.read(b('ffff000000'), 2), equals((none<int>(), 4)));
+      });
+
+      test('returns a fixed size codec', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          hasPrefix: false,
+        );
+        expect(codec, isA<FixedSizeCodec<Object?, Option<int>>>());
+        expect(
+          (codec as FixedSizeCodec<Object?, Option<int>>).fixedSize,
+          equals(2),
+        );
+      });
+
+      test('fails if the item is not fixed', () {
+        // Variable-size items cannot use zeroes none value.
+        expect(
+          () => getOptionCodec(
+            _getVariableSizeCodec(),
+            noneValue: const ZeroesOptionNoneValue(),
+            hasPrefix: false,
+          ),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              equals(SolanaErrorCode.codecsExpectedFixedLength),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('with custom none value', () {
+      test('encodes option numbers', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          hasPrefix: false,
+        );
+        expect(hex(codec.encode(42)), equals('2a00'));
+        expect(hex(codec.encode(some(42))), equals('2a00'));
+        expect(hex(codec.encode(null)), equals('ffff'));
+        expect(hex(codec.encode(none<num>())), equals('ffff'));
+      });
+
+      test('decodes option numbers', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          hasPrefix: false,
+        );
+        expect(codec.decode(b('2a00')), equals(some(42)));
+        expect(codec.decode(b('ffff')), equals(none<int>()));
+      });
+
+      test('can end up encoding the none value', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          hasPrefix: false,
+        );
+        expect(hex(codec.encode(65535)), equals('ffff'));
+      });
+
+      test('encodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(
+            getU16Codec(),
+            noneValue: ConstantOptionNoneValue(b('ffff')),
+            hasPrefix: false,
+          ),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          hasPrefix: false,
+        );
+        expect(hex(codec.encode(42)), equals('2a00'));
+        expect(hex(codec.encode(some(42))), equals('2a00'));
+        expect(hex(codec.encode(some(some(42)))), equals('2a00'));
+        expect(hex(codec.encode(some<Object?>(null))), equals('ffff'));
+        expect(hex(codec.encode(some(none<int>()))), equals('ffff'));
+        expect(hex(codec.encode(null)), equals('ffff'));
+        expect(hex(codec.encode(none<Object?>())), equals('ffff'));
+      });
+
+      test('decodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(
+            getU16Codec(),
+            noneValue: ConstantOptionNoneValue(b('ffff')),
+            hasPrefix: false,
+          ),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          hasPrefix: false,
+        );
+        expect(codec.decode(b('2a00')), equals(some(some(42))));
+        expect(codec.decode(b('ffff')), equals(none<Option<int>>()));
+      });
+
+      test('pushes the offset forward when writing', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          hasPrefix: false,
+        );
+        expect(codec.write(257, Uint8List(10), 3), equals(5));
+        expect(codec.write(null, Uint8List(10), 3), equals(5));
+      });
+
+      test('pushes the offset forward when reading', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('aaaa')),
+          hasPrefix: false,
+        );
+        expect(codec.read(b('ffff010100'), 2), equals((some(257), 4)));
+        expect(codec.read(b('ffffaaaa00'), 2), equals((none<int>(), 4)));
+      });
+
+      test('returns a variable size codec for different-length none value', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffffffff')),
+          hasPrefix: false,
+        );
+        expect(codec, isA<VariableSizeCodec<Object?, Option<int>>>());
+        final varCodec = codec as VariableSizeCodec<Object?, Option<int>>;
+        expect(varCodec.getSizeFromValue(null), equals(4));
+        expect(varCodec.getSizeFromValue(42), equals(2));
+        expect(varCodec.maxSize, equals(4));
+      });
+    });
+
+    group('with prefix and zeroable none value', () {
+      test('encodes option numbers', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+        );
+        expect(hex(codec.encode(0)), equals('010000'));
+        expect(hex(codec.encode(some(0))), equals('010000'));
+        expect(hex(codec.encode(42)), equals('012a00'));
+        expect(hex(codec.encode(some(42))), equals('012a00'));
+        expect(hex(codec.encode(null)), equals('000000'));
+        expect(hex(codec.encode(none<num>())), equals('000000'));
+      });
+
+      test('decodes option numbers', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+        );
+        expect(codec.decode(b('010000')), equals(some(0)));
+        expect(codec.decode(b('012a00')), equals(some(42)));
+        expect(codec.decode(b('000000')), equals(none<int>()));
+      });
+
+      test('encodes option numbers with explicit prefix', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          prefix: getU8Codec(),
+        );
+        expect(hex(codec.encode(0)), equals('010000'));
+        expect(hex(codec.encode(some(0))), equals('010000'));
+        expect(hex(codec.encode(42)), equals('012a00'));
+        expect(hex(codec.encode(some(42))), equals('012a00'));
+        expect(hex(codec.encode(null)), equals('000000'));
+        expect(hex(codec.encode(none<num>())), equals('000000'));
+      });
+
+      test('decodes option numbers with explicit prefix', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          prefix: getU8Codec(),
+        );
+        expect(codec.decode(b('010000')), equals(some(0)));
+        expect(codec.decode(b('012a00')), equals(some(42)));
+        expect(codec.decode(b('000000')), equals(none<int>()));
+      });
+
+      test('encodes option numbers with custom prefix', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          prefix: getU32Codec(),
+        );
+        expect(hex(codec.encode(0)), equals('010000000000'));
+        expect(hex(codec.encode(42)), equals('010000002a00'));
+        expect(hex(codec.encode(null)), equals('000000000000'));
+      });
+
+      test('decodes option numbers with custom prefix', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+          prefix: getU32Codec(),
+        );
+        expect(codec.decode(b('010000000000')), equals(some(0)));
+        expect(codec.decode(b('010000002a00')), equals(some(42)));
+        expect(codec.decode(b('000000000000')), equals(none<int>()));
+      });
+
+      test('encodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(
+            getU16Codec(),
+            noneValue: const ZeroesOptionNoneValue(),
+          ),
+          noneValue: const ZeroesOptionNoneValue(),
+        );
+        expect(hex(codec.encode(42)), equals('01012a00'));
+        expect(hex(codec.encode(some(42))), equals('01012a00'));
+        expect(hex(codec.encode(some(some(42)))), equals('01012a00'));
+        expect(hex(codec.encode(some<Object?>(null))), equals('01000000'));
+        expect(hex(codec.encode(some(none<int>()))), equals('01000000'));
+        expect(hex(codec.encode(null)), equals('00000000'));
+        expect(hex(codec.encode(none<Object?>())), equals('00000000'));
+      });
+
+      test('decodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(
+            getU16Codec(),
+            noneValue: const ZeroesOptionNoneValue(),
+          ),
+          noneValue: const ZeroesOptionNoneValue(),
+        );
+        expect(codec.decode(b('01012a00')), equals(some(some(42))));
+        expect(codec.decode(b('01000000')), equals(some(none<int>())));
+        expect(codec.decode(b('00000000')), equals(none<Option<int>>()));
+      });
+
+      test('pushes the offset forward when writing', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+        );
+        expect(codec.write(257, Uint8List(10), 3), equals(6));
+        expect(codec.write(null, Uint8List(10), 3), equals(6));
+      });
+
+      test('pushes the offset forward when reading', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+        );
+        expect(codec.read(b('ffff01010100'), 2), equals((some(257), 5)));
+        expect(codec.read(b('ffff00000000'), 2), equals((none<int>(), 5)));
+      });
+
+      test('returns a fixed size codec if the prefix is fixed', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: const ZeroesOptionNoneValue(),
+        );
+        expect(codec, isA<FixedSizeCodec<Object?, Option<int>>>());
+        expect(
+          (codec as FixedSizeCodec<Object?, Option<int>>).fixedSize,
+          equals(3),
+        );
+      });
+
+      test('fails if the item is not fixed', () {
+        expect(
+          () => getOptionCodec(
+            _getVariableSizeCodec(),
+            noneValue: const ZeroesOptionNoneValue(),
+          ),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              equals(SolanaErrorCode.codecsExpectedFixedLength),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('with prefix and custom none value', () {
+      test('encodes option numbers', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+        );
+        expect(hex(codec.encode(0)), equals('010000'));
+        expect(hex(codec.encode(some(0))), equals('010000'));
+        expect(hex(codec.encode(42)), equals('012a00'));
+        expect(hex(codec.encode(some(42))), equals('012a00'));
+        expect(hex(codec.encode(null)), equals('00ffff'));
+        expect(hex(codec.encode(none<num>())), equals('00ffff'));
+      });
+
+      test('decodes option numbers', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+        );
+        expect(codec.decode(b('010000')), equals(some(0)));
+        expect(codec.decode(b('012a00')), equals(some(42)));
+        expect(codec.decode(b('00ffff')), equals(none<int>()));
+      });
+
+      test('encodes option numbers with explicit prefix', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          prefix: getU8Codec(),
+        );
+        expect(hex(codec.encode(0)), equals('010000'));
+        expect(hex(codec.encode(some(0))), equals('010000'));
+        expect(hex(codec.encode(42)), equals('012a00'));
+        expect(hex(codec.encode(some(42))), equals('012a00'));
+        expect(hex(codec.encode(null)), equals('00ffff'));
+        expect(hex(codec.encode(none<num>())), equals('00ffff'));
+      });
+
+      test('decodes option numbers with explicit prefix', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          prefix: getU8Codec(),
+        );
+        expect(codec.decode(b('010000')), equals(some(0)));
+        expect(codec.decode(b('012a00')), equals(some(42)));
+        expect(codec.decode(b('00ffff')), equals(none<int>()));
+      });
+
+      test('encodes option numbers with custom prefix', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          prefix: getU32Codec(),
+        );
+        expect(hex(codec.encode(0)), equals('010000000000'));
+        expect(hex(codec.encode(some(0))), equals('010000000000'));
+        expect(hex(codec.encode(42)), equals('010000002a00'));
+        expect(hex(codec.encode(some(42))), equals('010000002a00'));
+        expect(hex(codec.encode(null)), equals('00000000ffff'));
+        expect(hex(codec.encode(none<num>())), equals('00000000ffff'));
+      });
+
+      test('decodes option numbers with custom prefix', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+          prefix: getU32Codec(),
+        );
+        expect(codec.decode(b('010000000000')), equals(some(0)));
+        expect(codec.decode(b('010000002a00')), equals(some(42)));
+        expect(codec.decode(b('00000000ffff')), equals(none<int>()));
+      });
+
+      test('encodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(
+            getU16Codec(),
+            noneValue: ConstantOptionNoneValue(b('ffff')),
+          ),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+        );
+        expect(hex(codec.encode(42)), equals('01012a00'));
+        expect(hex(codec.encode(some(42))), equals('01012a00'));
+        expect(hex(codec.encode(some(some(42)))), equals('01012a00'));
+        expect(hex(codec.encode(some<Object?>(null))), equals('0100ffff'));
+        expect(hex(codec.encode(some(none<int>()))), equals('0100ffff'));
+        expect(hex(codec.encode(null)), equals('00ffff'));
+        expect(hex(codec.encode(none<Object?>())), equals('00ffff'));
+      });
+
+      test('decodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(
+            getU16Codec(),
+            noneValue: ConstantOptionNoneValue(b('ffff')),
+          ),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+        );
+        expect(codec.decode(b('01012a00')), equals(some(some(42))));
+        expect(codec.decode(b('0100ffff')), equals(some(none<int>())));
+        expect(codec.decode(b('00ffff')), equals(none<Option<int>>()));
+      });
+
+      test('pushes the offset forward when writing', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffff')),
+        );
+        expect(codec.write(257, Uint8List(10), 3), equals(6));
+        expect(codec.write(null, Uint8List(10), 3), equals(6));
+      });
+
+      test('pushes the offset forward when reading', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('aaaa')),
+        );
+        expect(codec.read(b('ffff01010100'), 2), equals((some(257), 5)));
+        expect(codec.read(b('ffff00aaaa00'), 2), equals((none<int>(), 5)));
+      });
+
+      test('returns a variable size codec for different-length none value', () {
+        final codec = getOptionCodec(
+          getU16Codec(),
+          noneValue: ConstantOptionNoneValue(b('ffffffff')),
+        );
+        expect(codec, isA<VariableSizeCodec<Object?, Option<int>>>());
+        final varCodec = codec as VariableSizeCodec<Object?, Option<int>>;
+        expect(varCodec.getSizeFromValue(null), equals(5));
+        expect(varCodec.getSizeFromValue(42), equals(3));
+        expect(varCodec.maxSize, equals(5));
+      });
+    });
+
+    group('with no prefix nor none value', () {
+      test('encodes option numbers', () {
+        final codec = getOptionCodec(getU16Codec(), hasPrefix: false);
+        expect(hex(codec.encode(42)), equals('2a00'));
+        expect(hex(codec.encode(some(42))), equals('2a00'));
+        expect(hex(codec.encode(null)), equals(''));
+        expect(hex(codec.encode(none<num>())), equals(''));
+      });
+
+      test('decodes option numbers', () {
+        final codec = getOptionCodec(getU16Codec(), hasPrefix: false);
+        expect(codec.decode(b('2a00')), equals(some(42)));
+        expect(codec.decode(b('')), equals(none<int>()));
+      });
+
+      test('encodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(getU16Codec(), hasPrefix: false),
+          hasPrefix: false,
+        );
+        expect(hex(codec.encode(42)), equals('2a00'));
+        expect(hex(codec.encode(some(42))), equals('2a00'));
+        expect(hex(codec.encode(some(some(42)))), equals('2a00'));
+        expect(hex(codec.encode(some<Object?>(null))), equals(''));
+        expect(hex(codec.encode(some(none<int>()))), equals(''));
+        expect(hex(codec.encode(null)), equals(''));
+        expect(hex(codec.encode(none<Object?>())), equals(''));
+      });
+
+      test('decodes nested option numbers', () {
+        final codec = getOptionCodec(
+          getOptionCodec(getU16Codec(), hasPrefix: false),
+          hasPrefix: false,
+        );
+        expect(codec.decode(b('2a00')), equals(some(some(42))));
+        expect(codec.decode(b('')), equals(none<Option<int>>()));
+      });
+
+      test('pushes the offset forward when writing', () {
+        final codec = getOptionCodec(getU16Codec(), hasPrefix: false);
+        expect(codec.write(257, Uint8List(10), 3), equals(5));
+        expect(codec.write(null, Uint8List(10), 3), equals(3));
+      });
+
+      test('pushes the offset forward when reading', () {
+        final codec = getOptionCodec(getU16Codec(), hasPrefix: false);
+        expect(codec.read(b('ffff010100'), 2), equals((some(257), 4)));
+        expect(codec.read(b('ffff'), 2), equals((none<int>(), 2)));
+      });
+
+      test('returns a variable size codec', () {
+        final codec = getOptionCodec(getU16Codec(), hasPrefix: false);
+        expect(codec, isA<VariableSizeCodec<Object?, Option<int>>>());
+        final varCodec = codec as VariableSizeCodec<Object?, Option<int>>;
+        expect(varCodec.getSizeFromValue(null), equals(0));
+        expect(varCodec.getSizeFromValue(42), equals(2));
+        expect(varCodec.maxSize, equals(2));
+      });
+    });
+  });
+}
+
+/// Creates a variable-size codec for testing error cases.
+VariableSizeCodec<String, String> _getVariableSizeCodec() {
+  return VariableSizeCodec<String, String>(
+    getSizeFromValue: (value) => value.length,
+    write: (value, bytes, offset) {
+      for (var i = 0; i < value.length; i++) {
+        bytes[offset + i] = value.codeUnitAt(i);
+      }
+      return offset + value.length;
+    },
+    read: (bytes, offset) {
+      final value = String.fromCharCodes(bytes, offset);
+      return (value, bytes.length);
+    },
+  );
+}

--- a/packages/solana_kit_options/test/option_test.dart
+++ b/packages/solana_kit_options/test/option_test.dart
@@ -1,0 +1,86 @@
+import 'package:solana_kit_options/solana_kit_options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Option', () {
+    test('can create Some options', () {
+      final option = some(42);
+      expect(option, isA<Some<int>>());
+      expect((option as Some<int>).value, equals(42));
+    });
+
+    test('can create None options', () {
+      final option = none<int>();
+      expect(option, isA<None<int>>());
+    });
+
+    test('Some with null value is allowed', () {
+      final option = some<int?>(null);
+      expect(option, isA<Some<int?>>());
+      expect((option as Some<int?>).value, isNull);
+    });
+
+    test('Some equality', () {
+      expect(some(42), equals(some(42)));
+      expect(some(42), isNot(equals(some(43))));
+      expect(some('hello'), equals(some('hello')));
+    });
+
+    test('None equality', () {
+      expect(none<int>(), equals(none<int>()));
+    });
+
+    test('Some and None are not equal', () {
+      expect(some(42), isNot(equals(none<int>())));
+    });
+
+    test('Some hashCode', () {
+      expect(some(42).hashCode, equals(some(42).hashCode));
+    });
+
+    test('Some toString', () {
+      expect(some(42).toString(), equals('Some(42)'));
+      expect(some('hello').toString(), equals('Some(hello)'));
+    });
+
+    test('None toString', () {
+      expect(none<int>().toString(), equals('None'));
+    });
+
+    test('isSome returns true for Some', () {
+      expect(isSome(some(42)), isTrue);
+      expect(isSome(none<int>()), isFalse);
+    });
+
+    test('isNone returns true for None', () {
+      expect(isNone(some(42)), isFalse);
+      expect(isNone(none<int>()), isTrue);
+    });
+
+    test('isOption returns true for Option types', () {
+      expect(isOption(some(42)), isTrue);
+      expect(isOption(none<int>()), isTrue);
+      expect(isOption(42), isFalse);
+      expect(isOption(null), isFalse);
+      expect(isOption('anything'), isFalse);
+    });
+
+    test('pattern matching with switch', () {
+      Option<int> makeOption() => some(42);
+      final option = makeOption();
+      final result = switch (option) {
+        Some<int>(:final value) => 'Some($value)',
+        None<int>() => 'None',
+      };
+      expect(result, equals('Some(42)'));
+
+      Option<int> makeNone() => none<int>();
+      final noneOption = makeNone();
+      final noneResult = switch (noneOption) {
+        Some<int>(:final value) => 'Some($value)',
+        None<int>() => 'None',
+      };
+      expect(noneResult, equals('None'));
+    });
+  });
+}

--- a/packages/solana_kit_options/test/setup.dart
+++ b/packages/solana_kit_options/test/setup.dart
@@ -1,0 +1,18 @@
+import 'dart:typed_data';
+
+/// Converts a hex string into a [Uint8List].
+///
+/// Example: `b('010203')` returns `Uint8List.fromList([1, 2, 3])`.
+Uint8List b(String hex) {
+  if (hex.isEmpty) return Uint8List(0);
+  final bytes = <int>[];
+  for (var i = 0; i < hex.length; i += 2) {
+    bytes.add(int.parse(hex.substring(i, i + 2), radix: 16));
+  }
+  return Uint8List.fromList(bytes);
+}
+
+/// Converts a [Uint8List] to a hex string.
+String hex(Uint8List bytes) {
+  return bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+}

--- a/packages/solana_kit_options/test/unwrap_option_recursively_test.dart
+++ b/packages/solana_kit_options/test/unwrap_option_recursively_test.dart
@@ -1,0 +1,169 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_options/solana_kit_options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('unwrapOptionRecursively', () {
+    test('unwraps Some values', () {
+      expect(unwrapOptionRecursively(some<int?>(null)), isNull);
+      expect(unwrapOptionRecursively(some(42)), equals(42));
+      expect(unwrapOptionRecursively(some('hello')), equals('hello'));
+    });
+
+    test('unwraps None values to null', () {
+      expect(unwrapOptionRecursively(none<int>()), isNull);
+      expect(unwrapOptionRecursively(none<String>()), isNull);
+    });
+
+    test('unwraps nested Some and None values', () {
+      expect(unwrapOptionRecursively(some(some(some(false)))), equals(false));
+      expect(unwrapOptionRecursively(some(some(none<int>()))), isNull);
+    });
+
+    test('passes through scalars', () {
+      expect(unwrapOptionRecursively(1), equals(1));
+      expect(unwrapOptionRecursively('hello'), equals('hello'));
+      expect(unwrapOptionRecursively(true), equals(true));
+      expect(unwrapOptionRecursively(false), equals(false));
+      expect(unwrapOptionRecursively(null), isNull);
+    });
+
+    test('passes through TypedData', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      expect(unwrapOptionRecursively(bytes), equals(bytes));
+    });
+
+    test('passes through functions', () {
+      int fn() => 42;
+      expect(unwrapOptionRecursively(fn), equals(fn));
+    });
+
+    test('unwraps options inside Maps', () {
+      expect(
+        unwrapOptionRecursively({'foo': 'hello'}),
+        equals({'foo': 'hello'}),
+      );
+      expect(
+        unwrapOptionRecursively({'foo': none<String>()}),
+        equals({'foo': null}),
+      );
+      expect(
+        unwrapOptionRecursively({'foo': some(none<String>())}),
+        equals({'foo': null}),
+      );
+      expect(
+        unwrapOptionRecursively(some({'baz': none<int>(), 'foo': some('bar')})),
+        equals({'baz': null, 'foo': 'bar'}),
+      );
+    });
+
+    test('unwraps options inside Lists', () {
+      expect(unwrapOptionRecursively([1, true, '3']), equals([1, true, '3']));
+      expect(
+        unwrapOptionRecursively([some('a'), none<bool>(), some(some(3)), 'b']),
+        equals(['a', null, 3, 'b']),
+      );
+    });
+
+    test('unwraps complex nested structure', () {
+      final person = {
+        'name': 'Roo',
+        'age': 42,
+        'gender': none<String>(),
+        'address': {
+          'street': '11215 104 Ave NW',
+          'city': 'Edmonton',
+          'region': some('Alberta'),
+          'country': 'Canada',
+          'zipcode': 'T5K 2S1',
+          'phone': none<String>(),
+        },
+        'interests': [
+          {'name': 'Programming', 'category': some('IT')},
+          {'name': 'Modular Synths', 'category': some('Music')},
+          {'name': 'Popping bubble wrap', 'category': none<String>()},
+        ],
+      };
+
+      expect(
+        unwrapOptionRecursively(person),
+        equals({
+          'name': 'Roo',
+          'age': 42,
+          'gender': null,
+          'address': {
+            'street': '11215 104 Ave NW',
+            'city': 'Edmonton',
+            'region': 'Alberta',
+            'country': 'Canada',
+            'zipcode': 'T5K 2S1',
+            'phone': null,
+          },
+          'interests': [
+            {'name': 'Programming', 'category': 'IT'},
+            {'name': 'Modular Synths', 'category': 'Music'},
+            {'name': 'Popping bubble wrap', 'category': null},
+          ],
+        }),
+      );
+    });
+
+    test('uses custom fallback for None', () {
+      Object? fallback() => 42;
+
+      expect(unwrapOptionRecursively(some<int?>(null), fallback), isNull);
+      expect(unwrapOptionRecursively(some(100), fallback), equals(100));
+      expect(unwrapOptionRecursively(none<int>(), fallback), equals(42));
+      expect(
+        unwrapOptionRecursively(some(some(none<int>())), fallback),
+        equals(42),
+      );
+    });
+
+    test('uses custom fallback in complex structures', () {
+      Object? fallback() => 42;
+
+      final person = {
+        'name': 'Roo',
+        'age': 42,
+        'gender': none<String>(),
+        'address': {
+          'street': '11215 104 Ave NW',
+          'city': 'Edmonton',
+          'region': some('Alberta'),
+          'country': 'Canada',
+          'zipcode': 'T5K 2S1',
+          'phone': none<String>(),
+        },
+        'interests': [
+          {'name': 'Programming', 'category': some('IT')},
+          {'name': 'Modular Synths', 'category': some('Music')},
+          {'name': 'Popping bubble wrap', 'category': none<String>()},
+        ],
+      };
+
+      expect(
+        unwrapOptionRecursively(person, fallback),
+        equals({
+          'name': 'Roo',
+          'age': 42,
+          'gender': 42,
+          'address': {
+            'street': '11215 104 Ave NW',
+            'city': 'Edmonton',
+            'region': 'Alberta',
+            'country': 'Canada',
+            'zipcode': 'T5K 2S1',
+            'phone': 42,
+          },
+          'interests': [
+            {'name': 'Programming', 'category': 'IT'},
+            {'name': 'Modular Synths', 'category': 'Music'},
+            {'name': 'Popping bubble wrap', 'category': 42},
+          ],
+        }),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_options/test/unwrap_option_test.dart
+++ b/packages/solana_kit_options/test/unwrap_option_test.dart
@@ -1,0 +1,56 @@
+import 'package:solana_kit_options/solana_kit_options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('unwrapOption', () {
+    test('unwraps Some to its value', () {
+      expect(unwrapOption(some(42)), equals(42));
+      expect(unwrapOption(some('hello')), equals('hello'));
+    });
+
+    test('unwraps Some(null) to null', () {
+      expect(unwrapOption(some<int?>(null)), isNull);
+    });
+
+    test('unwraps None to null', () {
+      expect(unwrapOption(none<int>()), isNull);
+      expect(unwrapOption(none<String>()), isNull);
+    });
+  });
+
+  group('unwrapOptionOr', () {
+    test('unwraps Some to its value', () {
+      expect(unwrapOptionOr(some(1), () => 42), equals(1));
+      expect(unwrapOptionOr(some('A'), () => 'fallback'), equals('A'));
+    });
+
+    test('returns fallback for None', () {
+      expect(unwrapOptionOr(none<int>(), () => 42), equals(42));
+      expect(
+        unwrapOptionOr(none<String>(), () => 'fallback'),
+        equals('fallback'),
+      );
+    });
+
+    test('fallback can throw', () {
+      expect(unwrapOptionOr(some(1), () => throw Exception('fail')), equals(1));
+      expect(
+        () => unwrapOptionOr(none<int>(), () => throw Exception('fail')),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('wrapNullable', () {
+    test('wraps non-null to Some', () {
+      expect(wrapNullable(42), equals(some(42)));
+      expect(wrapNullable('hello'), equals(some('hello')));
+      expect(wrapNullable(false), equals(some(false)));
+    });
+
+    test('wraps null to None', () {
+      expect(wrapNullable<String>(null), equals(none<String>()));
+      expect(wrapNullable<int>(null), equals(none<int>()));
+    });
+  });
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -63,34 +63,34 @@
 
 ### solana_kit_codecs_numbers (~17 source files, ~15 test files)
 
-- [ ] T012 [P] [US3] Port integer codecs (u8, u16, u32, u64, u128, i8–i128) from `.repos/kit/packages/codecs-numbers/src/` to `packages/solana_kit_codecs_numbers/lib/src/`
-- [ ] T013 [P] [US3] Port float codecs (f32, f64) and shortU16 codec in `packages/solana_kit_codecs_numbers/lib/src/`
-- [ ] T014 [US3] Update barrel export `packages/solana_kit_codecs_numbers/lib/solana_kit_codecs_numbers.dart`
-- [ ] T015 [US3] Port all 15 test files from `.repos/kit/packages/codecs-numbers/src/__tests__/` to `packages/solana_kit_codecs_numbers/test/`
+- [x] T012 [P] [US3] Port integer codecs (u8, u16, u32, u64, u128, i8–i128) from `.repos/kit/packages/codecs-numbers/src/` to `packages/solana_kit_codecs_numbers/lib/src/`
+- [x] T013 [P] [US3] Port float codecs (f32, f64) and shortU16 codec in `packages/solana_kit_codecs_numbers/lib/src/`
+- [x] T014 [US3] Update barrel export `packages/solana_kit_codecs_numbers/lib/solana_kit_codecs_numbers.dart`
+- [x] T015 [US3] Port all 15 test files from `.repos/kit/packages/codecs-numbers/src/__tests__/` to `packages/solana_kit_codecs_numbers/test/`
 
 ### solana_kit_codecs_strings (~10 source files, ~8 test files)
 
-- [ ] T016 [P] [US3] Port string codecs (utf8, base58, base64, base16, base10, baseX) from `.repos/kit/packages/codecs-strings/src/` to `packages/solana_kit_codecs_strings/lib/src/`
-- [ ] T017 [US3] Update barrel export `packages/solana_kit_codecs_strings/lib/solana_kit_codecs_strings.dart`
-- [ ] T018 [US3] Port all 8 test files from `.repos/kit/packages/codecs-strings/src/__tests__/` to `packages/solana_kit_codecs_strings/test/`
+- [x] T016 [P] [US3] Port string codecs (utf8, base58, base64, base16, base10, baseX) from `.repos/kit/packages/codecs-strings/src/` to `packages/solana_kit_codecs_strings/lib/src/`
+- [x] T017 [US3] Update barrel export `packages/solana_kit_codecs_strings/lib/solana_kit_codecs_strings.dart`
+- [x] T018 [US3] Port all 8 test files from `.repos/kit/packages/codecs-strings/src/__tests__/` to `packages/solana_kit_codecs_strings/test/`
 
 ### solana_kit_codecs_data_structures (~21 source files, ~38 test files)
 
-- [ ] T019 [US3] Port struct, array, tuple codecs from `.repos/kit/packages/codecs-data-structures/src/` to `packages/solana_kit_codecs_data_structures/lib/src/`
-- [ ] T020 [P] [US3] Port map, set, enum, discriminated union codecs in `packages/solana_kit_codecs_data_structures/lib/src/`
-- [ ] T021 [P] [US3] Port bool, nullable, constant, bitArray, unit, hiddenPrefix, hiddenSuffix codecs in `packages/solana_kit_codecs_data_structures/lib/src/`
-- [ ] T022 [US3] Update barrel export `packages/solana_kit_codecs_data_structures/lib/solana_kit_codecs_data_structures.dart`
-- [ ] T023 [US3] Port all 38 test files from `.repos/kit/packages/codecs-data-structures/src/__tests__/` to `packages/solana_kit_codecs_data_structures/test/`
+- [x] T019 [US3] Port struct, array, tuple codecs from `.repos/kit/packages/codecs-data-structures/src/` to `packages/solana_kit_codecs_data_structures/lib/src/`
+- [x] T020 [P] [US3] Port map, set, enum, discriminated union codecs in `packages/solana_kit_codecs_data_structures/lib/src/`
+- [x] T021 [P] [US3] Port bool, nullable, constant, bitArray, unit, hiddenPrefix, hiddenSuffix codecs in `packages/solana_kit_codecs_data_structures/lib/src/`
+- [x] T022 [US3] Update barrel export `packages/solana_kit_codecs_data_structures/lib/solana_kit_codecs_data_structures.dart`
+- [x] T023 [US3] Port all 38 test files from `.repos/kit/packages/codecs-data-structures/src/__tests__/` to `packages/solana_kit_codecs_data_structures/test/`
 
 ### solana_kit_options (~6 source files, ~5 test files)
 
-- [ ] T024 [P] [US3] Port Option&lt;T&gt; sealed class (Some/None), utilities, and option codec from `.repos/kit/packages/options/src/` to `packages/solana_kit_options/lib/src/`
-- [ ] T025 [US3] Update barrel export `packages/solana_kit_options/lib/solana_kit_options.dart`
-- [ ] T026 [US3] Port all 5 test files from `.repos/kit/packages/options/src/__tests__/` to `packages/solana_kit_options/test/`
+- [x] T024 [P] [US3] Port Option&lt;T&gt; sealed class (Some/None), utilities, and option codec from `.repos/kit/packages/options/src/` to `packages/solana_kit_options/lib/src/`
+- [x] T025 [US3] Update barrel export `packages/solana_kit_options/lib/solana_kit_options.dart`
+- [x] T026 [US3] Port all 5 test files from `.repos/kit/packages/options/src/__tests__/` to `packages/solana_kit_options/test/`
 
 ### solana_kit_codecs (umbrella re-export)
 
-- [ ] T027 [US3] Create umbrella re-export of all codec packages in `packages/solana_kit_codecs/lib/solana_kit_codecs.dart`
+- [x] T027 [US3] Create umbrella re-export of all codec packages in `packages/solana_kit_codecs/lib/solana_kit_codecs.dart`
 
 **Checkpoint**: All codec packages implemented and tested. Developers can encode/decode all Solana data types. `melos test --scope="solana_kit_codecs*"` passes.
 


### PR DESCRIPTION
## Summary

- Implement `solana_kit_options` package ported from `@solana/options` with Rust-like `Option<T>` sealed class, 6 option codec encoding modes, unwrap utilities, and recursive unwrapping (90 tests)
- Create `solana_kit_codecs` umbrella package re-exporting core, numbers, strings, data structures, and options
- Completes all Phase 3 (US3) codec tasks (T024-T027)

## Test plan

- [x] `dart analyze` passes with zero issues for both packages
- [x] `dart test` passes (90 options tests)
- [x] `dart format --set-exit-if-changed` reports zero changes
- [x] `dprint check` passes
- [x] Changeset file included