### PR TITLE
✨ feat: implement instructions and programs packages

### DIFF
--- a/.changeset/instructions-programs.md
+++ b/.changeset/instructions-programs.md
@@ -1,0 +1,20 @@
+---
+solana_kit_instructions: minor
+solana_kit_programs: minor
+---
+
+Implement instructions and programs packages ported from `@solana/instructions` and `@solana/programs`.
+
+**solana_kit_instructions** (56 tests):
+
+- `AccountRole` enhanced enum with bitflag values (readonly, writable, readonlySigner, writableSigner)
+- 7 role manipulation functions: upgrade/downgrade signer/writable, merge, query
+- `AccountMeta` and `AccountLookupMeta` immutable classes with const constructors
+- `Instruction` class with optional accounts and data fields
+- 6 instruction validation functions: isInstructionForProgram, isInstructionWithAccounts, isInstructionWithData (with assert variants)
+
+**solana_kit_programs** (5 tests):
+
+- `isProgramError` function to identify custom program errors from transaction failures
+- Matches error code, instruction index, and program address against transaction message
+- `TransactionMessageInput` and `InstructionInput` minimal types for error checking

--- a/packages/solana_kit_instructions/lib/solana_kit_instructions.dart
+++ b/packages/solana_kit_instructions/lib/solana_kit_instructions.dart
@@ -1,1 +1,3 @@
-
+export 'src/accounts.dart';
+export 'src/instruction.dart';
+export 'src/roles.dart';

--- a/packages/solana_kit_instructions/lib/src/accounts.dart
+++ b/packages/solana_kit_instructions/lib/src/accounts.dart
@@ -1,0 +1,47 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+import 'package:solana_kit_instructions/src/roles.dart';
+
+/// Represents an account's address and metadata about its mutability and
+/// whether it must be a signer of the transaction.
+class AccountMeta {
+  /// Creates an [AccountMeta] with the given [address] and [role].
+  const AccountMeta({required this.address, required this.role});
+
+  /// The base58-encoded address of the account.
+  final Address address;
+
+  /// The role of the account in the transaction.
+  final AccountRole role;
+}
+
+/// Represents a lookup of the account's address in an address lookup table.
+///
+/// It specifies which lookup table account in which to perform the lookup, the
+/// index of the desired account address in that table, and metadata about its
+/// mutability. Notably, account addresses obtained via lookups may not act as
+/// signers.
+class AccountLookupMeta {
+  /// Creates an [AccountLookupMeta].
+  const AccountLookupMeta({
+    required this.address,
+    required this.addressIndex,
+    required this.lookupTableAddress,
+    required this.role,
+  });
+
+  /// The base58-encoded address of the account.
+  final Address address;
+
+  /// The index of the account address within the lookup table.
+  final int addressIndex;
+
+  /// The base58-encoded address of the lookup table account.
+  final Address lookupTableAddress;
+
+  /// The role of the account in the transaction.
+  ///
+  /// Must be either [AccountRole.readonly] or [AccountRole.writable] since
+  /// accounts obtained via lookups may not act as signers.
+  final AccountRole role;
+}

--- a/packages/solana_kit_instructions/lib/src/instruction.dart
+++ b/packages/solana_kit_instructions/lib/src/instruction.dart
@@ -1,0 +1,79 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+import 'package:solana_kit_instructions/src/accounts.dart';
+
+/// An instruction destined for a given program.
+class Instruction {
+  /// Creates an [Instruction] with the given [programAddress], optional
+  /// [accounts], and optional [data].
+  const Instruction({required this.programAddress, this.accounts, this.data});
+
+  /// The base58-encoded address of the program to invoke.
+  final Address programAddress;
+
+  /// The accounts that this instruction references.
+  final List<AccountMeta>? accounts;
+
+  /// The opaque data to pass to the program.
+  final Uint8List? data;
+}
+
+/// Returns `true` if [instruction] is destined for the program at
+/// [programAddress].
+bool isInstructionForProgram(Instruction instruction, Address programAddress) =>
+    instruction.programAddress == programAddress;
+
+/// Asserts that [instruction] is destined for the program at
+/// [programAddress].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionProgramIdMismatch] if the addresses do not
+/// match.
+void assertIsInstructionForProgram(
+  Instruction instruction,
+  Address programAddress,
+) {
+  if (instruction.programAddress != programAddress) {
+    throw SolanaError(SolanaErrorCode.instructionProgramIdMismatch, {
+      'actualProgramAddress': instruction.programAddress.value,
+      'expectedProgramAddress': programAddress.value,
+    });
+  }
+}
+
+/// Returns `true` if [instruction] has an accounts list (even if empty).
+bool isInstructionWithAccounts(Instruction instruction) =>
+    instruction.accounts != null;
+
+/// Asserts that [instruction] has an accounts list.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionExpectedToHaveAccounts] if the accounts list
+/// is `null`.
+void assertIsInstructionWithAccounts(Instruction instruction) {
+  if (instruction.accounts == null) {
+    throw SolanaError(SolanaErrorCode.instructionExpectedToHaveAccounts, {
+      'data': instruction.data,
+      'programAddress': instruction.programAddress.value,
+    });
+  }
+}
+
+/// Returns `true` if [instruction] has data (even if empty).
+bool isInstructionWithData(Instruction instruction) => instruction.data != null;
+
+/// Asserts that [instruction] has data.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionExpectedToHaveData] if data is `null`.
+void assertIsInstructionWithData(Instruction instruction) {
+  if (instruction.data == null) {
+    throw SolanaError(SolanaErrorCode.instructionExpectedToHaveData, {
+      'accountAddresses': instruction.accounts?.map((a) => a.address.value),
+      'programAddress': instruction.programAddress.value,
+    });
+  }
+}

--- a/packages/solana_kit_instructions/lib/src/roles.dart
+++ b/packages/solana_kit_instructions/lib/src/roles.dart
@@ -1,0 +1,92 @@
+/// Describes the purpose for which an account participates in a transaction.
+///
+/// Every account that participates in a transaction can be read from, but only
+/// ones that you mark as writable may be written to, and only ones that you
+/// indicate must sign the transaction will gain the privileges associated with
+/// signers at runtime.
+///
+/// The enum values use a bitflag scheme:
+///
+/// | Role              | isSigner | isWritable | Value |
+/// | ----------------- | -------- | ---------- | ----- |
+/// | `readonly`        | No       | No         | 0b00  |
+/// | `writable`        | No       | Yes        | 0b01  |
+/// | `readonlySigner`  | Yes      | No         | 0b10  |
+/// | `writableSigner`  | Yes      | Yes        | 0b11  |
+enum AccountRole {
+  /// A read-only, non-signer account.
+  readonly(0),
+
+  /// A writable, non-signer account.
+  writable(1),
+
+  /// A read-only signer account.
+  readonlySigner(2),
+
+  /// A writable signer account.
+  writableSigner(3);
+
+  const AccountRole(this.value);
+
+  /// The bitflag value of this role.
+  final int value;
+}
+
+/// Bitmask for the signer bit.
+const _isSignerBitmask = 0x02;
+
+/// Bitmask for the writable bit.
+const _isWritableBitmask = 0x01;
+
+/// Returns the [AccountRole] that corresponds to the given bitflag [value].
+AccountRole _roleFromValue(int value) =>
+    AccountRole.values.firstWhere((r) => r.value == value);
+
+/// Returns the non-signer variant of the supplied [role].
+///
+/// - [AccountRole.readonlySigner] becomes [AccountRole.readonly].
+/// - [AccountRole.writableSigner] becomes [AccountRole.writable].
+/// - Non-signer roles are returned unchanged.
+AccountRole downgradeRoleToNonSigner(AccountRole role) =>
+    _roleFromValue(role.value & ~_isSignerBitmask);
+
+/// Returns the read-only variant of the supplied [role].
+///
+/// - [AccountRole.writable] becomes [AccountRole.readonly].
+/// - [AccountRole.writableSigner] becomes [AccountRole.readonlySigner].
+/// - Read-only roles are returned unchanged.
+AccountRole downgradeRoleToReadonly(AccountRole role) =>
+    _roleFromValue(role.value & ~_isWritableBitmask);
+
+/// Returns `true` if [role] represents a signer account.
+bool isSignerRole(AccountRole role) =>
+    role.value >= AccountRole.readonlySigner.value;
+
+/// Returns `true` if [role] represents a writable account.
+bool isWritableRole(AccountRole role) => (role.value & _isWritableBitmask) != 0;
+
+/// Returns the [AccountRole] that grants the highest privileges of both
+/// [roleA] and [roleB].
+///
+/// ```dart
+/// // Returns AccountRole.writableSigner
+/// mergeRoles(AccountRole.readonlySigner, AccountRole.writable);
+/// ```
+AccountRole mergeRoles(AccountRole roleA, AccountRole roleB) =>
+    _roleFromValue(roleA.value | roleB.value);
+
+/// Returns the signer variant of the supplied [role].
+///
+/// - [AccountRole.readonly] becomes [AccountRole.readonlySigner].
+/// - [AccountRole.writable] becomes [AccountRole.writableSigner].
+/// - Signer roles are returned unchanged.
+AccountRole upgradeRoleToSigner(AccountRole role) =>
+    _roleFromValue(role.value | _isSignerBitmask);
+
+/// Returns the writable variant of the supplied [role].
+///
+/// - [AccountRole.readonly] becomes [AccountRole.writable].
+/// - [AccountRole.readonlySigner] becomes [AccountRole.writableSigner].
+/// - Writable roles are returned unchanged.
+AccountRole upgradeRoleToWritable(AccountRole role) =>
+    _roleFromValue(role.value | _isWritableBitmask);

--- a/packages/solana_kit_instructions/pubspec.yaml
+++ b/packages/solana_kit_instructions/pubspec.yaml
@@ -8,7 +8,9 @@ environment:
 resolution: workspace
 
 dependencies:
+  solana_kit_addresses:
   solana_kit_errors:
 
 dev_dependencies:
   solana_kit_lints:
+  test: ^1.25.0

--- a/packages/solana_kit_instructions/test/instruction_test.dart
+++ b/packages/solana_kit_instructions/test/instruction_test.dart
@@ -1,0 +1,184 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const programAddress = Address('address');
+
+  group('isInstructionForProgram', () {
+    test('returns true when the instruction has the given program address', () {
+      const instruction = Instruction(programAddress: programAddress);
+      expect(isInstructionForProgram(instruction, programAddress), isTrue);
+    });
+
+    test('returns false when the instruction does not have the given program '
+        'address', () {
+      const instruction = Instruction(programAddress: programAddress);
+      const otherAddress = Address('abc');
+      expect(isInstructionForProgram(instruction, otherAddress), isFalse);
+    });
+  });
+
+  group('assertIsInstructionForProgram', () {
+    test(
+      'does not throw when the instruction has the given program address',
+      () {
+        const instruction = Instruction(programAddress: programAddress);
+        expect(
+          () => assertIsInstructionForProgram(instruction, programAddress),
+          returnsNormally,
+        );
+      },
+    );
+
+    test(
+      'throws when the instruction does not have the given program address',
+      () {
+        const instruction = Instruction(programAddress: programAddress);
+        const otherAddress = Address('abc');
+        expect(
+          () => assertIsInstructionForProgram(instruction, otherAddress),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.instructionProgramIdMismatch,
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('isInstructionWithAccounts', () {
+    test('returns true when the instruction has an array of accounts', () {
+      const instruction = Instruction(
+        programAddress: programAddress,
+        accounts: [
+          AccountMeta(address: Address('abc'), role: AccountRole.readonly),
+        ],
+      );
+      expect(isInstructionWithAccounts(instruction), isTrue);
+    });
+
+    test(
+      'returns true when the instruction has an empty array of accounts',
+      () {
+        const instruction = Instruction(
+          programAddress: programAddress,
+          accounts: [],
+        );
+        expect(isInstructionWithAccounts(instruction), isTrue);
+      },
+    );
+
+    test(
+      'returns false when the instruction does not have accounts defined',
+      () {
+        const instruction = Instruction(programAddress: programAddress);
+        expect(isInstructionWithAccounts(instruction), isFalse);
+      },
+    );
+  });
+
+  group('assertIsInstructionWithAccounts', () {
+    test('does not throw when the instruction has an array of accounts', () {
+      const instruction = Instruction(
+        programAddress: programAddress,
+        accounts: [
+          AccountMeta(address: Address('abc'), role: AccountRole.readonly),
+        ],
+      );
+      expect(
+        () => assertIsInstructionWithAccounts(instruction),
+        returnsNormally,
+      );
+    });
+
+    test(
+      'does not throw when the instruction has an empty array of accounts',
+      () {
+        const instruction = Instruction(
+          programAddress: programAddress,
+          accounts: [],
+        );
+        expect(
+          () => assertIsInstructionWithAccounts(instruction),
+          returnsNormally,
+        );
+      },
+    );
+
+    test('throws when the instruction does not have accounts defined', () {
+      const instruction = Instruction(programAddress: programAddress);
+      expect(
+        () => assertIsInstructionWithAccounts(instruction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionExpectedToHaveAccounts,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('isInstructionWithData', () {
+    test('returns true when the instruction has non-empty data', () {
+      final instruction = Instruction(
+        programAddress: programAddress,
+        data: Uint8List.fromList([1, 2, 3, 4]),
+      );
+      expect(isInstructionWithData(instruction), isTrue);
+    });
+
+    test('returns true when the instruction has empty data', () {
+      final instruction = Instruction(
+        programAddress: programAddress,
+        data: Uint8List(0),
+      );
+      expect(isInstructionWithData(instruction), isTrue);
+    });
+
+    test('returns false when the instruction does not have data defined', () {
+      const instruction = Instruction(programAddress: programAddress);
+      expect(isInstructionWithData(instruction), isFalse);
+    });
+  });
+
+  group('assertIsInstructionWithData', () {
+    test('does not throw when the instruction has non-empty data', () {
+      final instruction = Instruction(
+        programAddress: programAddress,
+        data: Uint8List.fromList([1, 2, 3, 4]),
+      );
+      expect(() => assertIsInstructionWithData(instruction), returnsNormally);
+    });
+
+    test('does not throw when the instruction has empty data', () {
+      final instruction = Instruction(
+        programAddress: programAddress,
+        data: Uint8List(0),
+      );
+      expect(() => assertIsInstructionWithData(instruction), returnsNormally);
+    });
+
+    test('throws when the instruction does not have data defined', () {
+      const instruction = Instruction(programAddress: programAddress);
+      expect(
+        () => assertIsInstructionWithData(instruction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionExpectedToHaveData,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_instructions/test/roles_test.dart
+++ b/packages/solana_kit_instructions/test/roles_test.dart
@@ -1,0 +1,241 @@
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('downgradeRoleToNonSigner', () {
+    test('downgrades readonly to readonly', () {
+      expect(
+        downgradeRoleToNonSigner(AccountRole.readonly),
+        equals(AccountRole.readonly),
+      );
+    });
+    test('downgrades writable to writable', () {
+      expect(
+        downgradeRoleToNonSigner(AccountRole.writable),
+        equals(AccountRole.writable),
+      );
+    });
+    test('downgrades readonlySigner to readonly', () {
+      expect(
+        downgradeRoleToNonSigner(AccountRole.readonlySigner),
+        equals(AccountRole.readonly),
+      );
+    });
+    test('downgrades writableSigner to writable', () {
+      expect(
+        downgradeRoleToNonSigner(AccountRole.writableSigner),
+        equals(AccountRole.writable),
+      );
+    });
+  });
+
+  group('downgradeRoleToReadonly', () {
+    test('downgrades readonly to readonly', () {
+      expect(
+        downgradeRoleToReadonly(AccountRole.readonly),
+        equals(AccountRole.readonly),
+      );
+    });
+    test('downgrades writable to readonly', () {
+      expect(
+        downgradeRoleToReadonly(AccountRole.writable),
+        equals(AccountRole.readonly),
+      );
+    });
+    test('downgrades readonlySigner to readonlySigner', () {
+      expect(
+        downgradeRoleToReadonly(AccountRole.readonlySigner),
+        equals(AccountRole.readonlySigner),
+      );
+    });
+    test('downgrades writableSigner to readonlySigner', () {
+      expect(
+        downgradeRoleToReadonly(AccountRole.writableSigner),
+        equals(AccountRole.readonlySigner),
+      );
+    });
+  });
+
+  group('isSignerRole', () {
+    test('returns false for readonly', () {
+      expect(isSignerRole(AccountRole.readonly), isFalse);
+    });
+    test('returns false for writable', () {
+      expect(isSignerRole(AccountRole.writable), isFalse);
+    });
+    test('returns true for readonlySigner', () {
+      expect(isSignerRole(AccountRole.readonlySigner), isTrue);
+    });
+    test('returns true for writableSigner', () {
+      expect(isSignerRole(AccountRole.writableSigner), isTrue);
+    });
+  });
+
+  group('isWritableRole', () {
+    test('returns false for readonly', () {
+      expect(isWritableRole(AccountRole.readonly), isFalse);
+    });
+    test('returns true for writable', () {
+      expect(isWritableRole(AccountRole.writable), isTrue);
+    });
+    test('returns false for readonlySigner', () {
+      expect(isWritableRole(AccountRole.readonlySigner), isFalse);
+    });
+    test('returns true for writableSigner', () {
+      expect(isWritableRole(AccountRole.writableSigner), isTrue);
+    });
+  });
+
+  group('mergeRoles', () {
+    test('readonly + readonly = readonly', () {
+      expect(
+        mergeRoles(AccountRole.readonly, AccountRole.readonly),
+        equals(AccountRole.readonly),
+      );
+    });
+    test('readonly + writable = writable', () {
+      expect(
+        mergeRoles(AccountRole.readonly, AccountRole.writable),
+        equals(AccountRole.writable),
+      );
+    });
+    test('readonly + readonlySigner = readonlySigner', () {
+      expect(
+        mergeRoles(AccountRole.readonly, AccountRole.readonlySigner),
+        equals(AccountRole.readonlySigner),
+      );
+    });
+    test('readonly + writableSigner = writableSigner', () {
+      expect(
+        mergeRoles(AccountRole.readonly, AccountRole.writableSigner),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('writable + readonly = writable', () {
+      expect(
+        mergeRoles(AccountRole.writable, AccountRole.readonly),
+        equals(AccountRole.writable),
+      );
+    });
+    test('writable + writable = writable', () {
+      expect(
+        mergeRoles(AccountRole.writable, AccountRole.writable),
+        equals(AccountRole.writable),
+      );
+    });
+    test('writable + readonlySigner = writableSigner', () {
+      expect(
+        mergeRoles(AccountRole.writable, AccountRole.readonlySigner),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('writable + writableSigner = writableSigner', () {
+      expect(
+        mergeRoles(AccountRole.writable, AccountRole.writableSigner),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('readonlySigner + readonly = readonlySigner', () {
+      expect(
+        mergeRoles(AccountRole.readonlySigner, AccountRole.readonly),
+        equals(AccountRole.readonlySigner),
+      );
+    });
+    test('readonlySigner + writable = writableSigner', () {
+      expect(
+        mergeRoles(AccountRole.readonlySigner, AccountRole.writable),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('readonlySigner + readonlySigner = readonlySigner', () {
+      expect(
+        mergeRoles(AccountRole.readonlySigner, AccountRole.readonlySigner),
+        equals(AccountRole.readonlySigner),
+      );
+    });
+    test('readonlySigner + writableSigner = writableSigner', () {
+      expect(
+        mergeRoles(AccountRole.readonlySigner, AccountRole.writableSigner),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('writableSigner + readonly = writableSigner', () {
+      expect(
+        mergeRoles(AccountRole.writableSigner, AccountRole.readonly),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('writableSigner + writable = writableSigner', () {
+      expect(
+        mergeRoles(AccountRole.writableSigner, AccountRole.writable),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('writableSigner + readonlySigner = writableSigner', () {
+      expect(
+        mergeRoles(AccountRole.writableSigner, AccountRole.readonlySigner),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('writableSigner + writableSigner = writableSigner', () {
+      expect(
+        mergeRoles(AccountRole.writableSigner, AccountRole.writableSigner),
+        equals(AccountRole.writableSigner),
+      );
+    });
+  });
+
+  group('upgradeRoleToSigner', () {
+    test('upgrades readonly to readonlySigner', () {
+      expect(
+        upgradeRoleToSigner(AccountRole.readonly),
+        equals(AccountRole.readonlySigner),
+      );
+    });
+    test('upgrades writable to writableSigner', () {
+      expect(
+        upgradeRoleToSigner(AccountRole.writable),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('upgrades readonlySigner to readonlySigner', () {
+      expect(
+        upgradeRoleToSigner(AccountRole.readonlySigner),
+        equals(AccountRole.readonlySigner),
+      );
+    });
+    test('upgrades writableSigner to writableSigner', () {
+      expect(
+        upgradeRoleToSigner(AccountRole.writableSigner),
+        equals(AccountRole.writableSigner),
+      );
+    });
+  });
+
+  group('upgradeRoleToWritable', () {
+    test('upgrades readonly to writable', () {
+      expect(
+        upgradeRoleToWritable(AccountRole.readonly),
+        equals(AccountRole.writable),
+      );
+    });
+    test('upgrades writable to writable', () {
+      expect(
+        upgradeRoleToWritable(AccountRole.writable),
+        equals(AccountRole.writable),
+      );
+    });
+    test('upgrades readonlySigner to writableSigner', () {
+      expect(
+        upgradeRoleToWritable(AccountRole.readonlySigner),
+        equals(AccountRole.writableSigner),
+      );
+    });
+    test('upgrades writableSigner to writableSigner', () {
+      expect(
+        upgradeRoleToWritable(AccountRole.writableSigner),
+        equals(AccountRole.writableSigner),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_programs/lib/solana_kit_programs.dart
+++ b/packages/solana_kit_programs/lib/solana_kit_programs.dart
@@ -1,1 +1,1 @@
-
+export 'src/program_error.dart';

--- a/packages/solana_kit_programs/lib/src/program_error.dart
+++ b/packages/solana_kit_programs/lib/src/program_error.dart
@@ -1,0 +1,83 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+/// A minimal representation of a transaction message containing instructions
+/// indexed by their position.
+///
+/// This is used by [isProgramError] to look up the instruction at a given index
+/// and determine its program address.
+class TransactionMessageInput {
+  /// Creates a [TransactionMessageInput] with the given [instructions] map.
+  const TransactionMessageInput({required this.instructions});
+
+  /// A map of instruction indices to their corresponding [InstructionInput].
+  final Map<int, InstructionInput> instructions;
+}
+
+/// A minimal representation of an instruction containing only its program
+/// address.
+///
+/// This is used by [isProgramError] to check whether an instruction belongs to
+/// a specific program.
+class InstructionInput {
+  /// Creates an [InstructionInput] with the given [programAddress].
+  const InstructionInput({required this.programAddress});
+
+  /// The address of the program that this instruction targets.
+  final Address programAddress;
+}
+
+/// Identifies whether an [error] -- typically caused by a transaction failure
+/// -- is a custom program error from the provided [programAddress].
+///
+/// Since the RPC response only provides the index of the failed instruction,
+/// the [transactionMessage] is required to determine its program address.
+///
+/// When [code] is provided, the function also checks that the custom program
+/// error code matches the given value.
+///
+/// Returns `true` if:
+/// 1. The [error] is a [SolanaError] with code
+///    [SolanaErrorCode.instructionErrorCustom].
+/// 2. The instruction at the error's index in [transactionMessage] matches
+///    [programAddress].
+/// 3. If [code] is provided, the custom error code matches.
+///
+/// ```dart
+/// try {
+///   // Send and confirm your transaction.
+/// } catch (error) {
+///   if (isProgramError(error, transactionMessage, myProgramAddress, 42)) {
+///     // Handle custom program error 42 from this program.
+///   } else if (isProgramError(error, transactionMessage, myProgramAddress)) {
+///     // Handle all other custom program errors from this program.
+///   } else {
+///     throw error;
+///   }
+/// }
+/// ```
+bool isProgramError(
+  Object? error,
+  TransactionMessageInput transactionMessage,
+  Address programAddress, [
+  int? code,
+]) {
+  if (!isSolanaError(error, SolanaErrorCode.instructionErrorCustom)) {
+    return false;
+  }
+
+  final context = (error! as SolanaError).context;
+  final index = context['index'];
+
+  if (index is! int) {
+    return false;
+  }
+
+  final instruction = transactionMessage.instructions[index];
+
+  if (instruction == null || instruction.programAddress != programAddress) {
+    return false;
+  }
+
+  return code == null || context['code'] == code;
+}

--- a/packages/solana_kit_programs/pubspec.yaml
+++ b/packages/solana_kit_programs/pubspec.yaml
@@ -8,7 +8,9 @@ environment:
 resolution: workspace
 
 dependencies:
+  solana_kit_addresses:
   solana_kit_errors:
 
 dev_dependencies:
   solana_kit_lints:
+  test: ^1.25.0

--- a/packages/solana_kit_programs/test/program_error_test.dart
+++ b/packages/solana_kit_programs/test/program_error_test.dart
@@ -1,0 +1,119 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_programs/solana_kit_programs.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isProgramError', () {
+    test('identifies an error as a custom program error', () {
+      // Given a transaction message with a single instruction.
+      const programAddress = Address('1111');
+      const transactionMessage = TransactionMessageInput(
+        instructions: {0: InstructionInput(programAddress: programAddress)},
+      );
+
+      // And a custom program error on the instruction.
+      final error = SolanaError(SolanaErrorCode.instructionErrorCustom, {
+        'code': 42,
+        'index': 0,
+      });
+
+      // Then we expect the error to be identified as a program error.
+      expect(isProgramError(error, transactionMessage, programAddress), isTrue);
+    });
+
+    test('matches the provided custom program error code', () {
+      // Given a transaction message with a single instruction.
+      const programAddress = Address('1111');
+      const transactionMessage = TransactionMessageInput(
+        instructions: {0: InstructionInput(programAddress: programAddress)},
+      );
+
+      // And a custom program error with code 42.
+      final error = SolanaError(SolanaErrorCode.instructionErrorCustom, {
+        'code': 42,
+        'index': 0,
+      });
+
+      // When we specify the custom program error code 42.
+      final result = isProgramError(
+        error,
+        transactionMessage,
+        programAddress,
+        42,
+      );
+
+      // Then we expect the result to be true.
+      expect(result, isTrue);
+    });
+
+    test('returns false if the program address does not match', () {
+      // Given a transaction message with a program A instruction.
+      const programA = Address('1111');
+      const transactionMessage = TransactionMessageInput(
+        instructions: {0: InstructionInput(programAddress: programA)},
+      );
+
+      // And a custom program error on the instruction.
+      final error = SolanaError(SolanaErrorCode.instructionErrorCustom, {
+        'code': 42,
+        'index': 0,
+      });
+
+      // When we try to identify the error as a program error for program B.
+      const programB = Address('2222');
+      final result = isProgramError(error, transactionMessage, programB);
+
+      // Then we expect the result to be false.
+      expect(result, isFalse);
+    });
+
+    test(
+      'returns false if instruction index is missing from error context',
+      () {
+        // Given a transaction message with a single instruction.
+        const programAddress = Address('1111');
+        const transactionMessage = TransactionMessageInput(
+          instructions: {0: InstructionInput(programAddress: programAddress)},
+        );
+
+        // And a custom program error pointing to a missing instruction.
+        final error = SolanaError(SolanaErrorCode.instructionErrorCustom, {
+          'code': 42,
+          'index': 999,
+        });
+
+        // Then we expect the error not to be identified as a program error.
+        expect(
+          isProgramError(error, transactionMessage, programAddress),
+          isFalse,
+        );
+      },
+    );
+
+    test('returns false if custom program error code does not match', () {
+      // Given a transaction message with a single instruction.
+      const programAddress = Address('1111');
+      const transactionMessage = TransactionMessageInput(
+        instructions: {0: InstructionInput(programAddress: programAddress)},
+      );
+
+      // And a custom program error on the instruction with code 42.
+      final error = SolanaError(SolanaErrorCode.instructionErrorCustom, {
+        'code': 42,
+        'index': 0,
+      });
+
+      // When we try to identify the error as a program error with code 43.
+      final result = isProgramError(
+        error,
+        transactionMessage,
+        programAddress,
+        43,
+      );
+
+      // Then we expect the result to be false.
+      expect(result, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Implement `solana_kit_instructions` package ported from `@solana/instructions` with `AccountRole` enhanced enum (bitflag values), `AccountMeta`/`AccountLookupMeta` immutable classes, `Instruction` class, and 6 instruction validation functions (56 tests)
- Implement `solana_kit_programs` package ported from `@solana/programs` with `isProgramError` function for identifying custom program errors from transaction failures (5 tests)

## Test plan
- [x] 56 tests passing for `solana_kit_instructions`
- [x] 5 tests passing for `solana_kit_programs`
- [x] `dart analyze` clean across both packages
- [x] `dprint check` passes