### PR TITLE
✨ feat: implement signers package

### DIFF
--- a/.changeset/signers.md
+++ b/.changeset/signers.md
@@ -1,0 +1,16 @@
+---
+solana_kit_signers: minor
+---
+
+Implement signers package ported from `@solana/signers`.
+
+**solana_kit_signers** (88 tests):
+
+- Five core signer interfaces: `MessagePartialSigner`, `MessageModifyingSigner`, `TransactionPartialSigner`, `TransactionModifyingSigner`, `TransactionSendingSigner`
+- Composite types: `MessageSigner`, `TransactionSigner`, `KeyPairSigner` with Ed25519 signing
+- `NoopSigner` for adding signature slots without actual signing
+- `partiallySignTransactionMessageWithSigners` and `signTransactionMessageWithSigners` for signing transaction messages using attached signers
+- `signAndSendTransactionMessageWithSigners` for combined sign-and-send workflow
+- Signer extraction from instructions and transaction messages via account meta
+- Fee payer signer utilities
+- Signer deduplication and assertion helpers

--- a/packages/solana_kit_signers/lib/solana_kit_signers.dart
+++ b/packages/solana_kit_signers/lib/solana_kit_signers.dart
@@ -1,1 +1,17 @@
-
+export 'src/account_signer_meta.dart';
+export 'src/add_signers.dart';
+export 'src/deduplicate_signers.dart';
+export 'src/fee_payer_signer.dart';
+export 'src/keypair_signer.dart';
+export 'src/message_modifying_signer.dart';
+export 'src/message_partial_signer.dart';
+export 'src/message_signer.dart';
+export 'src/noop_signer.dart';
+export 'src/sign_transaction.dart';
+export 'src/signable_message.dart';
+export 'src/transaction_modifying_signer.dart';
+export 'src/transaction_partial_signer.dart';
+export 'src/transaction_sending_signer.dart';
+export 'src/transaction_signer.dart';
+export 'src/transaction_with_single_sending_signer.dart';
+export 'src/types.dart';

--- a/packages/solana_kit_signers/lib/src/account_signer_meta.dart
+++ b/packages/solana_kit_signers/lib/src/account_signer_meta.dart
@@ -1,0 +1,68 @@
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_signers/src/deduplicate_signers.dart';
+import 'package:solana_kit_signers/src/fee_payer_signer.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+/// An extension of the [AccountMeta] type that allows us to store
+/// transaction signers inside it.
+///
+/// Note that, because this type represents a signer, it must use one of
+/// the following two roles:
+/// - [AccountRole.readonlySigner]
+/// - [AccountRole.writableSigner]
+class AccountSignerMeta extends AccountMeta {
+  /// Creates an [AccountSignerMeta] with the given properties.
+  const AccountSignerMeta({
+    required super.address,
+    required super.role,
+    required this.signer,
+  });
+
+  /// The transaction signer associated with this account meta.
+  final Object signer;
+}
+
+/// Extracts and deduplicates all transaction signers stored inside the
+/// account metas of an instruction.
+///
+/// Any extracted signers that share the same address will be
+/// de-duplicated.
+List<Object> getSignersFromInstruction(Instruction instruction) {
+  final accounts = instruction.accounts;
+  if (accounts == null) return [];
+
+  final signers = <Object>[];
+  for (final account in accounts) {
+    if (account is AccountSignerMeta) {
+      signers.add(account.signer);
+    }
+  }
+
+  return deduplicateSigners(signers);
+}
+
+/// Extracts and deduplicates all transaction signers stored inside a given
+/// transaction message.
+///
+/// This includes any signers stored as the fee payer or in the instructions
+/// of the transaction message.
+///
+/// Any extracted signers that share the same address will be
+/// de-duplicated.
+List<Object> getSignersFromTransactionMessage(
+  TransactionMessage transactionMessage,
+) {
+  final signers = <Object>[];
+
+  // Check if the fee payer is a signer.
+  if (transactionMessage is TransactionMessageWithFeePayerSigner) {
+    signers.add(transactionMessage.feePayerSigner);
+  }
+
+  // Extract signers from all instructions.
+  for (final instruction in transactionMessage.instructions) {
+    signers.addAll(getSignersFromInstruction(instruction));
+  }
+
+  return deduplicateSigners(signers);
+}

--- a/packages/solana_kit_signers/lib/src/add_signers.dart
+++ b/packages/solana_kit_signers/lib/src/add_signers.dart
@@ -1,0 +1,104 @@
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_signers/src/account_signer_meta.dart';
+import 'package:solana_kit_signers/src/deduplicate_signers.dart';
+import 'package:solana_kit_signers/src/fee_payer_signer.dart';
+import 'package:solana_kit_signers/src/transaction_signer.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+/// Attaches the provided transaction signers to the account metas of an
+/// instruction when applicable.
+///
+/// For an account meta to match a provided signer it:
+/// - Must have a signer role ([AccountRole.readonlySigner] or
+///   [AccountRole.writableSigner]).
+/// - Must have the same address as the provided signer.
+/// - Must not have an attached signer already.
+Instruction addSignersToInstruction(
+  List<Object> signers,
+  Instruction instruction,
+) {
+  if (instruction.accounts == null || instruction.accounts!.isEmpty) {
+    return instruction;
+  }
+
+  final deduplicatedSigners = deduplicateSigners(signers);
+  final signerByAddress = {
+    for (final signer in deduplicatedSigners)
+      getTransactionSignerAddress(signer): signer,
+  };
+
+  final updatedAccounts = instruction.accounts!.map((account) {
+    final signer = signerByAddress[account.address];
+    if (!isSignerRole(account.role) ||
+        account is AccountSignerMeta ||
+        signer == null) {
+      return account;
+    }
+    return AccountSignerMeta(
+      address: account.address,
+      role: account.role,
+      signer: signer,
+    );
+  }).toList();
+
+  return Instruction(
+    programAddress: instruction.programAddress,
+    accounts: updatedAccounts,
+    data: instruction.data,
+  );
+}
+
+/// Attaches the provided transaction signers to the account metas of all
+/// instructions inside a transaction message and/or the transaction
+/// message fee payer, when applicable.
+///
+/// For an account meta to match a provided signer it:
+/// - Must have a signer role ([AccountRole.readonlySigner] or
+///   [AccountRole.writableSigner]).
+/// - Must have the same address as the provided signer.
+/// - Must not have an attached signer already.
+TransactionMessage addSignersToTransactionMessage(
+  List<Object> signers,
+  TransactionMessage transactionMessage,
+) {
+  // Check if the fee payer is an address-only fee payer (not a signer).
+  Object? feePayerSigner;
+  if (transactionMessage is! TransactionMessageWithFeePayerSigner &&
+      transactionMessage.feePayer != null) {
+    // Find a signer that matches the fee payer address.
+    for (final signer in signers) {
+      if (getTransactionSignerAddress(signer) == transactionMessage.feePayer) {
+        feePayerSigner = signer;
+        break;
+      }
+    }
+  }
+
+  if (feePayerSigner == null && transactionMessage.instructions.isEmpty) {
+    return transactionMessage;
+  }
+
+  final updatedInstructions = transactionMessage.instructions
+      .map((instruction) => addSignersToInstruction(signers, instruction))
+      .toList();
+
+  if (feePayerSigner != null) {
+    return TransactionMessageWithFeePayerSigner(
+      feePayerSigner: feePayerSigner,
+      version: transactionMessage.version,
+      instructions: updatedInstructions,
+      lifetimeConstraint: transactionMessage.lifetimeConstraint,
+    );
+  }
+
+  if (transactionMessage is TransactionMessageWithFeePayerSigner) {
+    return TransactionMessageWithFeePayerSigner(
+      feePayerSigner: transactionMessage.feePayerSigner,
+      version: transactionMessage.version,
+      instructions: updatedInstructions,
+      lifetimeConstraint: transactionMessage.lifetimeConstraint,
+    );
+  }
+
+  return transactionMessage.copyWith(instructions: updatedInstructions);
+}

--- a/packages/solana_kit_signers/lib/src/deduplicate_signers.dart
+++ b/packages/solana_kit_signers/lib/src/deduplicate_signers.dart
@@ -1,0 +1,42 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/src/message_modifying_signer.dart';
+import 'package:solana_kit_signers/src/message_partial_signer.dart';
+import 'package:solana_kit_signers/src/transaction_modifying_signer.dart';
+import 'package:solana_kit_signers/src/transaction_partial_signer.dart';
+import 'package:solana_kit_signers/src/transaction_sending_signer.dart';
+
+/// Gets the address from any signer type.
+Address getSignerAddress(Object signer) {
+  if (signer is TransactionPartialSigner) return signer.address;
+  if (signer is TransactionModifyingSigner) return signer.address;
+  if (signer is TransactionSendingSigner) return signer.address;
+  if (signer is MessagePartialSigner) return signer.address;
+  if (signer is MessageModifyingSigner) return signer.address;
+  throw ArgumentError('Value is not a signer: $signer');
+}
+
+/// Removes all duplicated signers from a provided list by comparing
+/// their addresses.
+///
+/// If two distinct signer objects share the same address, a [SolanaError]
+/// with code [SolanaErrorCode.signerAddressCannotHaveMultipleSigners] is
+/// thrown.
+List<T> deduplicateSigners<T extends Object>(List<T> signers) {
+  final deduplicated = <Address, T>{};
+
+  for (final signer in signers) {
+    final addr = getSignerAddress(signer);
+    final existing = deduplicated[addr];
+    if (existing == null) {
+      deduplicated[addr] = signer;
+    } else if (!identical(existing, signer)) {
+      throw SolanaError(
+        SolanaErrorCode.signerAddressCannotHaveMultipleSigners,
+        {'address': addr.value},
+      );
+    }
+  }
+
+  return deduplicated.values.toList();
+}

--- a/packages/solana_kit_signers/lib/src/fee_payer_signer.dart
+++ b/packages/solana_kit_signers/lib/src/fee_payer_signer.dart
@@ -1,0 +1,73 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_signers/src/transaction_signer.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+/// A [TransactionMessage] that uses a transaction signer as the fee payer.
+///
+/// This is an alternative to setting the fee payer as just an address.
+/// It stores the signer object alongside the transaction message so that
+/// the signer can be extracted later when signing the transaction.
+class TransactionMessageWithFeePayerSigner extends TransactionMessage {
+  /// Creates a [TransactionMessageWithFeePayerSigner].
+  TransactionMessageWithFeePayerSigner({
+    required this.feePayerSigner,
+    required super.version,
+    super.instructions,
+    super.lifetimeConstraint,
+  }) : super(feePayer: getTransactionSignerAddress(feePayerSigner));
+
+  /// The transaction signer to use as the fee payer.
+  final Object feePayerSigner;
+
+  @override
+  TransactionMessage copyWith({
+    TransactionVersion? version,
+    List<Instruction>? instructions,
+    Address? feePayer,
+    bool clearFeePayer = false,
+    LifetimeConstraint? lifetimeConstraint,
+    bool clearLifetimeConstraint = false,
+  }) {
+    // If clearing the fee payer, fall back to the base TransactionMessage.
+    if (clearFeePayer) {
+      return TransactionMessage(
+        version: version ?? this.version,
+        instructions: instructions ?? this.instructions,
+        lifetimeConstraint: clearLifetimeConstraint
+            ? null
+            : (lifetimeConstraint ?? this.lifetimeConstraint),
+      );
+    }
+
+    return TransactionMessageWithFeePayerSigner(
+      feePayerSigner: feePayerSigner,
+      version: version ?? this.version,
+      instructions: instructions ?? this.instructions,
+      lifetimeConstraint: clearLifetimeConstraint
+          ? null
+          : (lifetimeConstraint ?? this.lifetimeConstraint),
+    );
+  }
+}
+
+/// Sets the fee payer of a transaction message using a transaction signer.
+///
+/// ```dart
+/// final feePayer = await generateKeyPairSigner();
+/// final transactionMessage = setTransactionMessageFeePayerSigner(
+///   feePayer,
+///   createTransactionMessage(version: TransactionVersion.v0),
+/// );
+/// ```
+TransactionMessageWithFeePayerSigner setTransactionMessageFeePayerSigner(
+  Object feePayer,
+  TransactionMessage transactionMessage,
+) {
+  return TransactionMessageWithFeePayerSigner(
+    feePayerSigner: feePayer,
+    version: transactionMessage.version,
+    instructions: transactionMessage.instructions,
+    lifetimeConstraint: transactionMessage.lifetimeConstraint,
+  );
+}

--- a/packages/solana_kit_signers/lib/src/keypair_signer.dart
+++ b/packages/solana_kit_signers/lib/src/keypair_signer.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/src/message_partial_signer.dart';
+import 'package:solana_kit_signers/src/signable_message.dart';
+import 'package:solana_kit_signers/src/transaction_partial_signer.dart';
+import 'package:solana_kit_signers/src/types.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// Defines a signer that uses a [KeyPair] to sign messages and
+/// transactions.
+///
+/// It implements both the [MessagePartialSigner] and
+/// [TransactionPartialSigner] interfaces and keeps track of the [KeyPair]
+/// instance used to sign messages and transactions.
+class KeyPairSigner implements MessagePartialSigner, TransactionPartialSigner {
+  /// Creates a [KeyPairSigner] with the given [address] and [keyPair].
+  const KeyPairSigner({required this.address, required this.keyPair});
+
+  @override
+  final Address address;
+
+  /// The key pair used for signing.
+  final KeyPair keyPair;
+
+  @override
+  Future<List<Map<Address, SignatureBytes>>> signMessages(
+    List<SignableMessage> messages, [
+    SignerConfig? config,
+  ]) async {
+    return messages.map((message) {
+      final sig = signBytes(keyPair.privateKey, message.content);
+      return Map<Address, SignatureBytes>.unmodifiable({address: sig});
+    }).toList();
+  }
+
+  @override
+  Future<List<Map<Address, SignatureBytes>>> signTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    final results = <Map<Address, SignatureBytes>>[];
+    for (final transaction in transactions) {
+      final signedTransaction = await partiallySignTransaction([
+        keyPair,
+      ], transaction);
+      final sig = signedTransaction.signatures[address];
+      results.add(
+        Map<Address, SignatureBytes>.unmodifiable(
+          sig != null ? {address: sig} : <Address, SignatureBytes>{},
+        ),
+      );
+    }
+    return results;
+  }
+}
+
+/// Creates a [KeyPairSigner] from a provided [KeyPair].
+///
+/// ```dart
+/// final keyPair = generateKeyPair();
+/// final signer = createSignerFromKeyPair(keyPair);
+/// ```
+KeyPairSigner createSignerFromKeyPair(KeyPair keyPair) {
+  final addr = getAddressFromPublicKey(keyPair.publicKey);
+  return KeyPairSigner(address: addr, keyPair: keyPair);
+}
+
+/// Generates a signer capable of signing messages and transactions by
+/// generating a [KeyPair] and creating a [KeyPairSigner] from it.
+///
+/// ```dart
+/// final signer = generateKeyPairSigner();
+/// ```
+KeyPairSigner generateKeyPairSigner() {
+  return createSignerFromKeyPair(generateKeyPair());
+}
+
+/// Creates a new [KeyPairSigner] from a 64-bytes [Uint8List] secret key
+/// (private key and public key).
+///
+/// ```dart
+/// final signer = createKeyPairSignerFromBytes(keypairBytes);
+/// ```
+KeyPairSigner createKeyPairSignerFromBytes(Uint8List bytes) {
+  return createSignerFromKeyPair(createKeyPairFromBytes(bytes));
+}
+
+/// Creates a new [KeyPairSigner] from a 32-bytes [Uint8List] private key.
+///
+/// ```dart
+/// final signer = createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes);
+/// ```
+KeyPairSigner createKeyPairSignerFromPrivateKeyBytes(Uint8List bytes) {
+  return createSignerFromKeyPair(createKeyPairFromPrivateKeyBytes(bytes));
+}
+
+/// Checks whether the provided value implements the [KeyPairSigner]
+/// interface.
+bool isKeyPairSigner(Object? value) {
+  return value is KeyPairSigner;
+}
+
+/// Asserts that the provided value implements the [KeyPairSigner]
+/// interface.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerExpectedKeyPairSigner] if the check fails.
+void assertIsKeyPairSigner(Object? value) {
+  if (!isKeyPairSigner(value)) {
+    throw SolanaError(SolanaErrorCode.signerExpectedKeyPairSigner);
+  }
+}

--- a/packages/solana_kit_signers/lib/src/message_modifying_signer.dart
+++ b/packages/solana_kit_signers/lib/src/message_modifying_signer.dart
@@ -1,0 +1,54 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/src/signable_message.dart';
+import 'package:solana_kit_signers/src/types.dart';
+
+/// A signer interface that _potentially_ modifies the content of the
+/// provided [SignableMessage]s before signing them.
+///
+/// For instance, this enables wallets to prefix or suffix nonces to the
+/// messages they sign. For each message, instead of returning a signature
+/// dictionary, the [modifyAndSignMessages] function returns an updated
+/// [SignableMessage] with a potentially modified content and signature
+/// dictionary.
+///
+/// Characteristics:
+/// - **Sequential**. Contrary to partial signers, these cannot be executed
+///   in parallel as each call can modify the content of the message.
+/// - **First signers**. For a given message, a modifying signer must always
+///   be used before a partial signer.
+/// - **Potential conflicts**. If more than one modifying signer is provided,
+///   the second signer may invalidate the signature of the first one.
+// ignore: one_member_abstracts
+abstract class MessageModifyingSigner {
+  /// The base58-encoded address of this signer.
+  Address get address;
+
+  /// Potentially modifies the provided [messages] before signing them and
+  /// returns the updated [SignableMessage]s.
+  Future<List<SignableMessage>> modifyAndSignMessages(
+    List<SignableMessage> messages, [
+    SignerConfig? config,
+  ]);
+}
+
+/// Checks whether the provided value implements the
+/// [MessageModifyingSigner] interface.
+bool isMessageModifyingSigner(Object? value) {
+  return value is MessageModifyingSigner;
+}
+
+/// Asserts that the provided value implements the
+/// [MessageModifyingSigner] interface.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerExpectedMessageModifyingSigner] if the check
+/// fails.
+void assertIsMessageModifyingSigner(Object? value) {
+  if (!isMessageModifyingSigner(value)) {
+    final addr = value is MessageModifyingSigner ? value.address.value : '';
+    throw SolanaError(SolanaErrorCode.signerExpectedMessageModifyingSigner, {
+      'address': addr,
+    });
+  }
+}

--- a/packages/solana_kit_signers/lib/src/message_partial_signer.dart
+++ b/packages/solana_kit_signers/lib/src/message_partial_signer.dart
@@ -1,0 +1,50 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/src/signable_message.dart';
+import 'package:solana_kit_signers/src/types.dart';
+
+/// A signer interface that signs an array of [SignableMessage]s without
+/// modifying their content.
+///
+/// It defines a [signMessages] function that returns a signature dictionary
+/// for each provided message. Such signature dictionaries are expected to
+/// be merged with the existing ones if any.
+///
+/// Characteristics:
+/// - **Parallel**. When multiple signers sign the same message, we can
+///   perform this operation in parallel to obtain all their signatures.
+/// - **Flexible order**. The order in which we use these signers for a
+///   given message doesn't matter.
+// ignore: one_member_abstracts
+abstract class MessagePartialSigner {
+  /// The base58-encoded address of this signer.
+  Address get address;
+
+  /// Signs the provided [messages] and returns a signature dictionary
+  /// for each message.
+  Future<List<Map<Address, SignatureBytes>>> signMessages(
+    List<SignableMessage> messages, [
+    SignerConfig? config,
+  ]);
+}
+
+/// Checks whether the provided value implements the [MessagePartialSigner]
+/// interface.
+bool isMessagePartialSigner(Object? value) {
+  return value is MessagePartialSigner;
+}
+
+/// Asserts that the provided value implements the [MessagePartialSigner]
+/// interface.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerExpectedMessagePartialSigner] if the check fails.
+void assertIsMessagePartialSigner(Object? value) {
+  if (!isMessagePartialSigner(value)) {
+    final addr = value is MessagePartialSigner ? value.address.value : '';
+    throw SolanaError(SolanaErrorCode.signerExpectedMessagePartialSigner, {
+      'address': addr,
+    });
+  }
+}

--- a/packages/solana_kit_signers/lib/src/message_signer.dart
+++ b/packages/solana_kit_signers/lib/src/message_signer.dart
@@ -1,0 +1,21 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+import 'package:solana_kit_signers/src/message_modifying_signer.dart';
+import 'package:solana_kit_signers/src/message_partial_signer.dart';
+
+/// Checks whether the provided value implements either the
+/// [MessagePartialSigner] or [MessageModifyingSigner] interface.
+bool isMessageSigner(Object? value) {
+  return isMessagePartialSigner(value) || isMessageModifyingSigner(value);
+}
+
+/// Asserts that the provided value implements either the
+/// [MessagePartialSigner] or [MessageModifyingSigner] interface.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerExpectedMessageSigner] if the check fails.
+void assertIsMessageSigner(Object? value) {
+  if (!isMessageSigner(value)) {
+    throw SolanaError(SolanaErrorCode.signerExpectedMessageSigner);
+  }
+}

--- a/packages/solana_kit_signers/lib/src/noop_signer.dart
+++ b/packages/solana_kit_signers/lib/src/noop_signer.dart
@@ -1,0 +1,52 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/src/message_partial_signer.dart';
+import 'package:solana_kit_signers/src/signable_message.dart';
+import 'package:solana_kit_signers/src/transaction_partial_signer.dart';
+import 'package:solana_kit_signers/src/types.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// Defines a Noop (No-Operation) signer that pretends to partially sign
+/// messages and transactions.
+///
+/// For a given [Address], a Noop Signer can be created to offer an
+/// implementation of both the [MessagePartialSigner] and
+/// [TransactionPartialSigner] interfaces such that they do not sign
+/// anything. Namely, signing a transaction or a message with a
+/// [NoopSigner] will return an empty signature dictionary.
+class NoopSigner implements MessagePartialSigner, TransactionPartialSigner {
+  /// Creates a [NoopSigner] with the given [address].
+  const NoopSigner({required this.address});
+
+  @override
+  final Address address;
+
+  @override
+  Future<List<Map<Address, SignatureBytes>>> signMessages(
+    List<SignableMessage> messages, [
+    SignerConfig? config,
+  ]) async {
+    return messages
+        .map((_) => Map<Address, SignatureBytes>.unmodifiable({}))
+        .toList();
+  }
+
+  @override
+  Future<List<Map<Address, SignatureBytes>>> signTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    return transactions
+        .map((_) => Map<Address, SignatureBytes>.unmodifiable({}))
+        .toList();
+  }
+}
+
+/// Creates a [NoopSigner] from the provided [Address].
+///
+/// ```dart
+/// final signer = createNoopSigner(address('1234..5678'));
+/// ```
+NoopSigner createNoopSigner(Address addr) {
+  return NoopSigner(address: addr);
+}

--- a/packages/solana_kit_signers/lib/src/sign_transaction.dart
+++ b/packages/solana_kit_signers/lib/src/sign_transaction.dart
@@ -1,0 +1,263 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/src/account_signer_meta.dart';
+import 'package:solana_kit_signers/src/deduplicate_signers.dart';
+import 'package:solana_kit_signers/src/transaction_modifying_signer.dart';
+import 'package:solana_kit_signers/src/transaction_partial_signer.dart';
+import 'package:solana_kit_signers/src/transaction_sending_signer.dart';
+import 'package:solana_kit_signers/src/transaction_signer.dart';
+import 'package:solana_kit_signers/src/transaction_with_single_sending_signer.dart';
+import 'package:solana_kit_signers/src/types.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// Extracts all transaction signers inside the provided transaction message
+/// and uses them to return a signed transaction.
+///
+/// It first uses all [TransactionModifyingSigner]s sequentially before
+/// using all [TransactionPartialSigner]s in parallel.
+///
+/// If a composite signer implements both interfaces, it will be used as a
+/// [TransactionModifyingSigner] if no other signer implements that
+/// interface. Otherwise, it will be used as a [TransactionPartialSigner].
+///
+/// This function ignores [TransactionSendingSigner]s as it does not send
+/// the transaction.
+Future<Transaction> partiallySignTransactionMessageWithSigners(
+  TransactionMessage transactionMessage, [
+  TransactionSignerConfig? config,
+]) async {
+  final allSigners = deduplicateSigners(
+    getSignersFromTransactionMessage(
+      transactionMessage,
+    ).where(isTransactionSigner).toList(),
+  );
+
+  final categorized = _categorizeTransactionSigners(
+    allSigners,
+    identifySendingSigner: false,
+  );
+
+  return _signModifyingAndPartialTransactionSigners(
+    transactionMessage,
+    categorized.modifyingSigners,
+    categorized.partialSigners,
+    config,
+  );
+}
+
+/// Extracts all transaction signers inside the provided transaction message
+/// and uses them to return a signed transaction before asserting that all
+/// signatures required by the transaction are present.
+Future<Transaction> signTransactionMessageWithSigners(
+  TransactionMessage transactionMessage, [
+  TransactionSignerConfig? config,
+]) async {
+  final signedTransaction = await partiallySignTransactionMessageWithSigners(
+    transactionMessage,
+    config,
+  );
+  assertIsFullySignedTransaction(signedTransaction);
+  return signedTransaction;
+}
+
+/// Extracts all transaction signers inside the provided transaction message
+/// and uses them to sign it before sending it immediately to the
+/// blockchain.
+///
+/// It returns the signature of the sent transaction (i.e. its identifier)
+/// as bytes.
+Future<SignatureBytes> signAndSendTransactionMessageWithSigners(
+  TransactionMessage transactionMessage, [
+  TransactionSignerConfig? config,
+]) async {
+  assertIsTransactionMessageWithSingleSendingSigner(transactionMessage);
+
+  final allSigners = deduplicateSigners(
+    getSignersFromTransactionMessage(
+      transactionMessage,
+    ).where(isTransactionSigner).toList(),
+  );
+
+  final categorized = _categorizeTransactionSigners(allSigners);
+
+  if (config != null && config.aborted) {
+    throw StateError('The operation was aborted');
+  }
+
+  final signedTransaction = await _signModifyingAndPartialTransactionSigners(
+    transactionMessage,
+    categorized.modifyingSigners,
+    categorized.partialSigners,
+    config,
+  );
+
+  if (categorized.sendingSigner == null) {
+    throw SolanaError(SolanaErrorCode.signerTransactionSendingSignerMissing);
+  }
+
+  if (config != null && config.aborted) {
+    throw StateError('The operation was aborted');
+  }
+
+  final signatures = await categorized.sendingSigner!.signAndSendTransactions([
+    signedTransaction,
+  ], config);
+
+  if (config != null && config.aborted) {
+    throw StateError('The operation was aborted');
+  }
+
+  return signatures[0];
+}
+
+/// Result of categorizing transaction signers.
+class _CategorizedSigners {
+  const _CategorizedSigners({
+    required this.modifyingSigners,
+    required this.partialSigners,
+    this.sendingSigner,
+  });
+
+  final List<TransactionModifyingSigner> modifyingSigners;
+  final List<TransactionPartialSigner> partialSigners;
+  final TransactionSendingSigner? sendingSigner;
+}
+
+/// Identifies each provided TransactionSigner and categorizes them into
+/// their respective types.
+_CategorizedSigners _categorizeTransactionSigners(
+  List<Object> signers, {
+  bool identifySendingSigner = true,
+}) {
+  // Identify the unique sending signer that should be used.
+  final sendingSigner = identifySendingSigner
+      ? _identifyTransactionSendingSigner(signers)
+      : null;
+
+  // Now, focus on the other signers.
+  final otherSigners = signers
+      .where(
+        (signer) =>
+            !identical(signer, sendingSigner) &&
+            (isTransactionModifyingSigner(signer) ||
+                isTransactionPartialSigner(signer)),
+      )
+      .toList();
+
+  // Identify the modifying signers from the other signers.
+  final modifyingSigners = _identifyTransactionModifyingSigners(otherSigners);
+
+  // Use any remaining signers as partial signers.
+  final partialSigners = otherSigners
+      .where(isTransactionPartialSigner)
+      .where((signer) => !modifyingSigners.contains(signer))
+      .cast<TransactionPartialSigner>()
+      .toList();
+
+  return _CategorizedSigners(
+    modifyingSigners: modifyingSigners,
+    partialSigners: partialSigners,
+    sendingSigner: sendingSigner,
+  );
+}
+
+/// Identifies the best signer to use as a TransactionSendingSigner.
+TransactionSendingSigner? _identifyTransactionSendingSigner(
+  List<Object> signers,
+) {
+  final sendingSigners = signers.where(isTransactionSendingSigner).toList();
+  if (sendingSigners.isEmpty) return null;
+
+  // Prefer sending signers that do not offer other interfaces.
+  final sendingOnlySigners = sendingSigners
+      .where(
+        (signer) =>
+            !isTransactionModifyingSigner(signer) &&
+            !isTransactionPartialSigner(signer),
+      )
+      .toList();
+  if (sendingOnlySigners.isNotEmpty) {
+    return sendingOnlySigners[0] as TransactionSendingSigner;
+  }
+
+  // Otherwise, choose any sending signer.
+  return sendingSigners[0] as TransactionSendingSigner;
+}
+
+/// Identifies the best signers to use as TransactionModifyingSigners.
+List<TransactionModifyingSigner> _identifyTransactionModifyingSigners(
+  List<Object> signers,
+) {
+  final modifyingSigners = signers.where(isTransactionModifyingSigner).toList();
+  if (modifyingSigners.isEmpty) return [];
+
+  // Prefer modifying signers that do not offer partial signing.
+  final nonPartialSigners = modifyingSigners
+      .where((signer) => !isTransactionPartialSigner(signer))
+      .cast<TransactionModifyingSigner>()
+      .toList();
+  if (nonPartialSigners.isNotEmpty) return nonPartialSigners;
+
+  // Otherwise, choose only one modifying signer (whichever).
+  return [modifyingSigners[0] as TransactionModifyingSigner];
+}
+
+/// Signs a transaction using the provided TransactionModifyingSigners
+/// sequentially followed by the TransactionPartialSigners in parallel.
+Future<Transaction> _signModifyingAndPartialTransactionSigners(
+  TransactionMessage transactionMessage,
+  List<TransactionModifyingSigner> modifyingSigners,
+  List<TransactionPartialSigner> partialSigners, [
+  TransactionSignerConfig? config,
+]) async {
+  // Compile the transaction.
+  var transaction = compileTransaction(transactionMessage) as Transaction;
+
+  // Handle modifying signers sequentially.
+  for (final modifyingSigner in modifyingSigners) {
+    if (config != null && config.aborted) {
+      throw StateError('The operation was aborted');
+    }
+    final results = await modifyingSigner.modifyAndSignTransactions([
+      transaction,
+    ], config);
+    transaction = results[0];
+  }
+
+  // Handle partial signers in parallel.
+  if (config != null && config.aborted) {
+    throw StateError('The operation was aborted');
+  }
+
+  final signatureDictionaries = await Future.wait(
+    partialSigners.map((partialSigner) async {
+      final signatures = await partialSigner.signTransactions([
+        transaction,
+      ], config);
+      return signatures[0];
+    }),
+  );
+
+  // Merge all signatures.
+  final mergedSignatures = <Address, SignatureBytes?>{
+    ...transaction.signatures,
+  };
+  for (final sigDict in signatureDictionaries) {
+    mergedSignatures.addAll(sigDict);
+  }
+
+  if (transaction is TransactionWithLifetime) {
+    return TransactionWithLifetime(
+      messageBytes: transaction.messageBytes,
+      signatures: Map<Address, SignatureBytes?>.unmodifiable(mergedSignatures),
+      lifetimeConstraint: transaction.lifetimeConstraint,
+    );
+  }
+
+  return Transaction(
+    messageBytes: transaction.messageBytes,
+    signatures: Map<Address, SignatureBytes?>.unmodifiable(mergedSignatures),
+  );
+}

--- a/packages/solana_kit_signers/lib/src/signable_message.dart
+++ b/packages/solana_kit_signers/lib/src/signable_message.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+/// Defines a message that needs signing and its current set of signatures
+/// if any.
+///
+/// This class allows message modifying signers to decide on whether or not
+/// they should modify the provided message depending on whether or not
+/// signatures already exist for such message.
+class SignableMessage {
+  /// Creates a [SignableMessage] with the given [content] and [signatures].
+  const SignableMessage({required this.content, required this.signatures});
+
+  /// The content of the message as bytes.
+  final Uint8List content;
+
+  /// The current set of signatures for this message.
+  final Map<Address, SignatureBytes> signatures;
+}
+
+/// Creates a [SignableMessage] from a [Uint8List] or a UTF-8 string.
+///
+/// It optionally accepts a signature dictionary if the message already
+/// contains signatures.
+///
+/// ```dart
+/// final message = createSignableMessage(Uint8List.fromList([1, 2, 3]));
+/// final messageFromText = createSignableMessage('Hello world!');
+/// final messageWithSignatures = createSignableMessage(
+///   'Hello world!',
+///   {Address('1234..5678'): SignatureBytes(Uint8List(64))},
+/// );
+/// ```
+SignableMessage createSignableMessage(
+  Object content, [
+  Map<Address, SignatureBytes>? signatures,
+]) {
+  final Uint8List contentBytes;
+  if (content is String) {
+    contentBytes = Uint8List.fromList(utf8.encode(content));
+  } else if (content is Uint8List) {
+    contentBytes = content;
+  } else {
+    throw ArgumentError('content must be a String or Uint8List');
+  }
+
+  return SignableMessage(
+    content: contentBytes,
+    signatures: Map<Address, SignatureBytes>.unmodifiable(
+      signatures != null
+          ? Map<Address, SignatureBytes>.of(signatures)
+          : <Address, SignatureBytes>{},
+    ),
+  );
+}

--- a/packages/solana_kit_signers/lib/src/transaction_modifying_signer.dart
+++ b/packages/solana_kit_signers/lib/src/transaction_modifying_signer.dart
@@ -1,0 +1,56 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/src/types.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// A signer interface that potentially modifies the provided
+/// [Transaction]s before signing them.
+///
+/// For instance, this enables wallets to inject additional instructions
+/// into the transaction before signing them. For each transaction, instead
+/// of returning a signature dictionary, the [modifyAndSignTransactions]
+/// function returns an updated [Transaction] with a potentially modified
+/// set of instructions and signature dictionary.
+///
+/// Characteristics:
+/// - **Sequential**. Contrary to partial signers, these cannot be executed
+///   in parallel as each call can modify the provided transactions.
+/// - **First signers**. For a given transaction, a modifying signer must
+///   always be used before a partial signer.
+/// - **Potential conflicts**. If more than one modifying signer is
+///   provided, the second signer may invalidate the signature of the
+///   first one.
+// ignore: one_member_abstracts
+abstract class TransactionModifyingSigner {
+  /// The base58-encoded address of this signer.
+  Address get address;
+
+  /// Potentially modifies the provided [transactions] before signing
+  /// them and returns the updated [Transaction]s.
+  Future<List<Transaction>> modifyAndSignTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]);
+}
+
+/// Checks whether the provided value implements the
+/// [TransactionModifyingSigner] interface.
+bool isTransactionModifyingSigner(Object? value) {
+  return value is TransactionModifyingSigner;
+}
+
+/// Asserts that the provided value implements the
+/// [TransactionModifyingSigner] interface.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerExpectedTransactionModifyingSigner] if the check
+/// fails.
+void assertIsTransactionModifyingSigner(Object? value) {
+  if (!isTransactionModifyingSigner(value)) {
+    final addr = value is TransactionModifyingSigner ? value.address.value : '';
+    throw SolanaError(
+      SolanaErrorCode.signerExpectedTransactionModifyingSigner,
+      {'address': addr},
+    );
+  }
+}

--- a/packages/solana_kit_signers/lib/src/transaction_partial_signer.dart
+++ b/packages/solana_kit_signers/lib/src/transaction_partial_signer.dart
@@ -1,0 +1,52 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/src/types.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// A signer interface that signs an array of [Transaction]s without
+/// modifying their content.
+///
+/// It defines a [signTransactions] function that returns a signature
+/// dictionary for each provided transaction. Such signature dictionaries
+/// are expected to be merged with the existing ones if any.
+///
+/// Characteristics:
+/// - **Parallel**. It returns a signature dictionary for each provided
+///   transaction without modifying them, making it possible for multiple
+///   partial signers to sign the same transaction in parallel.
+/// - **Flexible order**. The order in which we use these signers for
+///   a given transaction doesn't matter.
+// ignore: one_member_abstracts
+abstract class TransactionPartialSigner {
+  /// The base58-encoded address of this signer.
+  Address get address;
+
+  /// Signs the provided [transactions] and returns a signature dictionary
+  /// for each transaction.
+  Future<List<Map<Address, SignatureBytes>>> signTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]);
+}
+
+/// Checks whether the provided value implements the
+/// [TransactionPartialSigner] interface.
+bool isTransactionPartialSigner(Object? value) {
+  return value is TransactionPartialSigner;
+}
+
+/// Asserts that the provided value implements the
+/// [TransactionPartialSigner] interface.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerExpectedTransactionPartialSigner] if the check
+/// fails.
+void assertIsTransactionPartialSigner(Object? value) {
+  if (!isTransactionPartialSigner(value)) {
+    final addr = value is TransactionPartialSigner ? value.address.value : '';
+    throw SolanaError(SolanaErrorCode.signerExpectedTransactionPartialSigner, {
+      'address': addr,
+    });
+  }
+}

--- a/packages/solana_kit_signers/lib/src/transaction_sending_signer.dart
+++ b/packages/solana_kit_signers/lib/src/transaction_sending_signer.dart
@@ -1,0 +1,59 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/src/types.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// A signer interface that signs one or multiple transactions before
+/// sending them immediately to the blockchain.
+///
+/// It defines a [signAndSendTransactions] function that returns the
+/// transaction signature (i.e. its identifier) for each provided
+/// [Transaction].
+///
+/// This interface is required for PDA wallets and other types of wallets
+/// that don't provide an interface for signing transactions without
+/// sending them.
+///
+/// Characteristics:
+/// - **Single signer**. Since this signer also sends the provided
+///   transactions, we can only use a single [TransactionSendingSigner]
+///   for a given set of transactions.
+/// - **Last signer**. Trivially, that signer must also be the last one
+///   used.
+/// - **Potential conflicts**. Since signers may decide to modify the given
+///   transactions before sending them, they may invalidate previous
+///   signatures.
+// ignore: one_member_abstracts
+abstract class TransactionSendingSigner {
+  /// The base58-encoded address of this signer.
+  Address get address;
+
+  /// Signs and sends the provided [transactions], returning the signature
+  /// for each transaction.
+  Future<List<SignatureBytes>> signAndSendTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]);
+}
+
+/// Checks whether the provided value implements the
+/// [TransactionSendingSigner] interface.
+bool isTransactionSendingSigner(Object? value) {
+  return value is TransactionSendingSigner;
+}
+
+/// Asserts that the provided value implements the
+/// [TransactionSendingSigner] interface.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerExpectedTransactionSendingSigner] if the check
+/// fails.
+void assertIsTransactionSendingSigner(Object? value) {
+  if (!isTransactionSendingSigner(value)) {
+    final addr = value is TransactionSendingSigner ? value.address.value : '';
+    throw SolanaError(SolanaErrorCode.signerExpectedTransactionSendingSigner, {
+      'address': addr,
+    });
+  }
+}

--- a/packages/solana_kit_signers/lib/src/transaction_signer.dart
+++ b/packages/solana_kit_signers/lib/src/transaction_signer.dart
@@ -1,0 +1,35 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/src/deduplicate_signers.dart';
+import 'package:solana_kit_signers/src/transaction_modifying_signer.dart';
+import 'package:solana_kit_signers/src/transaction_partial_signer.dart';
+import 'package:solana_kit_signers/src/transaction_sending_signer.dart';
+
+/// Checks whether the provided value implements any of the transaction
+/// signer interfaces: [TransactionPartialSigner],
+/// [TransactionModifyingSigner], or [TransactionSendingSigner].
+bool isTransactionSigner(Object? value) {
+  return isTransactionPartialSigner(value) ||
+      isTransactionModifyingSigner(value) ||
+      isTransactionSendingSigner(value);
+}
+
+/// Asserts that the provided value implements any of the transaction
+/// signer interfaces.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerExpectedTransactionSigner] if the check fails.
+void assertIsTransactionSigner(Object? value) {
+  if (!isTransactionSigner(value)) {
+    throw SolanaError(SolanaErrorCode.signerExpectedTransactionSigner);
+  }
+}
+
+/// Gets the address from a transaction signer.
+///
+/// This helper function returns the address from whichever transaction
+/// signer interface the value implements. Uses the shared
+/// [getSignerAddress] function.
+Address getTransactionSignerAddress(Object value) {
+  return getSignerAddress(value);
+}

--- a/packages/solana_kit_signers/lib/src/transaction_with_single_sending_signer.dart
+++ b/packages/solana_kit_signers/lib/src/transaction_with_single_sending_signer.dart
@@ -1,0 +1,63 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/src/account_signer_meta.dart';
+import 'package:solana_kit_signers/src/transaction_modifying_signer.dart';
+import 'package:solana_kit_signers/src/transaction_partial_signer.dart';
+import 'package:solana_kit_signers/src/transaction_sending_signer.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+/// Checks whether the provided transaction message has exactly one
+/// [TransactionSendingSigner].
+///
+/// This can be useful when using
+/// `signAndSendTransactionMessageWithSigners` to provide a fallback
+/// strategy in case the transaction message cannot be sent using that
+/// function.
+bool isTransactionMessageWithSingleSendingSigner(
+  TransactionMessage transactionMessage,
+) {
+  try {
+    assertIsTransactionMessageWithSingleSendingSigner(transactionMessage);
+    return true;
+  } on Object {
+    return false;
+  }
+}
+
+/// Asserts that the provided transaction message has exactly one
+/// [TransactionSendingSigner].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerTransactionSendingSignerMissing] if no sending
+/// signer exists.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.signerTransactionCannotHaveMultipleSendingSigners] if
+/// there are more than one sending-only signers.
+void assertIsTransactionMessageWithSingleSendingSigner(
+  TransactionMessage transactionMessage,
+) {
+  final signers = getSignersFromTransactionMessage(transactionMessage);
+  final sendingSigners = signers.where(isTransactionSendingSigner).toList();
+
+  if (sendingSigners.isEmpty) {
+    throw SolanaError(SolanaErrorCode.signerTransactionSendingSignerMissing);
+  }
+
+  // When identifying if there are multiple sending signers, we only need
+  // to check for sending signers that do not implement other transaction
+  // signer interfaces as they will be used as these other signer
+  // interfaces in case of a conflict.
+  final sendingOnlySigners = sendingSigners
+      .where(
+        (signer) =>
+            !isTransactionPartialSigner(signer) &&
+            !isTransactionModifyingSigner(signer),
+      )
+      .toList();
+
+  if (sendingOnlySigners.length > 1) {
+    throw SolanaError(
+      SolanaErrorCode.signerTransactionCannotHaveMultipleSendingSigners,
+    );
+  }
+}

--- a/packages/solana_kit_signers/lib/src/types.dart
+++ b/packages/solana_kit_signers/lib/src/types.dart
@@ -1,0 +1,22 @@
+/// The base configuration object for all signers -- including transaction
+/// and message signers.
+class SignerConfig {
+  /// Creates a [SignerConfig] with an optional [aborted] flag.
+  const SignerConfig({this.aborted = false});
+
+  /// Whether the signing operation has been aborted.
+  final bool aborted;
+}
+
+/// The base configuration object for transaction signers only.
+class TransactionSignerConfig extends SignerConfig {
+  /// Creates a [TransactionSignerConfig] with an optional [aborted] flag
+  /// and [minContextSlot].
+  const TransactionSignerConfig({super.aborted, this.minContextSlot});
+
+  /// Signers that simulate transactions (eg. wallets) might be interested in
+  /// knowing which slot was current when the transaction was prepared. They
+  /// can use this information to ensure that they don't run the simulation
+  /// at too early a slot.
+  final BigInt? minContextSlot;
+}

--- a/packages/solana_kit_signers/pubspec.yaml
+++ b/packages/solana_kit_signers/pubspec.yaml
@@ -8,8 +8,14 @@ environment:
 resolution: workspace
 
 dependencies:
+  solana_kit_addresses:
+  solana_kit_codecs_core:
   solana_kit_errors:
+  solana_kit_instructions:
   solana_kit_keys:
+  solana_kit_transaction_messages:
+  solana_kit_transactions:
 
 dev_dependencies:
   solana_kit_lints:
+  test: ^1.25.0

--- a/packages/solana_kit_signers/test/account_signer_meta_test.dart
+++ b/packages/solana_kit_signers/test/account_signer_meta_test.dart
@@ -1,0 +1,100 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('getSignersFromInstruction', () {
+    test('extracts signers from the account metas of the instruction', () {
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionModifyingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final instruction = createMockInstructionWithSigners([signerA, signerB]);
+
+      final extractedSigners = getSignersFromInstruction(instruction);
+
+      expect(extractedSigners, hasLength(2));
+      expect(identical(extractedSigners[0], signerA), isTrue);
+      expect(identical(extractedSigners[1], signerB), isTrue);
+    });
+
+    test('removes duplicated signers by reference', () {
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionModifyingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final instruction = createMockInstructionWithSigners([
+        signerA,
+        signerB,
+        signerA,
+        signerA,
+      ]);
+
+      final extractedSigners = getSignersFromInstruction(instruction);
+
+      expect(extractedSigners, hasLength(2));
+    });
+  });
+
+  group('getSignersFromTransactionMessage', () {
+    test('extracts signers from the account metas of the transaction', () {
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionModifyingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final transaction = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+      ]);
+
+      final extractedSigners = getSignersFromTransactionMessage(transaction);
+
+      expect(extractedSigners, hasLength(2));
+      expect(identical(extractedSigners[0], signerA), isTrue);
+      expect(identical(extractedSigners[1], signerB), isTrue);
+    });
+
+    test('extracts the fee payer signer of the transaction', () {
+      final feePayer = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final transaction = setTransactionMessageFeePayerSigner(
+        feePayer,
+        createTransactionMessage(version: TransactionVersion.v0),
+      );
+
+      final extractedSigners = getSignersFromTransactionMessage(transaction);
+
+      expect(extractedSigners, hasLength(1));
+      expect(identical(extractedSigners[0], feePayer), isTrue);
+    });
+
+    test('removes duplicated signers', () {
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionModifyingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final transaction = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+        signerA,
+        signerA,
+      ]);
+
+      final extractedSigners = getSignersFromTransactionMessage(transaction);
+
+      expect(extractedSigners, hasLength(2));
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/add_signers_test.dart
+++ b/packages/solana_kit_signers/test/add_signers_test.dart
@@ -1,0 +1,263 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('addSignersToInstruction', () {
+    test('adds signers to the account metas of the instruction', () {
+      final instruction = Instruction(
+        programAddress: const Address(
+          '9999999999999999999999999999999999999999999',
+        ),
+        accounts: [
+          const AccountMeta(
+            address: Address('11111111111111111111111111111111'),
+            role: AccountRole.readonlySigner,
+          ),
+          const AccountMeta(
+            address: Address('22222222222222222222222222222222'),
+            role: AccountRole.writableSigner,
+          ),
+        ],
+        data: Uint8List(0),
+      );
+
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionModifyingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+
+      final instructionWithSigners = addSignersToInstruction([
+        signerA,
+        signerB,
+      ], instruction);
+
+      expect(instructionWithSigners.accounts, hasLength(2));
+      expect(instructionWithSigners.accounts![0], isA<AccountSignerMeta>());
+      expect(instructionWithSigners.accounts![1], isA<AccountSignerMeta>());
+      expect(
+        (instructionWithSigners.accounts![0] as AccountSignerMeta).signer,
+        equals(signerA),
+      );
+      expect(
+        (instructionWithSigners.accounts![1] as AccountSignerMeta).signer,
+        equals(signerB),
+      );
+    });
+
+    test('ignores account metas that already have a signer', () {
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final instruction = Instruction(
+        programAddress: const Address(
+          '9999999999999999999999999999999999999999999',
+        ),
+        accounts: [
+          AccountSignerMeta(
+            address: const Address('11111111111111111111111111111111'),
+            role: AccountRole.readonlySigner,
+            signer: signerA,
+          ),
+        ],
+        data: Uint8List(0),
+      );
+
+      final signerB = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final instructionWithSigners = addSignersToInstruction([
+        signerB,
+      ], instruction);
+
+      // The original signer A should remain.
+      expect(
+        identical(
+          (instructionWithSigners.accounts![0] as AccountSignerMeta).signer,
+          signerA,
+        ),
+        isTrue,
+      );
+    });
+
+    test('ignores account metas that do not have a signer role', () {
+      final instruction = Instruction(
+        programAddress: const Address(
+          '9999999999999999999999999999999999999999999',
+        ),
+        accounts: [
+          const AccountMeta(
+            address: Address('11111111111111111111111111111111'),
+            role: AccountRole.writable,
+          ),
+        ],
+        data: Uint8List(0),
+      );
+
+      final signer = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final instructionWithSigners = addSignersToInstruction([
+        signer,
+      ], instruction);
+
+      expect(
+        instructionWithSigners.accounts![0],
+        isNot(isA<AccountSignerMeta>()),
+      );
+    });
+
+    test('can add the same signer to multiple account metas', () {
+      final instruction = Instruction(
+        programAddress: const Address(
+          '9999999999999999999999999999999999999999999',
+        ),
+        accounts: [
+          const AccountMeta(
+            address: Address('11111111111111111111111111111111'),
+            role: AccountRole.readonlySigner,
+          ),
+          const AccountMeta(
+            address: Address('11111111111111111111111111111111'),
+            role: AccountRole.writableSigner,
+          ),
+        ],
+        data: Uint8List(0),
+      );
+
+      final signer = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final instructionWithSigners = addSignersToInstruction([
+        signer,
+      ], instruction);
+
+      expect(instructionWithSigners.accounts![0], isA<AccountSignerMeta>());
+      expect(instructionWithSigners.accounts![1], isA<AccountSignerMeta>());
+    });
+
+    test('fails if two distinct signers are provided for the same address', () {
+      final instruction = Instruction(
+        programAddress: const Address(
+          '9999999999999999999999999999999999999999999',
+        ),
+        accounts: [
+          const AccountMeta(
+            address: Address('11111111111111111111111111111111'),
+            role: AccountRole.readonlySigner,
+          ),
+        ],
+        data: Uint8List(0),
+      );
+
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionModifyingSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+
+      expect(
+        () => addSignersToInstruction([signerA, signerB], instruction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerAddressCannotHaveMultipleSigners,
+          ),
+        ),
+      );
+    });
+
+    test('returns the instruction as-is if it has no account metas', () {
+      final instruction = Instruction(
+        programAddress: const Address(
+          '9999999999999999999999999999999999999999999',
+        ),
+        accounts: const [],
+        data: Uint8List(0),
+      );
+
+      final instructionWithSigners = addSignersToInstruction([], instruction);
+
+      expect(identical(instructionWithSigners, instruction), isTrue);
+    });
+  });
+
+  group('addSignersToTransactionMessage', () {
+    test('adds signers to the account metas of the transaction', () {
+      final instructionA = Instruction(
+        programAddress: const Address(
+          '8888888888888888888888888888888888888888888',
+        ),
+        accounts: [
+          const AccountMeta(
+            address: Address('11111111111111111111111111111111'),
+            role: AccountRole.readonlySigner,
+          ),
+        ],
+        data: Uint8List(0),
+      );
+      final instructionB = Instruction(
+        programAddress: const Address(
+          '9999999999999999999999999999999999999999999',
+        ),
+        accounts: [
+          const AccountMeta(
+            address: Address('22222222222222222222222222222222'),
+            role: AccountRole.writableSigner,
+          ),
+        ],
+        data: Uint8List(0),
+      );
+      final transaction = TransactionMessage(
+        version: TransactionVersion.v0,
+        instructions: [instructionA, instructionB],
+      );
+
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionModifyingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+
+      final transactionWithSigners = addSignersToTransactionMessage([
+        signerA,
+        signerB,
+      ], transaction);
+
+      expect(
+        transactionWithSigners.instructions[0].accounts![0],
+        isA<AccountSignerMeta>(),
+      );
+      expect(
+        transactionWithSigners.instructions[1].accounts![0],
+        isA<AccountSignerMeta>(),
+      );
+    });
+
+    test('returns the transaction as-is if it has no instructions or fee payer'
+        ' to update', () {
+      const transaction = TransactionMessage(version: TransactionVersion.v0);
+
+      final signer = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final transactionWithSigners = addSignersToTransactionMessage([
+        signer,
+      ], transaction);
+
+      expect(identical(transactionWithSigners, transaction), isTrue);
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/deduplicate_signers_test.dart
+++ b/packages/solana_kit_signers/test/deduplicate_signers_test.dart
@@ -1,0 +1,76 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('deduplicateSigners', () {
+    test('removes duplicated signers by address', () {
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockMessagePartialSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+
+      final signers = <Object>[
+        signerA,
+        signerB,
+        signerA,
+        signerA,
+        signerB,
+        signerB,
+      ];
+
+      final deduplicatedSigners = deduplicateSigners(signers);
+
+      expect(deduplicatedSigners, hasLength(2));
+      final addresses = deduplicatedSigners.map(getSignerAddress).toList()
+        ..sort((a, b) => a.value.compareTo(b.value));
+      expect(addresses.map((a) => a.value).toList(), [
+        '11111111111111111111111111111111',
+        '22222222222222222222222222222222',
+      ]);
+    });
+
+    test('fails to deduplicate distinct signers for the same address', () {
+      const addressA = Address('11111111111111111111111111111111');
+      const addressB = Address('22222222222222222222222222222222');
+      final signers = <Object>[
+        MockTransactionPartialSigner(addressA),
+        MockMessagePartialSigner(addressB),
+        MockTransactionModifyingSigner(addressA),
+        MockTransactionSendingSigner(addressA),
+      ];
+
+      expect(
+        () => deduplicateSigners(signers),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerAddressCannotHaveMultipleSigners,
+          ),
+        ),
+      );
+    });
+
+    test('filters signers without cloning them', () {
+      final signerA = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockMessagePartialSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final signers = <Object>[signerA, signerB];
+
+      final deduplicatedSigners = deduplicateSigners(signers);
+
+      expect(deduplicatedSigners, hasLength(2));
+      expect(identical(deduplicatedSigners[0], signerA), isTrue);
+      expect(identical(deduplicatedSigners[1], signerB), isTrue);
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/fee_payer_signer_test.dart
+++ b/packages/solana_kit_signers/test/fee_payer_signer_test.dart
@@ -1,0 +1,89 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('setTransactionMessageFeePayerSigner', () {
+    test('sets the fee payer signer on the transaction', () {
+      final feePayer = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final baseTx = createTransactionMessage(version: TransactionVersion.v0);
+
+      final txWithFeePayer = setTransactionMessageFeePayerSigner(
+        feePayer,
+        baseTx,
+      );
+
+      expect(txWithFeePayer, isA<TransactionMessageWithFeePayerSigner>());
+      expect(txWithFeePayer.feePayerSigner, equals(feePayer));
+      expect(txWithFeePayer.feePayer, equals(feePayer.address));
+    });
+
+    test(
+      'overrides the fee payer signer when it differs from the existing one',
+      () {
+        final feePayerA = MockTransactionPartialSigner(
+          const Address('11111111111111111111111111111111'),
+        );
+        final feePayerB = MockTransactionPartialSigner(
+          const Address('22222222222222222222222222222222'),
+        );
+        final baseTx = createTransactionMessage(version: TransactionVersion.v0);
+
+        final txWithFeePayerA = setTransactionMessageFeePayerSigner(
+          feePayerA,
+          baseTx,
+        );
+        final txWithFeePayerB = setTransactionMessageFeePayerSigner(
+          feePayerB,
+          txWithFeePayerA,
+        );
+
+        expect(txWithFeePayerB.feePayerSigner, equals(feePayerB));
+        expect(txWithFeePayerB.feePayer, equals(feePayerB.address));
+      },
+    );
+
+    test('overrides the fee payer even when the existing fee payer address is'
+        ' the same', () {
+      final feePayer = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final baseTx = createTransactionMessage(version: TransactionVersion.v0);
+
+      final txWithFeePayer = setTransactionMessageFeePayerSigner(
+        feePayer,
+        baseTx,
+      );
+      final txWithSameFeePayer = setTransactionMessageFeePayerSigner(
+        feePayer,
+        txWithFeePayer,
+      );
+
+      expect(txWithSameFeePayer.feePayerSigner, equals(feePayer));
+      expect(identical(txWithSameFeePayer, txWithFeePayer), isFalse);
+    });
+
+    test('overrides a non-signer fee payer with a signer fee payer', () {
+      final feePayer = MockTransactionPartialSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final baseTx = setTransactionMessageFeePayer(
+        feePayer.address,
+        createTransactionMessage(version: TransactionVersion.v0),
+      );
+
+      final txWithFeePayerSigner = setTransactionMessageFeePayerSigner(
+        feePayer,
+        baseTx,
+      );
+
+      expect(txWithFeePayerSigner, isA<TransactionMessageWithFeePayerSigner>());
+      expect(txWithFeePayerSigner.feePayerSigner, equals(feePayer));
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/keypair_signer_test.dart
+++ b/packages/solana_kit_signers/test/keypair_signer_test.dart
@@ -1,0 +1,150 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isKeyPairSigner', () {
+    test('returns true for KeyPairSigner', () {
+      final signer = generateKeyPairSigner();
+      expect(isKeyPairSigner(signer), isTrue);
+    });
+
+    test('returns false for non-KeyPairSigner', () {
+      expect(isKeyPairSigner('not a signer'), isFalse);
+      expect(isKeyPairSigner(null), isFalse);
+    });
+  });
+
+  group('assertIsKeyPairSigner', () {
+    test('succeeds for KeyPairSigner', () {
+      final signer = generateKeyPairSigner();
+      expect(() => assertIsKeyPairSigner(signer), returnsNormally);
+    });
+
+    test('throws for non-KeyPairSigner', () {
+      expect(
+        () => assertIsKeyPairSigner('not a signer'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerExpectedKeyPairSigner,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('createSignerFromKeyPair', () {
+    test('creates a KeyPairSigner from a given KeyPair', () {
+      final keyPair = generateKeyPair();
+      final signer = createSignerFromKeyPair(keyPair);
+
+      expect(signer.address, isNotNull);
+      expect(signer.keyPair, equals(keyPair));
+      expect(isKeyPairSigner(signer), isTrue);
+      expect(isMessagePartialSigner(signer), isTrue);
+      expect(isTransactionPartialSigner(signer), isTrue);
+    });
+
+    test('derives the correct address from the key pair', () {
+      final keyPair = generateKeyPair();
+      final expectedAddress = getAddressFromPublicKey(keyPair.publicKey);
+      final signer = createSignerFromKeyPair(keyPair);
+
+      expect(signer.address, equals(expectedAddress));
+    });
+  });
+
+  group('generateKeyPairSigner', () {
+    test('generates a new KeyPairSigner', () {
+      final signer = generateKeyPairSigner();
+
+      expect(signer.address, isNotNull);
+      expect(signer.keyPair, isNotNull);
+      expect(isKeyPairSigner(signer), isTrue);
+    });
+
+    test('generates different signers each time', () {
+      final signerA = generateKeyPairSigner();
+      final signerB = generateKeyPairSigner();
+
+      expect(signerA.address, isNot(equals(signerB.address)));
+    });
+  });
+
+  group('KeyPairSigner.signMessages', () {
+    test('signs messages using the key pair', () async {
+      final signer = generateKeyPairSigner();
+      final messages = [
+        createSignableMessage(Uint8List.fromList([1, 1, 1])),
+        createSignableMessage(Uint8List.fromList([2, 2, 2])),
+      ];
+
+      final signatureDictionaries = await signer.signMessages(messages);
+
+      expect(signatureDictionaries, hasLength(2));
+      expect(signatureDictionaries[0].containsKey(signer.address), isTrue);
+      expect(signatureDictionaries[1].containsKey(signer.address), isTrue);
+
+      // Verify signatures are valid.
+      final sig0 = signatureDictionaries[0][signer.address]!;
+      final sig1 = signatureDictionaries[1][signer.address]!;
+      expect(
+        verifySignature(signer.keyPair.publicKey, sig0, messages[0].content),
+        isTrue,
+      );
+      expect(
+        verifySignature(signer.keyPair.publicKey, sig1, messages[1].content),
+        isTrue,
+      );
+    });
+
+    test('returns unmodifiable signature dictionaries', () async {
+      final signer = generateKeyPairSigner();
+      final messages = [createSignableMessage('hello')];
+
+      final signatureDictionaries = await signer.signMessages(messages);
+
+      expect(
+        () => signatureDictionaries[0][const Address('test')] = SignatureBytes(
+          Uint8List(64),
+        ),
+        throwsUnsupportedError,
+      );
+    });
+  });
+
+  group('createKeyPairSignerFromBytes', () {
+    test('creates a signer from 64-byte key pair bytes', () {
+      final keyPair = generateKeyPair();
+      final bytes = Uint8List(64)
+        ..setAll(0, keyPair.privateKey)
+        ..setAll(32, keyPair.publicKey);
+
+      final signer = createKeyPairSignerFromBytes(bytes);
+
+      expect(
+        signer.address,
+        equals(getAddressFromPublicKey(keyPair.publicKey)),
+      );
+    });
+  });
+
+  group('createKeyPairSignerFromPrivateKeyBytes', () {
+    test('creates a signer from 32-byte private key bytes', () {
+      final keyPair = generateKeyPair();
+
+      final signer = createKeyPairSignerFromPrivateKeyBytes(keyPair.privateKey);
+
+      expect(
+        signer.address,
+        equals(getAddressFromPublicKey(keyPair.publicKey)),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/message_modifying_signer_test.dart
+++ b/packages/solana_kit_signers/test/message_modifying_signer_test.dart
@@ -1,0 +1,44 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('isMessageModifyingSigner', () {
+    test('returns true for MessageModifyingSigner', () {
+      final signer = MockMessageModifyingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isMessageModifyingSigner(signer), isTrue);
+    });
+
+    test('returns false for non-signer', () {
+      expect(isMessageModifyingSigner('not a signer'), isFalse);
+      expect(isMessageModifyingSigner(null), isFalse);
+    });
+  });
+
+  group('assertIsMessageModifyingSigner', () {
+    test('succeeds for MessageModifyingSigner', () {
+      final signer = MockMessageModifyingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsMessageModifyingSigner(signer), returnsNormally);
+    });
+
+    test('throws for non-signer', () {
+      expect(
+        () => assertIsMessageModifyingSigner('not a signer'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerExpectedMessageModifyingSigner,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/message_partial_signer_test.dart
+++ b/packages/solana_kit_signers/test/message_partial_signer_test.dart
@@ -1,0 +1,44 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('isMessagePartialSigner', () {
+    test('returns true for MessagePartialSigner', () {
+      final signer = MockMessagePartialSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isMessagePartialSigner(signer), isTrue);
+    });
+
+    test('returns false for non-signer', () {
+      expect(isMessagePartialSigner('not a signer'), isFalse);
+      expect(isMessagePartialSigner(null), isFalse);
+    });
+  });
+
+  group('assertIsMessagePartialSigner', () {
+    test('succeeds for MessagePartialSigner', () {
+      final signer = MockMessagePartialSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsMessagePartialSigner(signer), returnsNormally);
+    });
+
+    test('throws for non-signer', () {
+      expect(
+        () => assertIsMessagePartialSigner('not a signer'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerExpectedMessagePartialSigner,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/message_signer_test.dart
+++ b/packages/solana_kit_signers/test/message_signer_test.dart
@@ -1,0 +1,57 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('isMessageSigner', () {
+    test('returns true for MessagePartialSigner', () {
+      final signer = MockMessagePartialSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isMessageSigner(signer), isTrue);
+    });
+
+    test('returns true for MessageModifyingSigner', () {
+      final signer = MockMessageModifyingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isMessageSigner(signer), isTrue);
+    });
+
+    test('returns false for non-signer', () {
+      expect(isMessageSigner('not a signer'), isFalse);
+    });
+  });
+
+  group('assertIsMessageSigner', () {
+    test('succeeds for MessagePartialSigner', () {
+      final signer = MockMessagePartialSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsMessageSigner(signer), returnsNormally);
+    });
+
+    test('succeeds for MessageModifyingSigner', () {
+      final signer = MockMessageModifyingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsMessageSigner(signer), returnsNormally);
+    });
+
+    test('throws for non-signer', () {
+      expect(
+        () => assertIsMessageSigner('not a signer'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerExpectedMessageSigner,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/noop_signer_test.dart
+++ b/packages/solana_kit_signers/test/noop_signer_test.dart
@@ -1,0 +1,79 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('createNoopSigner', () {
+    test('creates a NoopSigner from a given address', () {
+      const myAddress = Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
+      final mySigner = createNoopSigner(myAddress);
+
+      expect(mySigner.address, equals(myAddress));
+      expect(isMessagePartialSigner(mySigner), isTrue);
+      expect(isTransactionPartialSigner(mySigner), isTrue);
+    });
+
+    test('returns empty signature dictionary when signing messages', () async {
+      const myAddress = Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
+      final mySigner = createNoopSigner(myAddress);
+
+      final messages = [
+        createSignableMessage('hello'),
+        createSignableMessage('world'),
+      ];
+      final signatureDictionaries = await mySigner.signMessages(messages);
+
+      expect(signatureDictionaries, hasLength(2));
+      expect(signatureDictionaries[0], isEmpty);
+      expect(signatureDictionaries[1], isEmpty);
+    });
+
+    test(
+      'returns empty signature dictionary when signing transactions',
+      () async {
+        const myAddress = Address(
+          'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy',
+        );
+        final mySigner = createNoopSigner(myAddress);
+
+        final mockTransactions = [
+          Transaction(
+            messageBytes: Uint8List(0),
+            signatures: <Address, SignatureBytes?>{},
+          ),
+          Transaction(
+            messageBytes: Uint8List(0),
+            signatures: <Address, SignatureBytes?>{},
+          ),
+        ];
+
+        final signatureDictionaries = await mySigner.signTransactions(
+          mockTransactions,
+        );
+
+        expect(signatureDictionaries, hasLength(2));
+        expect(signatureDictionaries[0], isEmpty);
+        expect(signatureDictionaries[1], isEmpty);
+      },
+    );
+
+    test('returns unmodifiable signature dictionaries', () async {
+      const myAddress = Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy');
+      final mySigner = createNoopSigner(myAddress);
+
+      final messages = [createSignableMessage('hello')];
+      final signatureDictionaries = await mySigner.signMessages(messages);
+
+      expect(
+        () => signatureDictionaries[0][const Address('test')] = SignatureBytes(
+          Uint8List(64),
+        ),
+        throwsUnsupportedError,
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/sign_transaction_test.dart
+++ b/packages/solana_kit_signers/test/sign_transaction_test.dart
@@ -1,0 +1,181 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+// Valid base58 addresses that encode to exactly 32 bytes.
+const _addressA = Address('22222222222222222222222222222222222222222222');
+const _addressB = Address('33333333333333333333333333333333333333333333');
+
+void main() {
+  group('partiallySignTransactionMessageWithSigners', () {
+    test('signs the transaction with its extracted signers', () async {
+      // Given a transaction with a modifying signer A and a partial signer B.
+      final signerA = MockTransactionModifyingSigner(_addressA);
+      final signerB = MockTransactionPartialSigner(_addressB);
+      final transactionMessage = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+      ]);
+
+      // Mock the modifying signer to return a modified transaction.
+      signerA.modifyAndSignTransactionsMock = (transactions, config) async {
+        return transactions.map((tx) {
+          return Transaction(
+            messageBytes: tx.messageBytes,
+            signatures: <Address, SignatureBytes?>{
+              _addressA: SignatureBytes(Uint8List.fromList(List.filled(64, 1))),
+              _addressB: null,
+            },
+          );
+        }).toList();
+      };
+
+      // Mock the partial signer to return signatures.
+      signerB.signTransactionsMock = (transactions, config) async {
+        return transactions.map((_) {
+          return <Address, SignatureBytes>{
+            _addressB: SignatureBytes(Uint8List.fromList(List.filled(64, 2))),
+          };
+        }).toList();
+      };
+
+      // When we partially sign this transaction.
+      final signedTransaction =
+          await partiallySignTransactionMessageWithSigners(transactionMessage);
+
+      // Then it contains signatures from both signers.
+      expect(signedTransaction.signatures[_addressA], isNotNull);
+      expect(signedTransaction.signatures[_addressB], isNotNull);
+    });
+
+    test('ignores sending signers', () async {
+      // Given a transaction with a sending signer A and a partial+sending
+      // composite signer B.
+      final signerA = MockTransactionSendingSigner(_addressA);
+
+      // Create a composite signer that is both sending and partial.
+      final signerB = MockTransactionSendingPartialSigner(_addressB)
+        ..signTransactionsMock = (transactions, config) async {
+          return transactions.map((_) {
+            return <Address, SignatureBytes>{
+              _addressB: SignatureBytes(Uint8List.fromList(List.filled(64, 2))),
+            };
+          }).toList();
+        };
+
+      final transactionMessage = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+      ]);
+
+      // When we partially sign this transaction.
+      final signedTransaction =
+          await partiallySignTransactionMessageWithSigners(transactionMessage);
+
+      // Then only the partial signer's signature is present.
+      expect(signedTransaction.signatures[_addressB], isNotNull);
+    });
+  });
+
+  group('signTransactionMessageWithSigners', () {
+    test('asserts the transaction is fully signed', () async {
+      // Given a transaction with a partial signer A and a sending signer B.
+      final signerA = MockTransactionPartialSigner(_addressA);
+      final signerB = MockTransactionSendingSigner(_addressB);
+      final transactionMessage = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+      ]);
+
+      signerA.signTransactionsMock = (transactions, config) async {
+        return transactions.map((_) {
+          return <Address, SignatureBytes>{
+            _addressA: SignatureBytes(Uint8List.fromList(List.filled(64, 1))),
+          };
+        }).toList();
+      };
+
+      // When we try to fully sign this transaction, it should fail because
+      // the sending signer doesn't provide a signature.
+      expect(
+        () => signTransactionMessageWithSigners(transactionMessage),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.transactionSignaturesMissing,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('signAndSendTransactionMessageWithSigners', () {
+    test('signs and sends the transaction', () async {
+      // Given a transaction with a partial signer A and a sending signer B.
+      final signerA = MockTransactionPartialSigner(_addressA);
+      final signerB = MockTransactionSendingSigner(_addressB);
+      final transactionMessage = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+      ]);
+
+      signerA.signTransactionsMock = (transactions, config) async {
+        return transactions.map((_) {
+          return <Address, SignatureBytes>{
+            _addressA: SignatureBytes(Uint8List.fromList(List.filled(64, 1))),
+          };
+        }).toList();
+      };
+
+      final expectedSignature = SignatureBytes(
+        Uint8List.fromList([1, 2, 3, ...List.filled(61, 0)]),
+      );
+      signerB.signAndSendTransactionsMock = (transactions, config) async {
+        return [expectedSignature];
+      };
+
+      // When we sign and send this transaction.
+      final transactionSignature =
+          await signAndSendTransactionMessageWithSigners(transactionMessage);
+
+      // Then the returned signature matches.
+      expect(transactionSignature.value, equals(expectedSignature.value));
+    });
+
+    test('fails if no sending signer exists on the transaction', () async {
+      // Given a transaction with only a partial signer.
+      final signer = MockTransactionPartialSigner(_addressA);
+      final transactionMessage = createMockTransactionMessageWithSigners([
+        signer,
+      ]);
+
+      signer.signTransactionsMock = (transactions, config) async {
+        return transactions.map((_) {
+          return <Address, SignatureBytes>{
+            _addressA: SignatureBytes(Uint8List.fromList(List.filled(64, 1))),
+          };
+        }).toList();
+      };
+
+      // When we try to sign and send, it should fail.
+      expect(
+        () => signAndSendTransactionMessageWithSigners(transactionMessage),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerTransactionSendingSignerMissing,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/signable_message_test.dart
+++ b/packages/solana_kit_signers/test/signable_message_test.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('createSignableMessage', () {
+    test('creates a SignableMessage from a byte array', () {
+      final content = Uint8List.fromList([1, 2, 3]);
+      final message = createSignableMessage(content);
+
+      expect(message.content, equals(content));
+      expect(message.signatures, isEmpty);
+    });
+
+    test('creates a SignableMessage with signatures', () {
+      final content = Uint8List.fromList([1, 2, 3]);
+      final signatures = <Address, SignatureBytes>{
+        const Address('11111111111111111111111111111111'): SignatureBytes(
+          Uint8List.fromList([1, 1, 1, 1]),
+        ),
+        const Address('22222222222222222222222222222222'): SignatureBytes(
+          Uint8List.fromList([2, 2, 2, 2]),
+        ),
+      };
+
+      final message = createSignableMessage(content, signatures);
+
+      expect(message.content, equals(content));
+      expect(message.signatures, equals(signatures));
+    });
+
+    test('creates a SignableMessage from a UTF-8 string', () {
+      final message = createSignableMessage('Hello world!');
+
+      expect(
+        message.content,
+        equals(Uint8List.fromList(utf8.encode('Hello world!'))),
+      );
+      expect(message.signatures, isEmpty);
+    });
+
+    test('creates an unmodifiable empty signature dictionary', () {
+      final message = createSignableMessage('Hello world!');
+      expect(message.signatures, isEmpty);
+      expect(
+        () => message.signatures[const Address('test')] = SignatureBytes(
+          Uint8List(64),
+        ),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('shallow copies and freezes the provided signature dictionary', () {
+      final signatures = <Address, SignatureBytes>{
+        const Address('11111111111111111111111111111111'): SignatureBytes(
+          Uint8List.fromList([1, 1, 1, 1]),
+        ),
+        const Address('22222222222222222222222222222222'): SignatureBytes(
+          Uint8List.fromList([2, 2, 2, 2]),
+        ),
+      };
+
+      final message = createSignableMessage('Hello world!', signatures);
+
+      // The signature dictionary is a copy.
+      expect(identical(message.signatures, signatures), isFalse);
+      expect(message.signatures, equals(signatures));
+
+      // The copy is unmodifiable.
+      expect(
+        () => message.signatures[const Address('test')] = SignatureBytes(
+          Uint8List(64),
+        ),
+        throwsUnsupportedError,
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/test_helpers.dart
+++ b/packages/solana_kit_signers/test/test_helpers.dart
@@ -1,0 +1,285 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// Creates a mock instruction with signer accounts for each provided
+/// signer.
+Instruction createMockInstructionWithSigners(List<Object> signers) {
+  return Instruction(
+    programAddress: const Address(
+      '55555555555555555555555555555555555555555555',
+    ),
+    accounts: signers
+        .map(
+          (signer) => AccountSignerMeta(
+            address: getTransactionSignerAddress(signer),
+            role: AccountRole.readonlySigner,
+            signer: signer,
+          ),
+        )
+        .toList(),
+    data: Uint8List(0),
+  );
+}
+
+/// Creates a mock transaction message with signers.
+TransactionMessage createMockTransactionMessageWithSigners(
+  List<Object> signers,
+) {
+  final feePayerAddress = signers.isNotEmpty
+      ? getTransactionSignerAddress(signers[0])
+      : const Address('22222222222222222222222222222222222222222222');
+
+  var message = createTransactionMessage(version: TransactionVersion.v0);
+  message = setTransactionMessageFeePayer(feePayerAddress, message);
+  message = setTransactionMessageLifetimeUsingBlockhash(
+    BlockhashLifetimeConstraint(
+      blockhash: 'Ep1Aq1hQ8oZ1FMd94KxvFSTiigHmGF4iYwYkiigZcKhB',
+      lastValidBlockHeight: BigInt.from(42),
+    ),
+    message,
+  );
+  message = appendTransactionMessageInstruction(
+    createMockInstructionWithSigners(signers),
+    message,
+  );
+  return message;
+}
+
+/// A mock implementation of [TransactionPartialSigner].
+class MockTransactionPartialSigner implements TransactionPartialSigner {
+  /// Creates a mock partial signer.
+  MockTransactionPartialSigner(this.address);
+
+  @override
+  final Address address;
+
+  /// The mock implementation for signTransactions.
+  Future<List<Map<Address, SignatureBytes>>> Function(
+    List<Transaction>,
+    TransactionSignerConfig?,
+  )?
+  signTransactionsMock;
+
+  @override
+  Future<List<Map<Address, SignatureBytes>>> signTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    if (signTransactionsMock != null) {
+      return signTransactionsMock!(transactions, config);
+    }
+    return transactions.map((_) => <Address, SignatureBytes>{}).toList();
+  }
+
+  /// Records of calls made.
+  final calls = <(List<Transaction>, TransactionSignerConfig?)>[];
+}
+
+/// A mock implementation of [TransactionModifyingSigner].
+class MockTransactionModifyingSigner implements TransactionModifyingSigner {
+  /// Creates a mock modifying signer.
+  MockTransactionModifyingSigner(this.address);
+
+  @override
+  final Address address;
+
+  /// The mock implementation for modifyAndSignTransactions.
+  Future<List<Transaction>> Function(
+    List<Transaction>,
+    TransactionSignerConfig?,
+  )?
+  modifyAndSignTransactionsMock;
+
+  @override
+  Future<List<Transaction>> modifyAndSignTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    if (modifyAndSignTransactionsMock != null) {
+      return modifyAndSignTransactionsMock!(transactions, config);
+    }
+    return transactions;
+  }
+}
+
+/// A mock implementation of [TransactionSendingSigner].
+class MockTransactionSendingSigner implements TransactionSendingSigner {
+  /// Creates a mock sending signer.
+  MockTransactionSendingSigner(this.address);
+
+  @override
+  final Address address;
+
+  /// The mock implementation for signAndSendTransactions.
+  Future<List<SignatureBytes>> Function(
+    List<Transaction>,
+    TransactionSignerConfig?,
+  )?
+  signAndSendTransactionsMock;
+
+  @override
+  Future<List<SignatureBytes>> signAndSendTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    if (signAndSendTransactionsMock != null) {
+      return signAndSendTransactionsMock!(transactions, config);
+    }
+    return transactions.map((_) => SignatureBytes(Uint8List(64))).toList();
+  }
+}
+
+/// A mock implementation of [MessagePartialSigner].
+class MockMessagePartialSigner implements MessagePartialSigner {
+  /// Creates a mock message partial signer.
+  MockMessagePartialSigner(this.address);
+
+  @override
+  final Address address;
+
+  @override
+  Future<List<Map<Address, SignatureBytes>>> signMessages(
+    List<SignableMessage> messages, [
+    SignerConfig? config,
+  ]) async {
+    return messages.map((_) => <Address, SignatureBytes>{}).toList();
+  }
+}
+
+/// A mock implementation of [MessageModifyingSigner].
+class MockMessageModifyingSigner implements MessageModifyingSigner {
+  /// Creates a mock message modifying signer.
+  MockMessageModifyingSigner(this.address);
+
+  @override
+  final Address address;
+
+  @override
+  Future<List<SignableMessage>> modifyAndSignMessages(
+    List<SignableMessage> messages, [
+    SignerConfig? config,
+  ]) async {
+    return messages;
+  }
+}
+
+/// A mock composite signer implementing sending and partial transaction
+/// signer interfaces (but not modifying).
+class MockTransactionSendingPartialSigner
+    implements TransactionPartialSigner, TransactionSendingSigner {
+  /// Creates a mock sending+partial signer.
+  MockTransactionSendingPartialSigner(this.address);
+
+  @override
+  final Address address;
+
+  /// The mock implementation for signTransactions.
+  Future<List<Map<Address, SignatureBytes>>> Function(
+    List<Transaction>,
+    TransactionSignerConfig?,
+  )?
+  signTransactionsMock;
+
+  /// The mock implementation for signAndSendTransactions.
+  Future<List<SignatureBytes>> Function(
+    List<Transaction>,
+    TransactionSignerConfig?,
+  )?
+  signAndSendTransactionsMock;
+
+  @override
+  Future<List<Map<Address, SignatureBytes>>> signTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    if (signTransactionsMock != null) {
+      return signTransactionsMock!(transactions, config);
+    }
+    return transactions.map((_) => <Address, SignatureBytes>{}).toList();
+  }
+
+  @override
+  Future<List<SignatureBytes>> signAndSendTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    if (signAndSendTransactionsMock != null) {
+      return signAndSendTransactionsMock!(transactions, config);
+    }
+    return transactions.map((_) => SignatureBytes(Uint8List(64))).toList();
+  }
+}
+
+/// A mock composite signer implementing all three transaction signer
+/// interfaces.
+class MockTransactionCompositeSigner
+    implements
+        TransactionPartialSigner,
+        TransactionModifyingSigner,
+        TransactionSendingSigner {
+  /// Creates a mock composite signer.
+  MockTransactionCompositeSigner(this.address);
+
+  @override
+  final Address address;
+
+  /// The mock implementation for signTransactions.
+  Future<List<Map<Address, SignatureBytes>>> Function(
+    List<Transaction>,
+    TransactionSignerConfig?,
+  )?
+  signTransactionsMock;
+
+  /// The mock implementation for modifyAndSignTransactions.
+  Future<List<Transaction>> Function(
+    List<Transaction>,
+    TransactionSignerConfig?,
+  )?
+  modifyAndSignTransactionsMock;
+
+  /// The mock implementation for signAndSendTransactions.
+  Future<List<SignatureBytes>> Function(
+    List<Transaction>,
+    TransactionSignerConfig?,
+  )?
+  signAndSendTransactionsMock;
+
+  @override
+  Future<List<Map<Address, SignatureBytes>>> signTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    if (signTransactionsMock != null) {
+      return signTransactionsMock!(transactions, config);
+    }
+    return transactions.map((_) => <Address, SignatureBytes>{}).toList();
+  }
+
+  @override
+  Future<List<Transaction>> modifyAndSignTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    if (modifyAndSignTransactionsMock != null) {
+      return modifyAndSignTransactionsMock!(transactions, config);
+    }
+    return transactions;
+  }
+
+  @override
+  Future<List<SignatureBytes>> signAndSendTransactions(
+    List<Transaction> transactions, [
+    TransactionSignerConfig? config,
+  ]) async {
+    if (signAndSendTransactionsMock != null) {
+      return signAndSendTransactionsMock!(transactions, config);
+    }
+    return transactions.map((_) => SignatureBytes(Uint8List(64))).toList();
+  }
+}

--- a/packages/solana_kit_signers/test/transaction_modifying_signer_test.dart
+++ b/packages/solana_kit_signers/test/transaction_modifying_signer_test.dart
@@ -1,0 +1,43 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('isTransactionModifyingSigner', () {
+    test('returns true for TransactionModifyingSigner', () {
+      final signer = MockTransactionModifyingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isTransactionModifyingSigner(signer), isTrue);
+    });
+
+    test('returns false for non-signer', () {
+      expect(isTransactionModifyingSigner('not a signer'), isFalse);
+    });
+  });
+
+  group('assertIsTransactionModifyingSigner', () {
+    test('succeeds for TransactionModifyingSigner', () {
+      final signer = MockTransactionModifyingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsTransactionModifyingSigner(signer), returnsNormally);
+    });
+
+    test('throws for non-signer', () {
+      expect(
+        () => assertIsTransactionModifyingSigner('not a signer'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerExpectedTransactionModifyingSigner,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/transaction_partial_signer_test.dart
+++ b/packages/solana_kit_signers/test/transaction_partial_signer_test.dart
@@ -1,0 +1,43 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('isTransactionPartialSigner', () {
+    test('returns true for TransactionPartialSigner', () {
+      final signer = MockTransactionPartialSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isTransactionPartialSigner(signer), isTrue);
+    });
+
+    test('returns false for non-signer', () {
+      expect(isTransactionPartialSigner('not a signer'), isFalse);
+    });
+  });
+
+  group('assertIsTransactionPartialSigner', () {
+    test('succeeds for TransactionPartialSigner', () {
+      final signer = MockTransactionPartialSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsTransactionPartialSigner(signer), returnsNormally);
+    });
+
+    test('throws for non-signer', () {
+      expect(
+        () => assertIsTransactionPartialSigner('not a signer'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerExpectedTransactionPartialSigner,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/transaction_sending_signer_test.dart
+++ b/packages/solana_kit_signers/test/transaction_sending_signer_test.dart
@@ -1,0 +1,43 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('isTransactionSendingSigner', () {
+    test('returns true for TransactionSendingSigner', () {
+      final signer = MockTransactionSendingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isTransactionSendingSigner(signer), isTrue);
+    });
+
+    test('returns false for non-signer', () {
+      expect(isTransactionSendingSigner('not a signer'), isFalse);
+    });
+  });
+
+  group('assertIsTransactionSendingSigner', () {
+    test('succeeds for TransactionSendingSigner', () {
+      final signer = MockTransactionSendingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsTransactionSendingSigner(signer), returnsNormally);
+    });
+
+    test('throws for non-signer', () {
+      expect(
+        () => assertIsTransactionSendingSigner('not a signer'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerExpectedTransactionSendingSigner,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/transaction_signer_test.dart
+++ b/packages/solana_kit_signers/test/transaction_signer_test.dart
@@ -1,0 +1,71 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('isTransactionSigner', () {
+    test('returns true for TransactionPartialSigner', () {
+      final signer = MockTransactionPartialSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isTransactionSigner(signer), isTrue);
+    });
+
+    test('returns true for TransactionModifyingSigner', () {
+      final signer = MockTransactionModifyingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isTransactionSigner(signer), isTrue);
+    });
+
+    test('returns true for TransactionSendingSigner', () {
+      final signer = MockTransactionSendingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(isTransactionSigner(signer), isTrue);
+    });
+
+    test('returns false for non-signer', () {
+      expect(isTransactionSigner('not a signer'), isFalse);
+    });
+  });
+
+  group('assertIsTransactionSigner', () {
+    test('succeeds for TransactionPartialSigner', () {
+      final signer = MockTransactionPartialSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsTransactionSigner(signer), returnsNormally);
+    });
+
+    test('succeeds for TransactionModifyingSigner', () {
+      final signer = MockTransactionModifyingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsTransactionSigner(signer), returnsNormally);
+    });
+
+    test('succeeds for TransactionSendingSigner', () {
+      final signer = MockTransactionSendingSigner(
+        const Address('Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy'),
+      );
+      expect(() => assertIsTransactionSigner(signer), returnsNormally);
+    });
+
+    test('throws for non-signer', () {
+      expect(
+        () => assertIsTransactionSigner('not a signer'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerExpectedTransactionSigner,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_signers/test/transaction_with_single_sending_signer_test.dart
+++ b/packages/solana_kit_signers/test/transaction_with_single_sending_signer_test.dart
@@ -1,0 +1,159 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('isTransactionMessageWithSingleSendingSigner', () {
+    test('returns true if a transaction message contains a single sending only'
+        ' signer', () {
+      final signer = MockTransactionSendingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final transaction = createMockTransactionMessageWithSigners([signer]);
+
+      expect(isTransactionMessageWithSingleSendingSigner(transaction), isTrue);
+    });
+
+    test('returns true if a transaction message contains multiple sending'
+        ' signer composites', () {
+      final signerA = MockTransactionCompositeSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionCompositeSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final transaction = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+      ]);
+
+      expect(isTransactionMessageWithSingleSendingSigner(transaction), isTrue);
+    });
+
+    test('returns false if a transaction message contains multiple sending'
+        ' only signers', () {
+      final signerA = MockTransactionSendingSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionSendingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final transaction = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+      ]);
+
+      expect(isTransactionMessageWithSingleSendingSigner(transaction), isFalse);
+    });
+
+    test(
+      'returns false if a transaction message contains no sending signer',
+      () {
+        final signerA = MockTransactionPartialSigner(
+          const Address('11111111111111111111111111111111'),
+        );
+        final signerB = MockTransactionModifyingSigner(
+          const Address('22222222222222222222222222222222'),
+        );
+        final transaction = createMockTransactionMessageWithSigners([
+          signerA,
+          signerB,
+        ]);
+
+        expect(
+          isTransactionMessageWithSingleSendingSigner(transaction),
+          isFalse,
+        );
+      },
+    );
+  });
+
+  group('assertIsTransactionMessageWithSingleSendingSigner', () {
+    test('succeeds if a transaction message contains a single sending only'
+        ' signer', () {
+      final signer = MockTransactionSendingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final transaction = createMockTransactionMessageWithSigners([signer]);
+
+      expect(
+        () => assertIsTransactionMessageWithSingleSendingSigner(transaction),
+        returnsNormally,
+      );
+    });
+
+    test('succeeds if a transaction contains multiple sending signer'
+        ' composites', () {
+      final signerA = MockTransactionCompositeSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionCompositeSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final transaction = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+      ]);
+
+      expect(
+        () => assertIsTransactionMessageWithSingleSendingSigner(transaction),
+        returnsNormally,
+      );
+    });
+
+    test('fails if a transaction message contains multiple sending only'
+        ' signers', () {
+      final signerA = MockTransactionSendingSigner(
+        const Address('11111111111111111111111111111111'),
+      );
+      final signerB = MockTransactionSendingSigner(
+        const Address('22222222222222222222222222222222'),
+      );
+      final transaction = createMockTransactionMessageWithSigners([
+        signerA,
+        signerB,
+      ]);
+
+      expect(
+        () => assertIsTransactionMessageWithSingleSendingSigner(transaction),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.signerTransactionCannotHaveMultipleSendingSigners,
+          ),
+        ),
+      );
+    });
+
+    test(
+      'fails if a transaction message contains no sending signer at all',
+      () {
+        final signerA = MockTransactionPartialSigner(
+          const Address('11111111111111111111111111111111'),
+        );
+        final signerB = MockTransactionModifyingSigner(
+          const Address('22222222222222222222222222222222'),
+        );
+        final transaction = createMockTransactionMessageWithSigners([
+          signerA,
+          signerB,
+        ]);
+
+        expect(
+          () => assertIsTransactionMessageWithSingleSendingSigner(transaction),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.signerTransactionSendingSignerMissing,
+            ),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -140,19 +140,19 @@
 
 ### solana_kit_transactions (~15 source files, ~17 test files)
 
-- [ ] T049 [US1] Port Transaction type, compilation, wire format from `.repos/kit/packages/transactions/src/` to `packages/solana_kit_transactions/lib/src/`
-- [ ] T050 [US1] Port signing, size calculation, base64 wire encoding in `packages/solana_kit_transactions/lib/src/`
-- [ ] T051 [US1] Port signature extraction and full-signature assertion in `packages/solana_kit_transactions/lib/src/`
-- [ ] T052 [US1] Update barrel export `packages/solana_kit_transactions/lib/solana_kit_transactions.dart`
-- [ ] T053 [US1] Port all 17 test files from `.repos/kit/packages/transactions/src/__tests__/` to `packages/solana_kit_transactions/test/`
+- [x] T049 [US1] Port Transaction type, compilation, wire format from `.repos/kit/packages/transactions/src/` to `packages/solana_kit_transactions/lib/src/`
+- [x] T050 [US1] Port signing, size calculation, base64 wire encoding in `packages/solana_kit_transactions/lib/src/`
+- [x] T051 [US1] Port signature extraction and full-signature assertion in `packages/solana_kit_transactions/lib/src/`
+- [x] T052 [US1] Update barrel export `packages/solana_kit_transactions/lib/solana_kit_transactions.dart`
+- [x] T053 [US1] Port all 17 test files from `.repos/kit/packages/transactions/src/__tests__/` to `packages/solana_kit_transactions/test/`
 
 ### solana_kit_signers (~22 source files, ~33 test files)
 
-- [ ] T054 [US1] Port signer interfaces (TransactionSigner, MessageSigner, TransactionPartialSigner, TransactionModifyingSigner, TransactionSendingSigner) from `.repos/kit/packages/signers/src/` to `packages/solana_kit_signers/lib/src/`
-- [ ] T055 [US1] Port KeyPairSigner, NoopSigner implementations in `packages/solana_kit_signers/lib/src/`
-- [ ] T056 [US1] Port signer utilities (createKeyPairSignerFromKeyPair, isTransactionSigner, assertIsTransactionSigner) in `packages/solana_kit_signers/lib/src/`
-- [ ] T057 [US1] Update barrel export `packages/solana_kit_signers/lib/solana_kit_signers.dart`
-- [ ] T058 [US1] Port all 33 test files from `.repos/kit/packages/signers/src/__tests__/` to `packages/solana_kit_signers/test/`
+- [x] T054 [US1] Port signer interfaces (TransactionSigner, MessageSigner, TransactionPartialSigner, TransactionModifyingSigner, TransactionSendingSigner) from `.repos/kit/packages/signers/src/` to `packages/solana_kit_signers/lib/src/`
+- [x] T055 [US1] Port KeyPairSigner, NoopSigner implementations in `packages/solana_kit_signers/lib/src/`
+- [x] T056 [US1] Port signer utilities (createKeyPairSignerFromKeyPair, isTransactionSigner, assertIsTransactionSigner) in `packages/solana_kit_signers/lib/src/`
+- [x] T057 [US1] Update barrel export `packages/solana_kit_signers/lib/solana_kit_signers.dart`
+- [x] T058 [US1] Port all 33 test files from `.repos/kit/packages/signers/src/__tests__/` to `packages/solana_kit_signers/test/`
 
 ### solana_kit_offchain_messages (~26 source files, ~11 test files)
 


### PR DESCRIPTION
## Summary

- Implements `solana_kit_signers` package ported from `@solana/signers`
- Five core signer interfaces: `MessagePartialSigner`, `MessageModifyingSigner`, `TransactionPartialSigner`, `TransactionModifyingSigner`, `TransactionSendingSigner`
- Composite types: `MessageSigner`, `TransactionSigner`, `KeyPairSigner` with Ed25519 signing
- `NoopSigner` for adding signature slots without actual signing
- Transaction message signing utilities: `partiallySignTransactionMessageWithSigners`, `signTransactionMessageWithSigners`, `signAndSendTransactionMessageWithSigners`
- Signer extraction from instructions and transaction messages via account meta
- Fee payer signer utilities and signer deduplication helpers
- 88 tests passing

## Test plan

- [x] `dart test packages/solana_kit_signers` — 88 tests pass
- [x] `dart analyze packages/solana_kit_signers` — no issues
- [x] `dart format --set-exit-if-changed packages/solana_kit_signers` — clean