### PR TITLE
✨ feat: implement transactions package

### DIFF
--- a/.changeset/transactions.md
+++ b/.changeset/transactions.md
@@ -1,0 +1,18 @@
+---
+solana_kit_transactions: minor
+---
+
+Implement transactions package ported from `@solana/transactions`.
+
+**solana_kit_transactions** (64 tests):
+
+- `Transaction` class with `messageBytes` (Uint8List) and `signatures` (Map<Address, SignatureBytes?>) fields
+- `TransactionWithLifetime` with blockhash and durable nonce lifetime constraints
+- `compileTransaction` to compile a TransactionMessage into a Transaction with signature slots and lifetime constraint
+- `partiallySignTransaction` and `signTransaction` for async Ed25519 signing with key pairs
+- `getSignatureFromTransaction` to extract fee payer signature
+- `isFullySignedTransaction` / `assertIsFullySignedTransaction` for signature completeness checks
+- Transaction size calculations with 1232-byte limit enforcement
+- `isSendableTransaction` / `assertIsSendableTransaction` combining signature and size checks
+- Wire format encoding with `getBase64EncodedWireTransaction`
+- Full transaction codec: signatures encoder (shortU16 prefix + 64 bytes each), transaction encoder/decoder

--- a/packages/solana_kit_transactions/lib/solana_kit_transactions.dart
+++ b/packages/solana_kit_transactions/lib/solana_kit_transactions.dart
@@ -1,1 +1,9 @@
-
+export 'src/codecs/signatures_encoder.dart';
+export 'src/codecs/transaction_codec.dart';
+export 'src/compile_transaction.dart';
+export 'src/lifetime.dart';
+export 'src/sendable_transaction.dart';
+export 'src/signatures.dart';
+export 'src/transaction.dart';
+export 'src/transaction_size.dart';
+export 'src/wire_transaction.dart';

--- a/packages/solana_kit_transactions/lib/src/codecs/signatures_encoder.dart
+++ b/packages/solana_kit_transactions/lib/src/codecs/signatures_encoder.dart
@@ -1,0 +1,56 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+/// Extracts the list of [SignatureBytes] to encode from a signatures map.
+///
+/// Null signatures are replaced with 64 zero bytes.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.transactionCannotEncodeWithEmptySignatures] if the
+/// signatures map is empty.
+List<SignatureBytes> _getSignaturesToEncode(
+  Map<Address, SignatureBytes?> signaturesMap,
+) {
+  final signatures = signaturesMap.values.toList();
+  if (signatures.isEmpty) {
+    throw SolanaError(
+      SolanaErrorCode.transactionCannotEncodeWithEmptySignatures,
+    );
+  }
+
+  return signatures.map((signature) {
+    if (signature == null) {
+      return SignatureBytes(Uint8List(64));
+    }
+    return signature;
+  }).toList();
+}
+
+/// Signatures encoder for legacy and v0 transactions, which encode signatures
+/// as an array with a shortU16 size prefix.
+VariableSizeEncoder<Map<Address, SignatureBytes?>>
+getSignaturesEncoderWithSizePrefix() {
+  final shortU16Enc = getShortU16Encoder();
+
+  return VariableSizeEncoder<Map<Address, SignatureBytes?>>(
+    getSizeFromValue: (signaturesMap) {
+      final sigs = _getSignaturesToEncode(signaturesMap);
+      final prefixSize = getEncodedSize(sigs.length, shortU16Enc);
+      return prefixSize + (sigs.length * 64);
+    },
+    write: (signaturesMap, bytes, offset) {
+      final sigs = _getSignaturesToEncode(signaturesMap);
+      var pos = shortU16Enc.write(sigs.length, bytes, offset);
+      for (final sig in sigs) {
+        bytes.setAll(pos, sig.value);
+        pos += 64;
+      }
+      return pos;
+    },
+  );
+}

--- a/packages/solana_kit_transactions/lib/src/codecs/transaction_codec.dart
+++ b/packages/solana_kit_transactions/lib/src/codecs/transaction_codec.dart
@@ -1,0 +1,153 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+import 'package:solana_kit_transactions/src/codecs/signatures_encoder.dart';
+import 'package:solana_kit_transactions/src/transaction.dart';
+
+/// Returns an encoder that you can use to encode a [Transaction] to a byte
+/// array in a wire format appropriate for sending to the Solana network for
+/// execution.
+VariableSizeEncoder<Transaction> getTransactionEncoder() {
+  final signaturesEncoder = getSignaturesEncoderWithSizePrefix();
+  final bytesEncoder = getBytesEncoder();
+
+  return VariableSizeEncoder<Transaction>(
+    getSizeFromValue: (transaction) {
+      return getEncodedSize(transaction.signatures, signaturesEncoder) +
+          getEncodedSize(transaction.messageBytes, bytesEncoder);
+    },
+    write: (transaction, bytes, offset) => bytesEncoder.write(
+      transaction.messageBytes,
+      bytes,
+      signaturesEncoder.write(transaction.signatures, bytes, offset),
+    ),
+  );
+}
+
+/// Returns a decoder that you can use to convert a byte array in the Solana
+/// transaction wire format to a [Transaction] object.
+VariableSizeDecoder<Transaction> getTransactionDecoder() {
+  final shortU16Dec = getShortU16Decoder();
+  final sigBytesDecoder = fixDecoderSize(getBytesDecoder(), 64);
+
+  return VariableSizeDecoder<Transaction>(
+    read: (bytes, offset) {
+      // Decode signatures array.
+      final (sigCount, sigCountEnd) = shortU16Dec.read(bytes, offset);
+      var pos = sigCountEnd;
+      final signatures = <Uint8List>[];
+      for (var i = 0; i < sigCount; i++) {
+        final (sigBytes, newPos) = sigBytesDecoder.read(bytes, pos);
+        signatures.add(sigBytes);
+        pos = newPos;
+      }
+
+      // Remaining bytes are the message.
+      final messageBytes = Uint8List.sublistView(bytes, pos);
+
+      // Decode signer addresses from message bytes.
+      final decoded = _decodeSignerAddresses(messageBytes);
+      final numRequiredSignatures = decoded.numRequiredSignatures;
+      final signerAddresses = decoded.signerAddresses;
+
+      // Signer addresses and signatures must be the same length.
+      if (signerAddresses.length != signatures.length) {
+        throw SolanaError(
+          SolanaErrorCode.transactionMessageSignaturesMismatch,
+          {
+            'numRequiredSignatures': numRequiredSignatures,
+            'signaturesLength': signatures.length,
+            'signerAddresses': signerAddresses.map((a) => a.value).toList(),
+          },
+        );
+      }
+
+      // Combine signer addresses + signatures into the signatures map.
+      final signaturesMap = <Address, SignatureBytes?>{};
+      for (var i = 0; i < signerAddresses.length; i++) {
+        final sigForAddress = signatures[i];
+        if (sigForAddress.every((b) => b == 0)) {
+          signaturesMap[signerAddresses[i]] = null;
+        } else {
+          signaturesMap[signerAddresses[i]] = SignatureBytes(sigForAddress);
+        }
+      }
+
+      return (
+        Transaction(
+          messageBytes: Uint8List.fromList(messageBytes),
+          signatures: signaturesMap,
+        ),
+        bytes.length,
+      );
+    },
+  );
+}
+
+/// Returns a codec that you can use to encode from or decode to a
+/// [Transaction].
+VariableSizeCodec<Transaction, Transaction> getTransactionCodec() {
+  final encoder = getTransactionEncoder();
+  final decoder = getTransactionDecoder();
+  return VariableSizeCodec<Transaction, Transaction>(
+    getSizeFromValue: encoder.getSizeFromValue,
+    write: encoder.write,
+    read: decoder.read,
+  );
+}
+
+/// Helper record for decoded signer data.
+class _SignerData {
+  const _SignerData({
+    required this.numRequiredSignatures,
+    required this.signerAddresses,
+  });
+  final int numRequiredSignatures;
+  final List<Address> signerAddresses;
+}
+
+/// Decodes signer addresses from compiled transaction message bytes.
+_SignerData _decodeSignerAddresses(Uint8List messageBytes) {
+  final versionDec = getTransactionVersionDecoder();
+  final u8Dec = getU8Decoder();
+  final shortU16Dec = getShortU16Decoder();
+  final addrDec = getAddressDecoder();
+
+  var pos = 0;
+
+  // Read transaction version.
+  final (_, versionEnd) = versionDec.read(messageBytes, pos);
+  pos = versionEnd;
+
+  // Read first byte of header: numSignerAccounts.
+  final (numRequiredSignatures, numSigEnd) = u8Dec.read(messageBytes, pos);
+  pos = numSigEnd;
+
+  // Skip next 2 bytes (numReadOnlySignedAccounts, numReadOnlyUnsignedAccounts).
+  pos += 2;
+
+  // Read static addresses array.
+  final (accountCount, countEnd) = shortU16Dec.read(messageBytes, pos);
+  pos = countEnd;
+
+  final staticAddresses = <Address>[];
+  for (var i = 0; i < accountCount; i++) {
+    final (addr, addrEnd) = addrDec.read(messageBytes, pos);
+    staticAddresses.add(addr);
+    pos = addrEnd;
+  }
+
+  final signerAddresses = staticAddresses.sublist(0, numRequiredSignatures);
+
+  return _SignerData(
+    numRequiredSignatures: numRequiredSignatures,
+    signerAddresses: signerAddresses,
+  );
+}

--- a/packages/solana_kit_transactions/lib/src/compile_transaction.dart
+++ b/packages/solana_kit_transactions/lib/src/compile_transaction.dart
@@ -1,0 +1,76 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+import 'package:solana_kit_transactions/src/lifetime.dart';
+
+/// Compiles a [TransactionMessage] into a [TransactionWithLifetime].
+///
+/// This includes the compiled bytes of the transaction message, and a map of
+/// signatures. This map will have a key for each address that is required to
+/// sign the transaction. The transaction will not yet have signatures for any
+/// of these addresses.
+///
+/// The transaction message must have a fee payer set and a lifetime constraint.
+TransactionWithLifetime compileTransaction(
+  TransactionMessage transactionMessage,
+) {
+  final compiledMessage = compileTransactionMessage(transactionMessage);
+  final messageBytes = getCompiledTransactionMessageEncoder().encode(
+    compiledMessage,
+  );
+
+  // Extract signer addresses from the compiled message.
+  final transactionSigners = compiledMessage.staticAccounts.sublist(
+    0,
+    compiledMessage.header.numSignerAccounts,
+  );
+
+  // Create signature map with null for all signers (preserving order).
+  final signatures = <Address, SignatureBytes?>{};
+  for (final signerAddress in transactionSigners) {
+    signatures[signerAddress] = null;
+  }
+
+  // Extract lifetime constraint from the transaction message.
+  Object? lifetimeConstraint;
+  if (isTransactionMessageWithBlockhashLifetime(transactionMessage)) {
+    final constraint =
+        transactionMessage.lifetimeConstraint! as BlockhashLifetimeConstraint;
+    lifetimeConstraint = TransactionBlockhashLifetime(
+      blockhash: constraint.blockhash,
+      lastValidBlockHeight: constraint.lastValidBlockHeight,
+    );
+  } else if (isTransactionMessageWithDurableNonceLifetime(transactionMessage)) {
+    final constraint =
+        transactionMessage.lifetimeConstraint!
+            as DurableNonceLifetimeConstraint;
+    final nonceAccountAddress =
+        transactionMessage.instructions[0].accounts![0].address;
+    lifetimeConstraint = TransactionDurableNonceLifetime(
+      nonce: constraint.nonce,
+      nonceAccountAddress: nonceAccountAddress,
+    );
+  }
+
+  if (lifetimeConstraint != null) {
+    return TransactionWithLifetime(
+      messageBytes: messageBytes,
+      signatures: signatures,
+      lifetimeConstraint: lifetimeConstraint,
+    );
+  }
+
+  // Even without a lifetime constraint, return a TransactionWithLifetime
+  // with a placeholder. In practice, the TS code always requires one.
+  return TransactionWithLifetime(
+    messageBytes: messageBytes,
+    signatures: signatures,
+    lifetimeConstraint: const _NoLifetime(),
+  );
+}
+
+/// Placeholder used when no lifetime constraint is detected.
+class _NoLifetime {
+  const _NoLifetime();
+}

--- a/packages/solana_kit_transactions/lib/src/lifetime.dart
+++ b/packages/solana_kit_transactions/lib/src/lifetime.dart
@@ -1,0 +1,220 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+import 'package:solana_kit_transactions/src/transaction.dart';
+
+/// A lifetime constraint based on the age of a blockhash observed on the
+/// network.
+///
+/// The transaction will continue to be eligible to land until the network
+/// considers the [blockhash] to be expired.
+@immutable
+class TransactionBlockhashLifetime {
+  /// Creates a [TransactionBlockhashLifetime].
+  const TransactionBlockhashLifetime({
+    required this.blockhash,
+    required this.lastValidBlockHeight,
+  });
+
+  /// A recent blockhash observed by the transaction proposer.
+  final String blockhash;
+
+  /// The block height beyond which the network will consider the blockhash
+  /// to be too old to make a transaction eligible to land.
+  final BigInt lastValidBlockHeight;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TransactionBlockhashLifetime &&
+          blockhash == other.blockhash &&
+          lastValidBlockHeight == other.lastValidBlockHeight;
+
+  @override
+  int get hashCode => Object.hash(blockhash, lastValidBlockHeight);
+
+  @override
+  String toString() =>
+      'TransactionBlockhashLifetime(blockhash: $blockhash, '
+      'lastValidBlockHeight: $lastValidBlockHeight)';
+}
+
+/// A lifetime constraint based on a durable nonce.
+///
+/// The transaction will continue to be eligible to land until the network
+/// considers the [nonce] to have advanced.
+@immutable
+class TransactionDurableNonceLifetime {
+  /// Creates a [TransactionDurableNonceLifetime].
+  const TransactionDurableNonceLifetime({
+    required this.nonce,
+    required this.nonceAccountAddress,
+  });
+
+  /// A value contained in the account with address [nonceAccountAddress]
+  /// at the time the transaction was prepared.
+  final String nonce;
+
+  /// The account that contains the [nonce] value.
+  final Address nonceAccountAddress;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TransactionDurableNonceLifetime &&
+          nonce == other.nonce &&
+          nonceAccountAddress == other.nonceAccountAddress;
+
+  @override
+  int get hashCode => Object.hash(nonce, nonceAccountAddress);
+
+  @override
+  String toString() =>
+      'TransactionDurableNonceLifetime(nonce: $nonce, '
+      'nonceAccountAddress: $nonceAccountAddress)';
+}
+
+/// The lifetime constraint for a transaction.
+///
+/// This is a sealed class with two subtypes:
+/// - [TransactionBlockhashLifetime]
+/// - [TransactionDurableNonceLifetime]
+typedef TransactionLifetimeConstraint = Object;
+
+/// A transaction that has a lifetime constraint attached.
+class TransactionWithLifetime extends Transaction {
+  /// Creates a [TransactionWithLifetime].
+  TransactionWithLifetime({
+    required super.messageBytes,
+    required super.signatures,
+    required this.lifetimeConstraint,
+  });
+
+  /// The lifetime constraint for this transaction.
+  final Object lifetimeConstraint;
+}
+
+/// Returns `true` if [transaction] has a blockhash-based lifetime constraint.
+bool isTransactionWithBlockhashLifetime(Transaction transaction) {
+  if (transaction is! TransactionWithLifetime) return false;
+  final constraint = transaction.lifetimeConstraint;
+  if (constraint is! TransactionBlockhashLifetime) return false;
+  // Validate that the blockhash is a valid base58 string of 32 bytes.
+  return _isBlockhash(constraint.blockhash);
+}
+
+/// Asserts that [transaction] has a blockhash-based lifetime constraint.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.transactionExpectedBlockhashLifetime] if the assertion
+/// fails.
+void assertIsTransactionWithBlockhashLifetime(Transaction transaction) {
+  if (!isTransactionWithBlockhashLifetime(transaction)) {
+    throw SolanaError(SolanaErrorCode.transactionExpectedBlockhashLifetime);
+  }
+}
+
+/// Returns `true` if [transaction] has a durable nonce-based lifetime
+/// constraint.
+bool isTransactionWithDurableNonceLifetime(Transaction transaction) {
+  if (transaction is! TransactionWithLifetime) return false;
+  final constraint = transaction.lifetimeConstraint;
+  if (constraint is! TransactionDurableNonceLifetime) return false;
+  // Validate the nonce account address is a valid address.
+  return isAddress(constraint.nonceAccountAddress.value);
+}
+
+/// Asserts that [transaction] has a durable nonce-based lifetime constraint.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.transactionExpectedNonceLifetime] if the assertion fails.
+void assertIsTransactionWithDurableNonceLifetime(Transaction transaction) {
+  if (!isTransactionWithDurableNonceLifetime(transaction)) {
+    throw SolanaError(SolanaErrorCode.transactionExpectedNonceLifetime);
+  }
+}
+
+/// The System Program address.
+const _systemProgramAddress = Address('11111111111111111111111111111111');
+
+/// Checks if a compiled instruction is an AdvanceNonceAccount instruction.
+bool _compiledInstructionIsAdvanceNonceInstruction(
+  CompiledInstruction instruction,
+  List<Address> staticAddresses,
+) {
+  return staticAddresses[instruction.programAddressIndex] ==
+          _systemProgramAddress &&
+      instruction.data != null &&
+      _isAdvanceNonceAccountInstructionData(instruction.data!) &&
+      instruction.accountIndices != null &&
+      instruction.accountIndices!.length == 3;
+}
+
+/// Checks if instruction data represents the AdvanceNonceAccount instruction.
+/// AdvanceNonceAccount is the fifth instruction in the System Program
+/// (index 4).
+bool _isAdvanceNonceAccountInstructionData(Uint8List data) {
+  return data.length == 4 &&
+      data[0] == 4 &&
+      data[1] == 0 &&
+      data[2] == 0 &&
+      data[3] == 0;
+}
+
+/// Returns `true` if [value] is a valid blockhash (base58 string that
+/// decodes to exactly 32 bytes).
+bool _isBlockhash(String value) {
+  if (value.length < 32 || value.length > 44) return false;
+  try {
+    // Reuse the address validation logic since a blockhash has the same
+    // base58-32-byte format as an address.
+    assertIsAddress(value);
+    return true;
+  } on Object {
+    return false;
+  }
+}
+
+/// Gets the lifetime constraint for a transaction from a compiled
+/// transaction message that includes a lifetime token.
+///
+/// If the first instruction is an AdvanceNonceAccount instruction, returns
+/// a [TransactionDurableNonceLifetime]. Otherwise, returns a
+/// [TransactionBlockhashLifetime] with lastValidBlockHeight set to max u64.
+Future<Object> getTransactionLifetimeConstraintFromCompiledTransactionMessage(
+  CompiledTransactionMessage compiledTransactionMessage,
+) async {
+  final instructions = compiledTransactionMessage.instructions;
+  final staticAccounts = compiledTransactionMessage.staticAccounts;
+  final lifetimeToken = compiledTransactionMessage.lifetimeToken;
+
+  if (instructions.isNotEmpty &&
+      _compiledInstructionIsAdvanceNonceInstruction(
+        instructions[0],
+        staticAccounts,
+      )) {
+    final nonceAccountIndex = instructions[0].accountIndices![0];
+    if (nonceAccountIndex >= staticAccounts.length) {
+      throw SolanaError(
+        SolanaErrorCode.transactionNonceAccountCannotBeInLookupTable,
+        {'nonce': lifetimeToken},
+      );
+    }
+    final nonceAccountAddress = staticAccounts[nonceAccountIndex];
+    return TransactionDurableNonceLifetime(
+      nonce: lifetimeToken ?? '',
+      nonceAccountAddress: nonceAccountAddress,
+    );
+  } else {
+    // Not known from the compiled message, so set to the maximum possible.
+    final maxU64 = BigInt.parse('18446744073709551615');
+    return TransactionBlockhashLifetime(
+      blockhash: lifetimeToken ?? '',
+      lastValidBlockHeight: maxU64,
+    );
+  }
+}

--- a/packages/solana_kit_transactions/lib/src/sendable_transaction.dart
+++ b/packages/solana_kit_transactions/lib/src/sendable_transaction.dart
@@ -1,0 +1,19 @@
+import 'package:solana_kit_transactions/src/signatures.dart';
+import 'package:solana_kit_transactions/src/transaction.dart';
+import 'package:solana_kit_transactions/src/transaction_size.dart';
+
+/// Returns `true` if the transaction has all the required conditions to be
+/// sent to the network: fully signed and within the size limit.
+bool isSendableTransaction(Transaction transaction) {
+  return isFullySignedTransaction(transaction) &&
+      isTransactionWithinSizeLimit(transaction);
+}
+
+/// Asserts that a given transaction has all the required conditions to be
+/// sent to the network.
+///
+/// Throws if the transaction is not fully signed or exceeds the size limit.
+void assertIsSendableTransaction(Transaction transaction) {
+  assertIsFullySignedTransaction(transaction);
+  assertIsTransactionWithinSizeLimit(transaction);
+}

--- a/packages/solana_kit_transactions/lib/src/signatures.dart
+++ b/packages/solana_kit_transactions/lib/src/signatures.dart
@@ -1,0 +1,168 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+import 'package:solana_kit_transactions/src/lifetime.dart';
+import 'package:solana_kit_transactions/src/transaction.dart';
+
+/// Cached base58 decoder instance.
+Decoder<String>? _base58Decoder;
+
+/// Given a transaction signed by its fee payer, this method will return the
+/// [Signature] that uniquely identifies it.
+///
+/// The fee payer is the first entry in the signatures map.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.transactionFeePayerSignatureMissing] if the fee payer
+/// has not signed.
+Signature getSignatureFromTransaction(Transaction transaction) {
+  _base58Decoder ??= getBase58Decoder();
+
+  // First signature is the fee payer's.
+  final signatureEntries = transaction.signatures.values;
+  if (signatureEntries.isEmpty) {
+    throw SolanaError(SolanaErrorCode.transactionFeePayerSignatureMissing);
+  }
+
+  final signatureBytes = signatureEntries.first;
+  if (signatureBytes == null) {
+    throw SolanaError(SolanaErrorCode.transactionFeePayerSignatureMissing);
+  }
+
+  final transactionSignature = _base58Decoder!.decode(signatureBytes.value);
+  return Signature(transactionSignature);
+}
+
+/// Given a list of [KeyPair] objects which are key pairs pertaining to
+/// addresses that are required to sign a transaction, this method will
+/// return a new signed transaction.
+///
+/// Though the resulting transaction might have every signature it needs to
+/// land on the network, this function will not assert that it does.
+Future<Transaction> partiallySignTransaction(
+  List<KeyPair> keyPairs,
+  Transaction transaction,
+) async {
+  Map<Address, SignatureBytes>? newSignatures;
+  Set<Address>? unexpectedSigners;
+
+  for (final keyPair in keyPairs) {
+    final addr = getAddressFromPublicKey(keyPair.publicKey);
+    final existingSignature = transaction.signatures[addr];
+
+    // Check if the address is expected to sign the transaction.
+    if (!transaction.signatures.containsKey(addr)) {
+      unexpectedSigners ??= <Address>{};
+      unexpectedSigners.add(addr);
+      continue;
+    }
+
+    // Skip if there are already unexpected signers since we won't be using
+    // the signatures.
+    if (unexpectedSigners != null) {
+      continue;
+    }
+
+    final newSignature = signBytes(
+      keyPair.privateKey,
+      transaction.messageBytes,
+    );
+
+    if (existingSignature != null &&
+        _bytesEqual(newSignature.value, existingSignature.value)) {
+      // Already have the same signature.
+      continue;
+    }
+
+    newSignatures ??= <Address, SignatureBytes>{};
+    newSignatures[addr] = newSignature;
+  }
+
+  if (unexpectedSigners != null && unexpectedSigners.isNotEmpty) {
+    final expectedSigners = transaction.signatures.keys.toList();
+    throw SolanaError(
+      SolanaErrorCode.transactionAddressesCannotSignTransaction,
+      {
+        'expectedAddresses': expectedSigners.map((a) => a.value).toList(),
+        'unexpectedAddresses': unexpectedSigners.map((a) => a.value).toList(),
+      },
+    );
+  }
+
+  if (newSignatures == null) {
+    return transaction;
+  }
+
+  final mergedSignatures = <Address, SignatureBytes?>{
+    ...transaction.signatures,
+    ...newSignatures,
+  };
+
+  if (transaction is TransactionWithLifetime) {
+    return TransactionWithLifetime(
+      messageBytes: transaction.messageBytes,
+      signatures: mergedSignatures,
+      lifetimeConstraint: transaction.lifetimeConstraint,
+    );
+  }
+
+  return Transaction(
+    messageBytes: transaction.messageBytes,
+    signatures: mergedSignatures,
+  );
+}
+
+/// Given a list of [KeyPair] objects, signs the transaction and asserts that
+/// it is fully signed.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.transactionSignaturesMissing] if the resulting
+/// transaction is not fully signed.
+Future<Transaction> signTransaction(
+  List<KeyPair> keyPairs,
+  Transaction transaction,
+) async {
+  final out = await partiallySignTransaction(keyPairs, transaction);
+  assertIsFullySignedTransaction(out);
+  return out;
+}
+
+/// Returns `true` if all entries in the transaction's signatures map have
+/// non-null signatures.
+bool isFullySignedTransaction(Transaction transaction) {
+  return transaction.signatures.values.every((sig) => sig != null);
+}
+
+/// Asserts that the transaction is fully signed.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.transactionSignaturesMissing] if any signer has a null
+/// signature, providing the list of missing signer addresses.
+void assertIsFullySignedTransaction(Transaction transaction) {
+  final missingSigs = <Address>[];
+  for (final entry in transaction.signatures.entries) {
+    if (entry.value == null) {
+      missingSigs.add(entry.key);
+    }
+  }
+
+  if (missingSigs.isNotEmpty) {
+    throw SolanaError(SolanaErrorCode.transactionSignaturesMissing, {
+      'addresses': missingSigs.map((a) => a.value).toList(),
+    });
+  }
+}
+
+/// Compares two byte arrays for equality.
+bool _bytesEqual(Uint8List a, Uint8List b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}

--- a/packages/solana_kit_transactions/lib/src/transaction.dart
+++ b/packages/solana_kit_transactions/lib/src/transaction.dart
@@ -1,0 +1,26 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+/// A compiled transaction consisting of message bytes and a signatures map.
+///
+/// The [messageBytes] are the compiled transaction message in wire format.
+/// The [signatures] map associates each signer's address with their 64-byte
+/// Ed25519 signature, or `null` if the address has not yet signed.
+class Transaction {
+  /// Creates a [Transaction] with the given [messageBytes] and [signatures].
+  Transaction({
+    required this.messageBytes,
+    required Map<Address, SignatureBytes?> signatures,
+  }) : signatures = Map<Address, SignatureBytes?>.unmodifiable(signatures);
+
+  /// The bytes of a compiled transaction message, encoded in wire format.
+  final Uint8List messageBytes;
+
+  /// A map between the addresses of a transaction message's signers, and the
+  /// 64-byte Ed25519 signature of the transaction's [messageBytes] by the
+  /// private key associated with each. A `null` value means the address has
+  /// not yet signed.
+  final Map<Address, SignatureBytes?> signatures;
+}

--- a/packages/solana_kit_transactions/lib/src/transaction_size.dart
+++ b/packages/solana_kit_transactions/lib/src/transaction_size.dart
@@ -1,0 +1,76 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+import 'package:solana_kit_transactions/src/codecs/transaction_codec.dart';
+import 'package:solana_kit_transactions/src/compile_transaction.dart';
+import 'package:solana_kit_transactions/src/transaction.dart';
+
+/// The maximum size of a transaction packet in bytes.
+const transactionPacketSize = 1280;
+
+/// The size of the transaction packet header in bytes.
+/// This includes the IPv6 header (40 bytes) and the fragment header (8 bytes).
+const transactionPacketHeader = 40 + 8;
+
+/// The maximum size of a transaction in bytes.
+///
+/// Note that this excludes the transaction packet header.
+/// In other words, this is how much content we can fit in a transaction packet.
+const transactionSizeLimit = transactionPacketSize - transactionPacketHeader;
+
+/// Gets the size of a given transaction in bytes.
+int getTransactionSize(Transaction transaction) {
+  final encoder = getTransactionEncoder();
+  return encoder.getSizeFromValue(transaction);
+}
+
+/// Returns `true` if the transaction is within the size limit.
+bool isTransactionWithinSizeLimit(Transaction transaction) {
+  return getTransactionSize(transaction) <= transactionSizeLimit;
+}
+
+/// Asserts that a given transaction is within the size limit.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.transactionExceedsSizeLimit] if the transaction exceeds
+/// the size limit.
+void assertIsTransactionWithinSizeLimit(Transaction transaction) {
+  final size = getTransactionSize(transaction);
+  if (size > transactionSizeLimit) {
+    throw SolanaError(SolanaErrorCode.transactionExceedsSizeLimit, {
+      'transactionSize': size,
+      'transactionSizeLimit': transactionSizeLimit,
+    });
+  }
+}
+
+/// Gets the compiled transaction size of a given transaction message in bytes.
+int getTransactionMessageSize(TransactionMessage transactionMessage) {
+  return getTransactionSize(compileTransaction(transactionMessage));
+}
+
+/// Checks if a transaction message is within the size limit when compiled
+/// into a transaction.
+bool isTransactionMessageWithinSizeLimit(
+  TransactionMessage transactionMessage,
+) {
+  return getTransactionMessageSize(transactionMessage) <= transactionSizeLimit;
+}
+
+/// Asserts that a given transaction message is within the size limit when
+/// compiled into a transaction.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.transactionExceedsSizeLimit] if the transaction message
+/// exceeds the size limit.
+void assertIsTransactionMessageWithinSizeLimit(
+  TransactionMessage transactionMessage,
+) {
+  final size = getTransactionMessageSize(transactionMessage);
+  if (size > transactionSizeLimit) {
+    throw SolanaError(SolanaErrorCode.transactionExceedsSizeLimit, {
+      'transactionSize': size,
+      'transactionSizeLimit': transactionSizeLimit,
+    });
+  }
+}

--- a/packages/solana_kit_transactions/lib/src/wire_transaction.dart
+++ b/packages/solana_kit_transactions/lib/src/wire_transaction.dart
@@ -1,0 +1,11 @@
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+import 'package:solana_kit_transactions/src/codecs/transaction_codec.dart';
+import 'package:solana_kit_transactions/src/transaction.dart';
+
+/// Given a signed transaction, this method returns the transaction as a
+/// base64-encoded wire transaction string.
+String getBase64EncodedWireTransaction(Transaction transaction) {
+  final wireTransactionBytes = getTransactionEncoder().encode(transaction);
+  return getBase64Decoder().decode(wireTransactionBytes);
+}

--- a/packages/solana_kit_transactions/pubspec.yaml
+++ b/packages/solana_kit_transactions/pubspec.yaml
@@ -8,8 +8,17 @@ environment:
 resolution: workspace
 
 dependencies:
+  meta: ^1.16.0
+  solana_kit_addresses:
+  solana_kit_codecs_core:
+  solana_kit_codecs_data_structures:
+  solana_kit_codecs_numbers:
+  solana_kit_codecs_strings:
   solana_kit_errors:
+  solana_kit_instructions:
+  solana_kit_keys:
   solana_kit_transaction_messages:
 
 dev_dependencies:
   solana_kit_lints:
+  test: ^1.25.0

--- a/packages/solana_kit_transactions/test/codecs/signatures_encoder_test.dart
+++ b/packages/solana_kit_transactions/test/codecs/signatures_encoder_test.dart
@@ -1,0 +1,107 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getSignaturesEncoderWithSizePrefix', () {
+    test('throws when encoding an empty signatures map', () {
+      final encoder = getSignaturesEncoderWithSizePrefix();
+      expect(
+        () => encoder.encode(const {}),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionCannotEncodeWithEmptySignatures,
+          ),
+        ),
+      );
+    });
+
+    test('encodes a single null signature as 64 zero bytes', () {
+      final encoder = getSignaturesEncoderWithSizePrefix();
+      final encoded = encoder.encode(const {
+        Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): null,
+      });
+      // 1 byte prefix (count=1) + 64 bytes signature = 65 bytes.
+      expect(encoded.length, 65);
+      // First byte is the shortU16-encoded count (1).
+      expect(encoded[0], 1);
+      // The remaining 64 bytes should all be zero.
+      for (var i = 1; i < 65; i++) {
+        expect(encoded[i], 0, reason: 'byte at index $i should be 0');
+      }
+    });
+
+    test('encodes a non-null signature correctly', () {
+      final sigBytes = SignatureBytes(
+        Uint8List.fromList(List<int>.filled(64, 0xff)),
+      );
+      final encoder = getSignaturesEncoderWithSizePrefix();
+      final encoded = encoder.encode({
+        const Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): sigBytes,
+      });
+      expect(encoded.length, 65);
+      expect(encoded[0], 1);
+      for (var i = 1; i < 65; i++) {
+        expect(encoded[i], 0xff);
+      }
+    });
+
+    test('encodes multiple signatures', () {
+      final sigA = SignatureBytes(Uint8List.fromList(List<int>.filled(64, 1)));
+      final sigB = SignatureBytes(Uint8List.fromList(List<int>.filled(64, 2)));
+      final encoder = getSignaturesEncoderWithSizePrefix();
+      final encoded = encoder.encode({
+        const Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): sigA,
+        const Address('BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'): sigB,
+      });
+      // 1 byte prefix (count=2) + 128 bytes = 129 bytes.
+      expect(encoded.length, 129);
+      expect(encoded[0], 2);
+      // First signature: all 1s.
+      for (var i = 1; i < 65; i++) {
+        expect(encoded[i], 1);
+      }
+      // Second signature: all 2s.
+      for (var i = 65; i < 129; i++) {
+        expect(encoded[i], 2);
+      }
+    });
+
+    test('encodes mixed null and non-null signatures', () {
+      final sigA = SignatureBytes(
+        Uint8List.fromList(List<int>.filled(64, 0xab)),
+      );
+      final encoder = getSignaturesEncoderWithSizePrefix();
+      final encoded = encoder.encode({
+        const Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): sigA,
+        const Address('BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'): null,
+      });
+      expect(encoded.length, 129);
+      expect(encoded[0], 2);
+      // First signature: all 0xab.
+      for (var i = 1; i < 65; i++) {
+        expect(encoded[i], 0xab);
+      }
+      // Second signature: all zeros (null).
+      for (var i = 65; i < 129; i++) {
+        expect(encoded[i], 0);
+      }
+    });
+
+    test('getSizeFromValue returns correct size', () {
+      final encoder = getSignaturesEncoderWithSizePrefix();
+      final size = encoder.getSizeFromValue(const {
+        Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): null,
+        Address('BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'): null,
+      });
+      // 1 byte prefix (count=2) + 128 bytes = 129 bytes.
+      expect(size, 129);
+    });
+  });
+}

--- a/packages/solana_kit_transactions/test/codecs/transaction_codec_test.dart
+++ b/packages/solana_kit_transactions/test/codecs/transaction_codec_test.dart
@@ -1,0 +1,153 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getTransactionEncoder', () {
+    test('encodes a transaction with null signatures to bytes', () {
+      final transaction = Transaction(
+        messageBytes: Uint8List.fromList([1, 2, 3]),
+        signatures: const {Address('11111111111111111111111111111111'): null},
+      );
+      final encoder = getTransactionEncoder();
+      final encoded = encoder.encode(transaction);
+      expect(encoded, isA<Uint8List>());
+      // 1 (shortU16 count) + 64 (signature) + 3 (message) = 68.
+      expect(encoded.length, 68);
+    });
+
+    test('encodes a transaction with a real signature', () {
+      final sigBytes = SignatureBytes(
+        Uint8List.fromList(List<int>.filled(64, 0xab)),
+      );
+      final transaction = Transaction(
+        messageBytes: Uint8List.fromList([1, 2, 3]),
+        signatures: {
+          const Address('11111111111111111111111111111111'): sigBytes,
+        },
+      );
+      final encoder = getTransactionEncoder();
+      final encoded = encoder.encode(transaction);
+      expect(encoded.length, 68);
+      // Verify signature bytes are in the encoded output.
+      for (var i = 1; i < 65; i++) {
+        expect(encoded[i], 0xab);
+      }
+    });
+
+    test('getSizeFromValue returns correct size', () {
+      final transaction = Transaction(
+        messageBytes: Uint8List.fromList([1, 2, 3, 4, 5]),
+        signatures: const {Address('11111111111111111111111111111111'): null},
+      );
+      final encoder = getTransactionEncoder();
+      final size = encoder.getSizeFromValue(transaction);
+      // 1 (shortU16 count) + 64 (signature) + 5 (message) = 70.
+      expect(size, 70);
+    });
+  });
+
+  group('getTransactionDecoder', () {
+    test('decodes a round-tripped transaction', () {
+      // Create and compile a transaction message.
+      final message = const TransactionMessage(version: TransactionVersion.v0)
+          .copyWith(
+            feePayer: const Address(
+              '22222222222222222222222222222222222222222222',
+            ),
+            lifetimeConstraint: BlockhashLifetimeConstraint(
+              blockhash: '11111111111111111111111111111111',
+              lastValidBlockHeight: BigInt.zero,
+            ),
+          );
+
+      final compiled = compileTransaction(message);
+      final encoder = getTransactionEncoder();
+      final encoded = encoder.encode(compiled);
+
+      final decoder = getTransactionDecoder();
+      final decoded = decoder.decode(encoded);
+
+      expect(decoded.messageBytes, compiled.messageBytes);
+      expect(decoded.signatures.length, compiled.signatures.length);
+      // All signatures should be null since the original was unsigned.
+      for (final sig in decoded.signatures.values) {
+        expect(sig, isNull);
+      }
+    });
+
+    test('decodes a transaction with a real signature', () {
+      final sigBytes = SignatureBytes(
+        Uint8List.fromList(List<int>.filled(64, 0xab)),
+      );
+
+      final message = const TransactionMessage(version: TransactionVersion.v0)
+          .copyWith(
+            feePayer: const Address(
+              '22222222222222222222222222222222222222222222',
+            ),
+            lifetimeConstraint: BlockhashLifetimeConstraint(
+              blockhash: '11111111111111111111111111111111',
+              lastValidBlockHeight: BigInt.zero,
+            ),
+          );
+
+      final compiled = compileTransaction(message);
+
+      // Replace the null signature with a real one.
+      final feePayer = compiled.signatures.keys.first;
+      final transaction = Transaction(
+        messageBytes: compiled.messageBytes,
+        signatures: {feePayer: sigBytes},
+      );
+
+      final encoder = getTransactionEncoder();
+      final encoded = encoder.encode(transaction);
+
+      final decoder = getTransactionDecoder();
+      final decoded = decoder.decode(encoded);
+
+      expect(decoded.signatures[feePayer], isNotNull);
+      expect(decoded.signatures[feePayer]!.value, sigBytes.value);
+    });
+  });
+
+  group('getTransactionCodec', () {
+    test('round-trips a compiled transaction', () {
+      final message = const TransactionMessage(version: TransactionVersion.v0)
+          .copyWith(
+            feePayer: const Address(
+              '22222222222222222222222222222222222222222222',
+            ),
+            lifetimeConstraint: BlockhashLifetimeConstraint(
+              blockhash: '11111111111111111111111111111111',
+              lastValidBlockHeight: BigInt.zero,
+            ),
+            instructions: [
+              const Instruction(
+                programAddress: Address(
+                  '33333333333333333333333333333333333333333333',
+                ),
+              ),
+            ],
+          );
+
+      final compiled = compileTransaction(message);
+      final codec = getTransactionCodec();
+      final encoded = codec.encode(compiled);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded.messageBytes, compiled.messageBytes);
+      expect(decoded.signatures.length, compiled.signatures.length);
+      expect(
+        decoded.signatures.keys.toList(),
+        compiled.signatures.keys.toList(),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_transactions/test/compile_transaction_test.dart
+++ b/packages/solana_kit_transactions/test/compile_transaction_test.dart
@@ -1,0 +1,130 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('compileTransaction', () {
+    final mockBlockhash = BlockhashLifetimeConstraint(
+      blockhash: '11111111111111111111111111111111',
+      lastValidBlockHeight: BigInt.one,
+    );
+
+    TransactionMessage createMessage() {
+      return const TransactionMessage(version: TransactionVersion.v0).copyWith(
+        feePayer: const Address('22222222222222222222222222222222222222222222'),
+        lifetimeConstraint: mockBlockhash,
+      );
+    }
+
+    test('compiles the supplied TransactionMessage and sets messageBytes', () {
+      final message = createMessage();
+      final transaction = compileTransaction(message);
+      expect(transaction.messageBytes, isA<Uint8List>());
+      expect(transaction.messageBytes.isNotEmpty, isTrue);
+    });
+
+    test('compiles signatures with correct number of entries', () {
+      final message = createMessage();
+      final transaction = compileTransaction(message);
+      // Fee payer is the only signer.
+      expect(transaction.signatures.length, 1);
+    });
+
+    test('inserts signers into the correct position in the signatures map', () {
+      final message = createMessage();
+      final transaction = compileTransaction(message);
+      expect(
+        transaction.signatures.keys.first,
+        const Address('22222222222222222222222222222222222222222222'),
+      );
+    });
+
+    test('inserts a null signature into the map for each signer', () {
+      final message = createMessage();
+      final transaction = compileTransaction(message);
+      expect(transaction.signatures.values.toList(), [null]);
+    });
+
+    test('returns a blockhash lifetime constraint when the transaction message '
+        'has a blockhash constraint', () {
+      final message = createMessage();
+      final transaction = compileTransaction(message);
+      expect(transaction, isA<TransactionWithLifetime>());
+      final lifetime = transaction.lifetimeConstraint;
+      expect(lifetime, isA<TransactionBlockhashLifetime>());
+      final blockhashLifetime = lifetime as TransactionBlockhashLifetime;
+      expect(blockhashLifetime.blockhash, '11111111111111111111111111111111');
+      expect(blockhashLifetime.lastValidBlockHeight, BigInt.one);
+    });
+
+    test('returns a durable nonce lifetime constraint when the transaction '
+        'message has a nonce constraint', () {
+      final baseMessage =
+          const TransactionMessage(version: TransactionVersion.v0).copyWith(
+            feePayer: const Address(
+              '22222222222222222222222222222222222222222222',
+            ),
+          );
+      final nonceMessage = setTransactionMessageLifetimeUsingDurableNonce(
+        const DurableNonceConfig(
+          nonce: '33333333333333333333333333333333',
+          nonceAccountAddress: Address(
+            '44444444444444444444444444444444444444444444',
+          ),
+          nonceAuthorityAddress: Address(
+            '55555555555555555555555555555555555555555555',
+          ),
+        ),
+        baseMessage,
+      );
+
+      final transaction = compileTransaction(nonceMessage);
+      expect(transaction, isA<TransactionWithLifetime>());
+      final lifetime = transaction.lifetimeConstraint;
+      expect(lifetime, isA<TransactionDurableNonceLifetime>());
+      final nonceLifetime = lifetime as TransactionDurableNonceLifetime;
+      expect(nonceLifetime.nonce, '33333333333333333333333333333333');
+      expect(
+        nonceLifetime.nonceAccountAddress,
+        const Address('44444444444444444444444444444444444444444444'),
+      );
+    });
+
+    test('compiles a message with multiple signers', () {
+      final message = const TransactionMessage(version: TransactionVersion.v0)
+          .copyWith(
+            feePayer: const Address(
+              '22222222222222222222222222222222222222222222',
+            ),
+            lifetimeConstraint: mockBlockhash,
+            instructions: [
+              const Instruction(
+                programAddress: Address(
+                  '55555555555555555555555555555555555555555555',
+                ),
+                accounts: [
+                  AccountMeta(
+                    address: Address(
+                      '66666666666666666666666666666666666666666666',
+                    ),
+                    role: AccountRole.readonlySigner,
+                  ),
+                ],
+              ),
+            ],
+          );
+
+      final transaction = compileTransaction(message);
+      // Fee payer + the readonly signer = 2 signers.
+      expect(transaction.signatures.length, 2);
+      expect(
+        transaction.signatures.keys.toList(),
+        contains(const Address('22222222222222222222222222222222222222222222')),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_transactions/test/lifetime_test.dart
+++ b/packages/solana_kit_transactions/test/lifetime_test.dart
@@ -1,0 +1,354 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+import 'package:test/test.dart';
+
+const _systemProgramAddress = Address('11111111111111111111111111111111');
+
+void main() {
+  group('getTransactionLifetimeConstraintFromCompiledTransactionMessage', () {
+    final maxU64 = BigInt.parse('18446744073709551615');
+
+    test('returns a blockhash transaction lifetime when there are no '
+        'instructions', () async {
+      const compiledMessage = CompiledTransactionMessage(
+        version: TransactionVersion.v0,
+        header: MessageHeader(
+          numSignerAccounts: 1,
+          numReadonlySignerAccounts: 0,
+          numReadonlyNonSignerAccounts: 0,
+        ),
+        staticAccounts: [
+          Address('22222222222222222222222222222222222222222222'),
+        ],
+        instructions: [],
+        lifetimeToken: 'abc',
+      );
+
+      final result =
+          await getTransactionLifetimeConstraintFromCompiledTransactionMessage(
+            compiledMessage,
+          );
+      expect(result, isA<TransactionBlockhashLifetime>());
+      final blockhash = result as TransactionBlockhashLifetime;
+      expect(blockhash.blockhash, 'abc');
+      expect(blockhash.lastValidBlockHeight, maxU64);
+    });
+
+    group('returns a blockhash transaction lifetime when the first instruction '
+        'is not an AdvanceNonceAccount instruction', () {
+      test('because the program is not the System Program', () async {
+        final compiledMessage = CompiledTransactionMessage(
+          version: TransactionVersion.v0,
+          header: const MessageHeader(
+            numSignerAccounts: 1,
+            numReadonlySignerAccounts: 0,
+            numReadonlyNonSignerAccounts: 0,
+          ),
+          staticAccounts: const [Address('otherProgramAddress333333333333')],
+          instructions: [
+            CompiledInstruction(
+              programAddressIndex: 0,
+              accountIndices: const [1, 2, 3],
+              data: Uint8List.fromList([4, 0, 0, 0]),
+            ),
+          ],
+          lifetimeToken: 'abc',
+        );
+
+        final result =
+            await getTransactionLifetimeConstraintFromCompiledTransactionMessage(
+              compiledMessage,
+            );
+        expect(result, isA<TransactionBlockhashLifetime>());
+        final blockhash = result as TransactionBlockhashLifetime;
+        expect(blockhash.blockhash, 'abc');
+        expect(blockhash.lastValidBlockHeight, maxU64);
+      });
+
+      test(
+        'because the instruction data is not for AdvanceNonceAccount',
+        () async {
+          final compiledMessage = CompiledTransactionMessage(
+            version: TransactionVersion.v0,
+            header: const MessageHeader(
+              numSignerAccounts: 1,
+              numReadonlySignerAccounts: 0,
+              numReadonlyNonSignerAccounts: 0,
+            ),
+            staticAccounts: const [_systemProgramAddress],
+            instructions: [
+              CompiledInstruction(
+                programAddressIndex: 0,
+                accountIndices: const [1, 2, 3],
+                data: Uint8List.fromList([1, 0, 0, 0]),
+              ),
+            ],
+            lifetimeToken: 'abc',
+          );
+
+          final result =
+              await getTransactionLifetimeConstraintFromCompiledTransactionMessage(
+                compiledMessage,
+              );
+          expect(result, isA<TransactionBlockhashLifetime>());
+        },
+      );
+
+      test('because the instruction does not have exactly 3 accounts', () async {
+        final compiledMessage = CompiledTransactionMessage(
+          version: TransactionVersion.v0,
+          header: const MessageHeader(
+            numSignerAccounts: 1,
+            numReadonlySignerAccounts: 0,
+            numReadonlyNonSignerAccounts: 0,
+          ),
+          staticAccounts: const [_systemProgramAddress],
+          instructions: [
+            CompiledInstruction(
+              programAddressIndex: 0,
+              accountIndices: const [1, 2],
+              data: Uint8List.fromList([4, 0, 0, 0]),
+            ),
+          ],
+          lifetimeToken: 'abc',
+        );
+
+        final result =
+            await getTransactionLifetimeConstraintFromCompiledTransactionMessage(
+              compiledMessage,
+            );
+        expect(result, isA<TransactionBlockhashLifetime>());
+      });
+
+      test('because it has no account indices', () async {
+        final compiledMessage = CompiledTransactionMessage(
+          version: TransactionVersion.v0,
+          header: const MessageHeader(
+            numSignerAccounts: 1,
+            numReadonlySignerAccounts: 0,
+            numReadonlyNonSignerAccounts: 0,
+          ),
+          staticAccounts: const [_systemProgramAddress],
+          instructions: [
+            CompiledInstruction(
+              programAddressIndex: 0,
+              data: Uint8List.fromList([4, 0, 0, 0]),
+            ),
+          ],
+          lifetimeToken: 'abc',
+        );
+
+        final result =
+            await getTransactionLifetimeConstraintFromCompiledTransactionMessage(
+              compiledMessage,
+            );
+        expect(result, isA<TransactionBlockhashLifetime>());
+      });
+    });
+
+    test('returns a durable nonce transaction lifetime when the first '
+        'instruction is an AdvanceNonceAccount instruction', () async {
+      final compiledMessage = CompiledTransactionMessage(
+        version: TransactionVersion.v0,
+        header: const MessageHeader(
+          numSignerAccounts: 1,
+          numReadonlySignerAccounts: 0,
+          numReadonlyNonSignerAccounts: 0,
+        ),
+        staticAccounts: const [
+          Address('11111111111111111111111111111111'),
+          Address('nonceAccountAddress33333333333333'),
+          Address('recentBlockhashesSysvarAddress333'),
+          Address('nonceAuthorityAddress33333333333'),
+        ],
+        instructions: [
+          CompiledInstruction(
+            programAddressIndex: 0,
+            accountIndices: const [1, 2, 3],
+            data: Uint8List.fromList([4, 0, 0, 0]),
+          ),
+        ],
+        lifetimeToken: 'abc',
+      );
+
+      final result =
+          await getTransactionLifetimeConstraintFromCompiledTransactionMessage(
+            compiledMessage,
+          );
+      expect(result, isA<TransactionDurableNonceLifetime>());
+      final nonce = result as TransactionDurableNonceLifetime;
+      expect(nonce.nonce, 'abc');
+      expect(
+        nonce.nonceAccountAddress,
+        const Address('nonceAccountAddress33333333333333'),
+      );
+    });
+
+    test(
+      'fatals if the nonce account address is not in static accounts',
+      () async {
+        final compiledMessage = CompiledTransactionMessage(
+          version: TransactionVersion.v0,
+          header: const MessageHeader(
+            numSignerAccounts: 1,
+            numReadonlySignerAccounts: 0,
+            numReadonlyNonSignerAccounts: 0,
+          ),
+          staticAccounts: const [Address('11111111111111111111111111111111')],
+          instructions: [
+            CompiledInstruction(
+              programAddressIndex: 0,
+              accountIndices: const [1, 2, 3],
+              data: Uint8List.fromList([4, 0, 0, 0]),
+            ),
+          ],
+          lifetimeToken: 'abc',
+        );
+
+        expect(
+          () async =>
+              getTransactionLifetimeConstraintFromCompiledTransactionMessage(
+                compiledMessage,
+              ),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.transactionNonceAccountCannotBeInLookupTable,
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('assertIsTransactionWithBlockhashLifetime', () {
+    test('throws for a transaction with no lifetime constraint', () {
+      final transaction = Transaction(
+        messageBytes: Uint8List(0),
+        signatures: const {},
+      );
+      expect(
+        () => assertIsTransactionWithBlockhashLifetime(transaction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionExpectedBlockhashLifetime,
+          ),
+        ),
+      );
+    });
+
+    test('throws for a transaction with a durable nonce constraint', () {
+      final transaction = TransactionWithLifetime(
+        messageBytes: Uint8List(0),
+        signatures: const {},
+        lifetimeConstraint: const TransactionDurableNonceLifetime(
+          nonce: 'abcd',
+          nonceAccountAddress: Address(
+            '2B7hCrBozp5hPV31mw1qUh5XhXYs9f6p1GsRdHNjF4xS',
+          ),
+        ),
+      );
+      expect(
+        () => assertIsTransactionWithBlockhashLifetime(transaction),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test(
+      'does not throw for a transaction with a valid blockhash constraint',
+      () {
+        final transaction = TransactionWithLifetime(
+          messageBytes: Uint8List(0),
+          signatures: const {},
+          lifetimeConstraint: TransactionBlockhashLifetime(
+            blockhash: '11111111111111111111111111111111',
+            lastValidBlockHeight: BigInt.from(1234),
+          ),
+        );
+        expect(
+          () => assertIsTransactionWithBlockhashLifetime(transaction),
+          returnsNormally,
+        );
+      },
+    );
+  });
+
+  group('assertIsTransactionWithDurableNonceLifetime', () {
+    const validAddress = Address(
+      '2B7hCrBozp5hPV31mw1qUh5XhXYs9f6p1GsRdHNjF4xS',
+    );
+
+    test('throws for a transaction with no lifetime constraint', () {
+      final transaction = Transaction(
+        messageBytes: Uint8List(0),
+        signatures: const {},
+      );
+      expect(
+        () => assertIsTransactionWithDurableNonceLifetime(transaction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionExpectedNonceLifetime,
+          ),
+        ),
+      );
+    });
+
+    test('throws for a transaction with a blockhash constraint', () {
+      final transaction = TransactionWithLifetime(
+        messageBytes: Uint8List(0),
+        signatures: const {},
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.from(1234),
+        ),
+      );
+      expect(
+        () => assertIsTransactionWithDurableNonceLifetime(transaction),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('throws for a transaction with a durable nonce lifetime but an '
+        'invalid nonceAccountAddress value', () {
+      final transaction = TransactionWithLifetime(
+        messageBytes: Uint8List(0),
+        signatures: const {},
+        lifetimeConstraint: const TransactionDurableNonceLifetime(
+          nonce: 'abcd',
+          nonceAccountAddress: Address('not a valid address'),
+        ),
+      );
+      expect(
+        () => assertIsTransactionWithDurableNonceLifetime(transaction),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test(
+      'does not throw for a transaction with a valid durable nonce lifetime',
+      () {
+        final transaction = TransactionWithLifetime(
+          messageBytes: Uint8List(0),
+          signatures: const {},
+          lifetimeConstraint: const TransactionDurableNonceLifetime(
+            nonce: 'abcd',
+            nonceAccountAddress: validAddress,
+          ),
+        );
+        expect(
+          () => assertIsTransactionWithDurableNonceLifetime(transaction),
+          returnsNormally,
+        );
+      },
+    );
+  });
+}

--- a/packages/solana_kit_transactions/test/signatures_test.dart
+++ b/packages/solana_kit_transactions/test/signatures_test.dart
@@ -1,0 +1,450 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getSignatureFromTransaction', () {
+    test("returns the signature associated with a transaction's fee payer", () {
+      final sigBytes = SignatureBytes(
+        Uint8List.fromList(List<int>.filled(64, 9)),
+      );
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: {
+          const Address('12345678901234567890123456789012'): sigBytes,
+        },
+      );
+      final sig = getSignatureFromTransaction(transaction);
+      expect(sig.value, isA<String>());
+      expect(sig.value.isNotEmpty, isTrue);
+    });
+
+    test('throws when supplied a transaction that has not been signed by the '
+        'fee payer', () {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: const {},
+      );
+      expect(
+        () => getSignatureFromTransaction(transaction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionFeePayerSignatureMissing,
+          ),
+        ),
+      );
+    });
+
+    test('throws when the fee payer signature is null', () {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: const {Address('12345678901234567890123456789012'): null},
+      );
+      expect(
+        () => getSignatureFromTransaction(transaction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionFeePayerSignatureMissing,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('partiallySignTransaction', () {
+    late KeyPair keyPairA;
+    late KeyPair keyPairB;
+    late KeyPair keyPairC;
+    late Address addressA;
+    late Address addressB;
+    late Address addressC;
+
+    setUp(() {
+      keyPairA = generateKeyPair();
+      keyPairB = generateKeyPair();
+      keyPairC = generateKeyPair();
+      addressA = getAddressFromPublicKey(keyPairA.publicKey);
+      addressB = getAddressFromPublicKey(keyPairB.publicKey);
+      addressC = getAddressFromPublicKey(keyPairC.publicKey);
+    });
+
+    test(
+      "returns a signed transaction having the first signer's signature",
+      () async {
+        final transaction = TransactionWithLifetime(
+          lifetimeConstraint: TransactionBlockhashLifetime(
+            blockhash: '11111111111111111111111111111111',
+            lastValidBlockHeight: BigInt.zero,
+          ),
+          messageBytes: Uint8List.fromList([1, 2, 3]),
+          signatures: {addressA: null},
+        );
+
+        final signed = await partiallySignTransaction([keyPairA], transaction);
+        expect(signed.signatures[addressA], isNotNull);
+        expect(signed.signatures[addressA]!.value.length, 64);
+      },
+    );
+
+    test('returns unchanged compiled message bytes', () async {
+      final messageBytes = Uint8List.fromList([1, 2, 3]);
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: messageBytes,
+        signatures: {addressA: null},
+      );
+      final signed = await partiallySignTransaction([keyPairA], transaction);
+      expect(signed.messageBytes, messageBytes);
+    });
+
+    test(
+      'returns a signed transaction with null for missing signers',
+      () async {
+        final transaction = TransactionWithLifetime(
+          lifetimeConstraint: TransactionBlockhashLifetime(
+            blockhash: '11111111111111111111111111111111',
+            lastValidBlockHeight: BigInt.zero,
+          ),
+          messageBytes: Uint8List.fromList([1, 2, 3]),
+          signatures: {addressA: null, addressB: null, addressC: null},
+        );
+        final signed = await partiallySignTransaction([keyPairA], transaction);
+        expect(signed.signatures[addressA], isNotNull);
+        expect(signed.signatures[addressB], isNull);
+        expect(signed.signatures[addressC], isNull);
+      },
+    );
+
+    test(
+      "returns a transaction having the second signer's signature",
+      () async {
+        final transaction = TransactionWithLifetime(
+          lifetimeConstraint: TransactionBlockhashLifetime(
+            blockhash: '11111111111111111111111111111111',
+            lastValidBlockHeight: BigInt.zero,
+          ),
+          messageBytes: Uint8List.fromList([1, 2, 3]),
+          signatures: {addressA: null, addressB: null},
+        );
+        final signed = await partiallySignTransaction([keyPairB], transaction);
+        expect(signed.signatures[addressB], isNotNull);
+      },
+    );
+
+    test('returns a transaction with multiple signatures', () async {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List.fromList([1, 2, 3]),
+        signatures: {addressA: null, addressB: null, addressC: null},
+      );
+      final signed = await partiallySignTransaction([
+        keyPairA,
+        keyPairB,
+        keyPairC,
+      ], transaction);
+      expect(signed.signatures[addressA], isNotNull);
+      expect(signed.signatures[addressB], isNotNull);
+      expect(signed.signatures[addressC], isNotNull);
+    });
+
+    test('returns the same transaction if no signatures changed', () async {
+      final existingSig = signBytes(
+        keyPairA.privateKey,
+        Uint8List.fromList([1, 2, 3]),
+      );
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List.fromList([1, 2, 3]),
+        signatures: {addressA: existingSig},
+      );
+      final signed = await partiallySignTransaction([keyPairA], transaction);
+      expect(identical(signed, transaction), isTrue);
+    });
+
+    test('replaces an existing different signature', () async {
+      final differentSig = SignatureBytes(
+        Uint8List.fromList(List<int>.filled(64, 0xff)),
+      );
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List.fromList([1, 2, 3]),
+        signatures: {addressA: differentSig},
+      );
+      final signed = await partiallySignTransaction([keyPairA], transaction);
+      expect(signed.signatures[addressA], isNotNull);
+      // The signature should be different from the original different one.
+      expect(
+        signed.signatures[addressA]!.value,
+        isNot(equals(differentSig.value)),
+      );
+    });
+
+    test(
+      'throws if a keypair is for an address not in the signatures',
+      () async {
+        final transaction = TransactionWithLifetime(
+          lifetimeConstraint: TransactionBlockhashLifetime(
+            blockhash: '11111111111111111111111111111111',
+            lastValidBlockHeight: BigInt.zero,
+          ),
+          messageBytes: Uint8List.fromList([1, 2, 3]),
+          signatures: {addressA: null},
+        );
+        expect(
+          () => partiallySignTransaction([keyPairB], transaction),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.transactionAddressesCannotSignTransaction,
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'throws with multiple addresses if multiple keypairs are unexpected',
+      () async {
+        final transaction = TransactionWithLifetime(
+          lifetimeConstraint: TransactionBlockhashLifetime(
+            blockhash: '11111111111111111111111111111111',
+            lastValidBlockHeight: BigInt.zero,
+          ),
+          messageBytes: Uint8List.fromList([1, 2, 3]),
+          signatures: {addressA: null},
+        );
+        expect(
+          () => partiallySignTransaction([keyPairB, keyPairC], transaction),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.transactionAddressesCannotSignTransaction,
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('signTransaction', () {
+    late KeyPair keyPairA;
+    late KeyPair keyPairB;
+    late Address addressA;
+    late Address addressB;
+
+    setUp(() {
+      keyPairA = generateKeyPair();
+      keyPairB = generateKeyPair();
+      addressA = getAddressFromPublicKey(keyPairA.publicKey);
+      addressB = getAddressFromPublicKey(keyPairB.publicKey);
+    });
+
+    test('fatals when missing a signer', () async {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List.fromList([1, 2, 3]),
+        signatures: {addressA: null, addressB: null},
+      );
+      expect(
+        () => signTransaction([keyPairA], transaction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionSignaturesMissing,
+          ),
+        ),
+      );
+    });
+
+    test('returns a signed transaction with multiple signatures', () async {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List.fromList([1, 2, 3]),
+        signatures: {addressA: null, addressB: null},
+      );
+      final signed = await signTransaction([keyPairA, keyPairB], transaction);
+      expect(signed.signatures[addressA], isNotNull);
+      expect(signed.signatures[addressB], isNotNull);
+    });
+
+    test(
+      'returns a signed transaction with the compiled message bytes',
+      () async {
+        final messageBytes = Uint8List.fromList([1, 2, 3]);
+        final transaction = TransactionWithLifetime(
+          lifetimeConstraint: TransactionBlockhashLifetime(
+            blockhash: '11111111111111111111111111111111',
+            lastValidBlockHeight: BigInt.zero,
+          ),
+          messageBytes: messageBytes,
+          signatures: {addressA: null, addressB: null},
+        );
+        final signed = await signTransaction([keyPairA, keyPairB], transaction);
+        expect(signed.messageBytes, messageBytes);
+      },
+    );
+  });
+
+  group('isFullySignedTransaction', () {
+    test('returns false if the transaction has missing signatures', () {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: const {Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): null},
+      );
+      expect(isFullySignedTransaction(transaction), isFalse);
+    });
+
+    test('returns true if the transaction is signed by all its signers', () {
+      final sigA = SignatureBytes(Uint8List(64));
+      final sigB = SignatureBytes(Uint8List.fromList(List<int>.filled(64, 1)));
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: {
+          const Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): sigA,
+          const Address('BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'): sigB,
+        },
+      );
+      expect(isFullySignedTransaction(transaction), isTrue);
+    });
+
+    test('returns true if the transaction has no signatures', () {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: const {},
+      );
+      expect(isFullySignedTransaction(transaction), isTrue);
+    });
+  });
+
+  group('assertIsFullySignedTransaction', () {
+    test('throws if the transaction has no signature for the fee payer', () {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: const {Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): null},
+      );
+      expect(
+        () => assertIsFullySignedTransaction(transaction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionSignaturesMissing,
+          ),
+        ),
+      );
+    });
+
+    test('throws all missing signers if the transaction has no signature for '
+        'multiple signers', () {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: const {
+          Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): null,
+          Address('BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'): null,
+        },
+      );
+      expect(
+        () => assertIsFullySignedTransaction(transaction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionSignaturesMissing,
+          ),
+        ),
+      );
+    });
+
+    test('does not throw if the transaction is signed by its only signer', () {
+      final sigA = SignatureBytes(Uint8List(64));
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: {const Address('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'): sigA},
+      );
+      expect(
+        () => assertIsFullySignedTransaction(transaction),
+        returnsNormally,
+      );
+    });
+
+    test('does not throw if the transaction has no signatures', () {
+      final transaction = TransactionWithLifetime(
+        lifetimeConstraint: TransactionBlockhashLifetime(
+          blockhash: '11111111111111111111111111111111',
+          lastValidBlockHeight: BigInt.zero,
+        ),
+        messageBytes: Uint8List(0),
+        signatures: const {},
+      );
+      expect(
+        () => assertIsFullySignedTransaction(transaction),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/packages/solana_kit_transactions/test/transaction_size_test.dart
+++ b/packages/solana_kit_transactions/test/transaction_size_test.dart
@@ -1,0 +1,93 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final mockBlockhash = BlockhashLifetimeConstraint(
+    blockhash: '11111111111111111111111111111111',
+    lastValidBlockHeight: BigInt.zero,
+  );
+
+  TransactionMessage smallMessage() {
+    return const TransactionMessage(version: TransactionVersion.v0).copyWith(
+      feePayer: const Address('22222222222222222222222222222222222222222222'),
+      lifetimeConstraint: mockBlockhash,
+    );
+  }
+
+  TransactionMessage oversizedMessage() {
+    return smallMessage().copyWith(
+      instructions: [
+        Instruction(
+          data: Uint8List(transactionSizeLimit + 1),
+          programAddress: const Address(
+            '33333333333333333333333333333333333333333333',
+          ),
+        ),
+      ],
+    );
+  }
+
+  group('getTransactionSize', () {
+    test('gets the size of a transaction', () {
+      final transaction = compileTransaction(smallMessage());
+      final size = getTransactionSize(transaction);
+      // The size should be a reasonable small value.
+      expect(size, greaterThan(0));
+      expect(size, lessThan(transactionSizeLimit));
+    });
+
+    test('gets the size of an oversized transaction', () {
+      final transaction = compileTransaction(oversizedMessage());
+      final size = getTransactionSize(transaction);
+      expect(size, greaterThan(transactionSizeLimit));
+    });
+  });
+
+  group('isTransactionWithinSizeLimit', () {
+    test('returns true when the transaction size is under the limit', () {
+      final transaction = compileTransaction(smallMessage());
+      expect(isTransactionWithinSizeLimit(transaction), isTrue);
+    });
+
+    test('returns false when the transaction size is above the limit', () {
+      final transaction = compileTransaction(oversizedMessage());
+      expect(isTransactionWithinSizeLimit(transaction), isFalse);
+    });
+  });
+
+  group('assertIsTransactionWithinSizeLimit', () {
+    test('does not throw when the transaction size is under the limit', () {
+      final transaction = compileTransaction(smallMessage());
+      expect(
+        () => assertIsTransactionWithinSizeLimit(transaction),
+        returnsNormally,
+      );
+    });
+
+    test('throws when the transaction size is above the limit', () {
+      final transaction = compileTransaction(oversizedMessage());
+      expect(
+        () => assertIsTransactionWithinSizeLimit(transaction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionExceedsSizeLimit,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('transactionSizeLimit', () {
+    test('equals 1232 (1280 - 48)', () {
+      expect(transactionSizeLimit, 1232);
+    });
+  });
+}

--- a/packages/solana_kit_transactions/test/wire_transaction_test.dart
+++ b/packages/solana_kit_transactions/test/wire_transaction_test.dart
@@ -1,0 +1,66 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getBase64EncodedWireTransaction', () {
+    test('serializes a transaction to wire format', () {
+      final transaction = Transaction(
+        messageBytes: Uint8List.fromList([
+          128, 2, 1, 1, 3, 15, 30, 107, 20, 33, 192, 74, 7, 4, 49, 38, //
+          92, 25, 197, 187, 238, 25, 146, 186, 232, 175, 209, 205, 7, 142,
+          248, 175, 112, 71, 220, 17, 247, 45, 91, 65, 60, 101, 64, 222,
+          21, 12, 147, 115, 20, 77, 81, 51, 202, 76, 184, 48, 186, 15,
+          117, 103, 22, 172, 234, 14, 80, 215, 148, 53, 229, 60, 121, 172,
+          80, 135, 1, 40, 28, 16, 196, 153, 112, 103, 22, 239, 184, 102,
+          74, 235, 162, 191, 71, 52, 30, 59, 226, 189, 193, 31, 112, 71,
+          220, 30, 60, 214, 40, 67, 128, 148, 14, 8, 98, 76, 184, 51,
+          139, 119, 220, 51, 37, 117, 209, 95, 163, 154, 15, 29, 241, 94,
+          224, 143, 184, 35, 238, 1, 2, 1, 1, 0, 0,
+        ]),
+        signatures: {
+          const Address('22222222222222222222222222222222222222222222'): null,
+          const Address(
+            '44444444444444444444444444444444444444444444',
+          ): SignatureBytes(
+            Uint8List.fromList([
+              0x65, 0xc9, 0xfa, 0x89, 0xe6, 0xab, 0xdb, 0x8b, //
+              0x62, 0x79, 0xaf, 0x58, 0x43, 0x82, 0x48, 0xa6,
+              0x7f, 0xbc, 0x40, 0xb2, 0x37, 0x06, 0x76, 0xe0,
+              0xed, 0xa6, 0xef, 0x73, 0x7d, 0x39, 0xfc, 0x30,
+              0x6c, 0x80, 0x80, 0xc0, 0x66, 0x2d, 0x32, 0x7a,
+              0x56, 0xb5, 0xb9, 0xd3, 0xc1, 0x20, 0xd7, 0x15,
+              0xa4, 0x34, 0x3f, 0x93, 0x8a, 0x23, 0xee, 0x08,
+              0xfb, 0x82, 0x3e, 0xe0, 0x8f, 0xb8, 0x23, 0xee,
+            ]),
+          ),
+        },
+      );
+
+      final encoded = getBase64EncodedWireTransaction(transaction);
+      expect(encoded, isA<String>());
+      expect(encoded.isNotEmpty, isTrue);
+      // The encoded string should be a valid base64 string.
+      expect(RegExp(r'^[A-Za-z0-9+/]+=*$').hasMatch(encoded), isTrue);
+    });
+
+    test('produces a deterministic result', () {
+      final sigBytes = SignatureBytes(
+        Uint8List.fromList(List<int>.filled(64, 42)),
+      );
+      final transaction = Transaction(
+        messageBytes: Uint8List.fromList([1, 2, 3, 4]),
+        signatures: {
+          const Address('11111111111111111111111111111111'): sigBytes,
+        },
+      );
+
+      final encoded1 = getBase64EncodedWireTransaction(transaction);
+      final encoded2 = getBase64EncodedWireTransaction(transaction);
+      expect(encoded1, encoded2);
+    });
+  });
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -104,39 +104,39 @@
 
 ### solana_kit_addresses (~7 source files, ~6 test files)
 
-- [ ] T028 [US1] Port Address extension type, base58 codec, validation from `.repos/kit/packages/addresses/src/` to `packages/solana_kit_addresses/lib/src/`
-- [ ] T029 [US1] Port PDA computation (getProgramDerivedAddress, findProgramDerivedAddress, createAddressWithSeed) in `packages/solana_kit_addresses/lib/src/`
-- [ ] T030 [US1] Port isOnCurve validation in `packages/solana_kit_addresses/lib/src/`
-- [ ] T031 [US1] Update barrel export `packages/solana_kit_addresses/lib/solana_kit_addresses.dart`
-- [ ] T032 [US1] Port all 6 test files from `.repos/kit/packages/addresses/src/__tests__/` to `packages/solana_kit_addresses/test/`
+- [x] T028 [US1] Port Address extension type, base58 codec, validation from `.repos/kit/packages/addresses/src/` to `packages/solana_kit_addresses/lib/src/`
+- [x] T029 [US1] Port PDA computation (getProgramDerivedAddress, findProgramDerivedAddress, createAddressWithSeed) in `packages/solana_kit_addresses/lib/src/`
+- [x] T030 [US1] Port isOnCurve validation in `packages/solana_kit_addresses/lib/src/`
+- [x] T031 [US1] Update barrel export `packages/solana_kit_addresses/lib/solana_kit_addresses.dart`
+- [x] T032 [US1] Port all 6 test files from `.repos/kit/packages/addresses/src/__tests__/` to `packages/solana_kit_addresses/test/`
 
 ### solana_kit_keys (~10 source files, ~10 test files)
 
-- [ ] T033 [US1] Port Ed25519 key generation, signing, verification from `.repos/kit/packages/keys/src/` to `packages/solana_kit_keys/lib/src/` using `cryptography` package
-- [ ] T034 [US1] Port Signature extension type and signature codec in `packages/solana_kit_keys/lib/src/`
-- [ ] T035 [US1] Update barrel export `packages/solana_kit_keys/lib/solana_kit_keys.dart`
-- [ ] T036 [US1] Port all 10 test files from `.repos/kit/packages/keys/src/__tests__/` to `packages/solana_kit_keys/test/`
+- [x] T033 [US1] Port Ed25519 key generation, signing, verification from `.repos/kit/packages/keys/src/` to `packages/solana_kit_keys/lib/src/` using `cryptography` package
+- [x] T034 [US1] Port Signature extension type and signature codec in `packages/solana_kit_keys/lib/src/`
+- [x] T035 [US1] Update barrel export `packages/solana_kit_keys/lib/solana_kit_keys.dart`
+- [x] T036 [US1] Port all 10 test files from `.repos/kit/packages/keys/src/__tests__/` to `packages/solana_kit_keys/test/`
 
 ### solana_kit_instructions (~4 source files, ~2 test files)
 
-- [ ] T037 [P] [US1] Port IInstruction, IAccountMeta, AccountRole from `.repos/kit/packages/instructions/src/` to `packages/solana_kit_instructions/lib/src/`
-- [ ] T038 [US1] Update barrel export `packages/solana_kit_instructions/lib/solana_kit_instructions.dart`
-- [ ] T039 [US1] Port all 2 test files from `.repos/kit/packages/instructions/src/__tests__/` to `packages/solana_kit_instructions/test/`
+- [x] T037 [P] [US1] Port IInstruction, IAccountMeta, AccountRole from `.repos/kit/packages/instructions/src/` to `packages/solana_kit_instructions/lib/src/`
+- [x] T038 [US1] Update barrel export `packages/solana_kit_instructions/lib/solana_kit_instructions.dart`
+- [x] T039 [US1] Port all 2 test files from `.repos/kit/packages/instructions/src/__tests__/` to `packages/solana_kit_instructions/test/`
 
 ### solana_kit_programs (~2 source files, ~2 test files)
 
-- [ ] T040 [P] [US1] Port isProgramError, getProgramErrorMessage from `.repos/kit/packages/programs/src/` to `packages/solana_kit_programs/lib/src/`
-- [ ] T041 [US1] Update barrel export `packages/solana_kit_programs/lib/solana_kit_programs.dart`
-- [ ] T042 [US1] Port all 2 test files from `.repos/kit/packages/programs/src/__tests__/` to `packages/solana_kit_programs/test/`
+- [x] T040 [P] [US1] Port isProgramError, getProgramErrorMessage from `.repos/kit/packages/programs/src/` to `packages/solana_kit_programs/lib/src/`
+- [x] T041 [US1] Update barrel export `packages/solana_kit_programs/lib/solana_kit_programs.dart`
+- [x] T042 [US1] Port all 2 test files from `.repos/kit/packages/programs/src/__tests__/` to `packages/solana_kit_programs/test/`
 
 ### solana_kit_transaction_messages (~38 source files, ~22 test files)
 
-- [ ] T043 [US1] Port TransactionMessage type and creation from `.repos/kit/packages/transaction-messages/src/` to `packages/solana_kit_transaction_messages/lib/src/`
-- [ ] T044 [US1] Port fee payer, blockhash lifetime, durable nonce lifetime setters in `packages/solana_kit_transaction_messages/lib/src/`
-- [ ] T045 [US1] Port instruction append/prepend, address lookup table support in `packages/solana_kit_transaction_messages/lib/src/`
-- [ ] T046 [US1] Port message compilation and decompilation in `packages/solana_kit_transaction_messages/lib/src/`
-- [ ] T047 [US1] Update barrel export `packages/solana_kit_transaction_messages/lib/solana_kit_transaction_messages.dart`
-- [ ] T048 [US1] Port all 22 test files from `.repos/kit/packages/transaction-messages/src/__tests__/` to `packages/solana_kit_transaction_messages/test/`
+- [x] T043 [US1] Port TransactionMessage type and creation from `.repos/kit/packages/transaction-messages/src/` to `packages/solana_kit_transaction_messages/lib/src/`
+- [x] T044 [US1] Port fee payer, blockhash lifetime, durable nonce lifetime setters in `packages/solana_kit_transaction_messages/lib/src/`
+- [x] T045 [US1] Port instruction append/prepend, address lookup table support in `packages/solana_kit_transaction_messages/lib/src/`
+- [x] T046 [US1] Port message compilation and decompilation in `packages/solana_kit_transaction_messages/lib/src/`
+- [x] T047 [US1] Update barrel export `packages/solana_kit_transaction_messages/lib/solana_kit_transaction_messages.dart`
+- [x] T048 [US1] Port all 22 test files from `.repos/kit/packages/transaction-messages/src/__tests__/` to `packages/solana_kit_transaction_messages/test/`
 
 ### solana_kit_transactions (~15 source files, ~17 test files)
 


### PR DESCRIPTION
## Summary

- Port `@solana/transactions` to Dart as `solana_kit_transactions` with 64 tests
- Implement `Transaction` class with `messageBytes` and `signatures` map, plus `TransactionWithLifetime` for blockhash/nonce constraints
- `compileTransaction` compiles TransactionMessage into Transaction with signature slots and lifetime detection
- Async signing with `partiallySignTransaction` and `signTransaction` using Ed25519 key pairs
- Full wire format codec: signatures encoder (shortU16 prefix + 64 bytes each), transaction encoder/decoder
- Size validation with 1232-byte limit and `isSendableTransaction` combining signature + size checks

## Test plan

- [x] 64 tests passing in `solana_kit_transactions`
- [x] `dart analyze` clean with no issues
- [x] `dart format --set-exit-if-changed` passes