### PR TITLE
✨ feat: implement RPC types package

### DIFF
--- a/.changeset/rpc-types.md
+++ b/.changeset/rpc-types.md
@@ -1,0 +1,22 @@
+---
+solana_kit_rpc_types: minor
+---
+
+Implement RPC types package ported from `@solana/rpc-types`.
+
+**solana_kit_rpc_types** (85 tests):
+
+- `Blockhash` extension type with validation, codec (32-byte base58), and comparator
+- `Lamports` extension type (0 to 2^64-1) with generic encoder/decoder/codec wrappers
+- `UnixTimestamp` extension type (i64 range) with validation
+- `StringifiedBigInt` and `StringifiedNumber` extension types with validation
+- `Commitment` enum (processed, confirmed, finalized) with comparator
+- `MicroLamports`, `SignedLamports`, `Slot`, `Epoch` type aliases
+- Encoded data types: `Base58EncodedBytes`, `Base64EncodedBytes`, data response records
+- Account info types: `AccountInfoBase` and encoding-specific variants
+- `TokenAmount`, `TokenBalance` for SPL token data
+- `TransactionError` and `InstructionError` sealed class hierarchies
+- `TransactionVersion`, `Reward`, `TransactionStatus` types
+- Cluster URL types: `MainnetUrl`, `DevnetUrl`, `TestnetUrl`
+- `SolanaRpcResponse<T>` wrapper with slot context
+- Account filter types: `DataSlice`, memcmp and datasize filters

--- a/packages/solana_kit_rpc_types/lib/solana_kit_rpc_types.dart
+++ b/packages/solana_kit_rpc_types/lib/solana_kit_rpc_types.dart
@@ -1,1 +1,16 @@
-
+export 'src/account_filter.dart';
+export 'src/account_info.dart';
+export 'src/blockhash.dart';
+export 'src/cluster_url.dart';
+export 'src/commitment.dart';
+export 'src/encoded_bytes.dart';
+export 'src/lamports.dart';
+export 'src/rpc_response.dart';
+export 'src/stringified_bigint.dart';
+export 'src/stringified_number.dart';
+export 'src/token_amount.dart';
+export 'src/token_balance.dart';
+export 'src/transaction_error.dart';
+export 'src/transaction_types.dart';
+export 'src/typed_numbers.dart';
+export 'src/unix_timestamp.dart';

--- a/packages/solana_kit_rpc_types/lib/src/account_filter.dart
+++ b/packages/solana_kit_rpc_types/lib/src/account_filter.dart
@@ -1,0 +1,69 @@
+import 'package:solana_kit_rpc_types/src/encoded_bytes.dart';
+
+/// Describes a slice of account data to retrieve.
+class DataSlice {
+  const DataSlice({required this.length, required this.offset});
+
+  /// The number of bytes to return.
+  final int length;
+
+  /// The byte offset from which to start reading.
+  final int offset;
+}
+
+/// A memory comparison filter for account data, using base58 encoding.
+class MemcmpFilterBase58 {
+  const MemcmpFilterBase58({required this.bytes, required this.offset});
+
+  /// The bytes to match, as a base-58 encoded string.
+  ///
+  /// Data is limited to a maximum of 128 decoded bytes.
+  final Base58EncodedBytes bytes;
+
+  /// The encoding used for the byte string.
+  String get encoding => 'base58';
+
+  /// The byte offset into the account data from which to start the
+  /// comparison.
+  final BigInt offset;
+}
+
+/// A memory comparison filter for account data, using base64 encoding.
+class MemcmpFilterBase64 {
+  const MemcmpFilterBase64({required this.bytes, required this.offset});
+
+  /// The bytes to match, as a base-64 encoded string.
+  ///
+  /// Data is limited to a maximum of 128 decoded bytes.
+  final Base64EncodedBytes bytes;
+
+  /// The encoding used for the byte string.
+  String get encoding => 'base64';
+
+  /// The byte offset into the account data from which to start the
+  /// comparison.
+  final BigInt offset;
+}
+
+/// A memory comparison filter for getProgramAccounts.
+///
+/// This filter matches when the bytes supplied are equal to the account data
+/// at the given offset.
+class GetProgramAccountsMemcmpFilter {
+  const GetProgramAccountsMemcmpFilter({required this.memcmp});
+
+  /// The memory comparison parameters.
+  ///
+  /// Either a [MemcmpFilterBase58] or [MemcmpFilterBase64].
+  final Object memcmp;
+}
+
+/// A data size filter for getProgramAccounts.
+///
+/// This filter matches when the account data length is equal to [dataSize].
+class GetProgramAccountsDatasizeFilter {
+  const GetProgramAccountsDatasizeFilter({required this.dataSize});
+
+  /// The expected data size in bytes.
+  final BigInt dataSize;
+}

--- a/packages/solana_kit_rpc_types/lib/src/account_info.dart
+++ b/packages/solana_kit_rpc_types/lib/src/account_info.dart
@@ -1,0 +1,127 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+import 'package:solana_kit_rpc_types/src/encoded_bytes.dart';
+import 'package:solana_kit_rpc_types/src/lamports.dart';
+
+/// Base account information shared by all account info variants.
+class AccountInfoBase {
+  const AccountInfoBase({
+    required this.executable,
+    required this.lamports,
+    required this.owner,
+    required this.space,
+  });
+
+  /// Indicates if the account contains a program (and is strictly read-only).
+  final bool executable;
+
+  /// Number of lamports assigned to this account.
+  final Lamports lamports;
+
+  /// Address of the program this account has been assigned to.
+  final Address owner;
+
+  /// The size of the account data in bytes (excluding the 128 bytes of
+  /// header).
+  final BigInt space;
+}
+
+/// Account info with base58-encoded bytes as data.
+@Deprecated('Use AccountInfoWithBase64EncodedData instead')
+class AccountInfoWithBase58Bytes {
+  @Deprecated('Use AccountInfoWithBase64EncodedData instead')
+  const AccountInfoWithBase58Bytes({required this.data});
+
+  /// The account data as base58-encoded bytes.
+  final Base58EncodedBytes data;
+}
+
+/// Account info with base58-encoded data response.
+@Deprecated('Use AccountInfoWithBase64EncodedData instead')
+class AccountInfoWithBase58EncodedData {
+  @Deprecated('Use AccountInfoWithBase64EncodedData instead')
+  const AccountInfoWithBase58EncodedData({required this.data});
+
+  /// The account data as a (base58String, 'base58') tuple.
+  final Base58EncodedDataResponse data;
+}
+
+/// Account info with base64-encoded data.
+class AccountInfoWithBase64EncodedData {
+  const AccountInfoWithBase64EncodedData({required this.data});
+
+  /// The account data as a (base64String, 'base64') tuple.
+  final Base64EncodedDataResponse data;
+}
+
+/// Account info with base64-encoded zstd-compressed data.
+class AccountInfoWithBase64EncodedZStdCompressedData {
+  const AccountInfoWithBase64EncodedZStdCompressedData({required this.data});
+
+  /// The account data as a (base64+zstdString, 'base64+zstd') tuple.
+  final Base64EncodedZStdCompressedDataResponse data;
+}
+
+/// Parsed account data from jsonParsed encoding.
+class ParsedAccountData {
+  const ParsedAccountData({
+    required this.type,
+    required this.program,
+    required this.space,
+    this.info,
+  });
+
+  /// The parsed info, if available.
+  final Map<String, Object?>? info;
+
+  /// A label that indicates the type of the account data.
+  final String type;
+
+  /// Name of the program that owns this account.
+  final String program;
+
+  /// The size of the account data.
+  final BigInt space;
+}
+
+/// Account info data for jsonParsed encoding - can be either parsed data or
+/// fall back to base64 encoding.
+sealed class AccountInfoJsonData {
+  const AccountInfoJsonData();
+}
+
+/// Parsed account data variant.
+class AccountInfoJsonDataParsed extends AccountInfoJsonData {
+  const AccountInfoJsonDataParsed({required this.parsed});
+
+  /// The parsed account data.
+  final ParsedAccountData parsed;
+}
+
+/// Fallback base64-encoded data variant (used when jsonParsed encoding is
+/// requested but a parser cannot be found).
+class AccountInfoJsonDataBase64 extends AccountInfoJsonData {
+  const AccountInfoJsonDataBase64({required this.data});
+
+  /// The account data as a (base64String, 'base64') tuple.
+  final Base64EncodedDataResponse data;
+}
+
+/// Account info with json-parsed data.
+class AccountInfoWithJsonData {
+  const AccountInfoWithJsonData({required this.data});
+
+  /// The account data, either parsed or base64-encoded.
+  final AccountInfoJsonData data;
+}
+
+/// Wraps account info with the account's public key.
+class AccountInfoWithPubkey<TAccount extends AccountInfoBase> {
+  const AccountInfoWithPubkey({required this.account, required this.pubkey});
+
+  /// The account information.
+  final TAccount account;
+
+  /// The public key of the account.
+  final Address pubkey;
+}

--- a/packages/solana_kit_rpc_types/lib/src/blockhash.dart
+++ b/packages/solana_kit_rpc_types/lib/src/blockhash.dart
@@ -1,0 +1,132 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+/// A Solana blockhash represented as a validated base58-encoded string.
+///
+/// A [Blockhash] wraps a [String] that has been validated to be a
+/// base58-encoded representation of exactly 32 bytes. This is an extension
+/// type so it has zero runtime overhead compared to a plain [String].
+///
+/// Use the [blockhash] factory function to create a [Blockhash] from an
+/// untrusted string.
+extension type const Blockhash(String value) {}
+
+/// Returns `true` if [putativeBlockhash] is a valid base58-encoded blockhash.
+bool isBlockhash(String putativeBlockhash) {
+  return isAddress(putativeBlockhash);
+}
+
+/// Asserts that [putativeBlockhash] is a valid base58-encoded blockhash.
+///
+/// A valid blockhash has the same format as an address: a string length
+/// between 32 and 44 characters that decodes to exactly 32 bytes.
+///
+/// Throws [SolanaError] with [SolanaErrorCode.blockhashStringLengthOutOfRange]
+/// if the string length is outside [32, 44].
+///
+/// Throws [SolanaError] with [SolanaErrorCode.invalidBlockhashByteLength]
+/// if the decoded byte array is not exactly 32 bytes.
+void assertIsBlockhash(String putativeBlockhash) {
+  try {
+    assertIsAddress(putativeBlockhash);
+  } on SolanaError catch (error) {
+    if (isSolanaError(error, SolanaErrorCode.addressesStringLengthOutOfRange)) {
+      throw SolanaError(
+        SolanaErrorCode.blockhashStringLengthOutOfRange,
+        error.context,
+      );
+    }
+    if (isSolanaError(error, SolanaErrorCode.addressesInvalidByteLength)) {
+      throw SolanaError(
+        SolanaErrorCode.invalidBlockhashByteLength,
+        error.context,
+      );
+    }
+    rethrow;
+  }
+}
+
+/// Creates a [Blockhash] from a string, asserting that it is a valid
+/// base58-encoded blockhash.
+///
+/// Throws a [SolanaError] if the string is not a valid blockhash.
+Blockhash blockhash(String putativeBlockhash) {
+  assertIsBlockhash(putativeBlockhash);
+  return Blockhash(putativeBlockhash);
+}
+
+/// Returns a fixed-size encoder that encodes a base58-encoded blockhash
+/// into exactly 32 bytes.
+FixedSizeEncoder<Blockhash> getBlockhashEncoder() {
+  final addressEncoder = getAddressEncoder();
+  return transformEncoder<Address, Blockhash>(addressEncoder, (bh) {
+        assertIsBlockhash(bh.value);
+        return Address(bh.value);
+      })
+      as FixedSizeEncoder<Blockhash>;
+}
+
+/// Returns a fixed-size decoder that decodes exactly 32 bytes into a
+/// base58-encoded [Blockhash].
+FixedSizeDecoder<Blockhash> getBlockhashDecoder() {
+  final addressDecoder = getAddressDecoder();
+  return transformDecoder<Address, Blockhash>(
+        addressDecoder,
+        (value, bytes, offset) => Blockhash(value.value),
+      )
+      as FixedSizeDecoder<Blockhash>;
+}
+
+/// Returns a fixed-size codec that encodes and decodes [Blockhash] values
+/// as exactly 32 bytes.
+FixedSizeCodec<Blockhash, Blockhash> getBlockhashCodec() {
+  return combineCodec(getBlockhashEncoder(), getBlockhashDecoder())
+      as FixedSizeCodec<Blockhash, Blockhash>;
+}
+
+/// Returns a [Comparator] that sorts blockhash strings using base58
+/// collation rules.
+///
+/// The comparator sorts blockhashes using a case-sensitive variant-aware
+/// string comparison where lowercase letters sort before uppercase. This
+/// matches the base58 alphabet ordering used by Solana.
+Comparator<String> getBlockhashComparator() {
+  return _compareBase58;
+}
+
+/// Compares two base58-encoded strings using character-by-character comparison
+/// according to the base58 alphabet ordering.
+int _compareBase58(String a, String b) {
+  final minLen = a.length < b.length ? a.length : b.length;
+  for (var i = 0; i < minLen; i++) {
+    final charA = a.codeUnitAt(i);
+    final charB = b.codeUnitAt(i);
+    if (charA != charB) {
+      final orderA = _charOrder(charA);
+      final orderB = _charOrder(charB);
+      return orderA.compareTo(orderB);
+    }
+  }
+  return a.length.compareTo(b.length);
+}
+
+/// Returns a sort-order value for a character code following ICU collation
+/// rules with caseFirst: 'lower' and sensitivity: 'variant'.
+int _charOrder(int codeUnit) {
+  // Digits 0-9 (codeUnits 48-57) sort first
+  if (codeUnit >= 48 && codeUnit <= 57) {
+    return codeUnit - 48; // 0-9
+  }
+  // Letters: lowercase before uppercase for same letter
+  if (codeUnit >= 97 && codeUnit <= 122) {
+    // lowercase letter: maps to (letter_index * 2 + 10)
+    return (codeUnit - 97) * 2 + 10;
+  }
+  if (codeUnit >= 65 && codeUnit <= 90) {
+    // uppercase letter: maps to (letter_index * 2 + 11)
+    return (codeUnit - 65) * 2 + 11;
+  }
+  // Fallback for non-alphanumeric characters
+  return codeUnit + 100;
+}

--- a/packages/solana_kit_rpc_types/lib/src/cluster_url.dart
+++ b/packages/solana_kit_rpc_types/lib/src/cluster_url.dart
@@ -1,0 +1,32 @@
+/// A branded URL string for Solana mainnet.
+extension type const MainnetUrl(String value) implements String {}
+
+/// A branded URL string for Solana devnet.
+extension type const DevnetUrl(String value) implements String {}
+
+/// A branded URL string for Solana testnet.
+extension type const TestnetUrl(String value) implements String {}
+
+/// A union type of all cluster URL types.
+///
+/// Can be a [MainnetUrl], [DevnetUrl], [TestnetUrl], or any arbitrary
+/// [String].
+typedef ClusterUrl = String;
+
+/// Given a URL, casts it to a type that is only accepted where mainnet URLs
+/// are expected.
+MainnetUrl mainnet(String putativeString) {
+  return MainnetUrl(putativeString);
+}
+
+/// Given a URL, casts it to a type that is only accepted where devnet URLs
+/// are expected.
+DevnetUrl devnet(String putativeString) {
+  return DevnetUrl(putativeString);
+}
+
+/// Given a URL, casts it to a type that is only accepted where testnet URLs
+/// are expected.
+TestnetUrl testnet(String putativeString) {
+  return TestnetUrl(putativeString);
+}

--- a/packages/solana_kit_rpc_types/lib/src/commitment.dart
+++ b/packages/solana_kit_rpc_types/lib/src/commitment.dart
@@ -1,0 +1,44 @@
+/// A union of all possible commitment statuses -- each a measure of the
+/// network confirmation and stake levels on a particular block.
+///
+/// Read more about the statuses themselves at
+/// https://docs.solana.com/cluster/commitments.
+enum Commitment {
+  /// The node will query the most recent block confirmed by supermajority of
+  /// the cluster as having reached maximum lockout, meaning the cluster has
+  /// recognized this block as finalized.
+  finalized,
+
+  /// The node will query the most recent block that has been voted on by
+  /// supermajority of the cluster.
+  confirmed,
+
+  /// The node will query its most recent block. Note that the block may still
+  /// be skipped by the cluster.
+  processed,
+}
+
+/// Returns a [Comparator] that sorts [Commitment] values according to their
+/// level of finality in ascending order (processed < confirmed < finalized).
+Comparator<Commitment> getCommitmentComparator() {
+  return commitmentComparator;
+}
+
+/// Compares two [Commitment] values according to their level of finality.
+///
+/// Returns:
+/// - `-1` if [a] has a lower finality level than [b]
+/// - `0` if [a] and [b] have the same finality level
+/// - `1` if [a] has a higher finality level than [b]
+int commitmentComparator(Commitment a, Commitment b) {
+  if (a == b) return 0;
+  return _getCommitmentScore(a) < _getCommitmentScore(b) ? -1 : 1;
+}
+
+int _getCommitmentScore(Commitment commitment) {
+  return switch (commitment) {
+    Commitment.finalized => 2,
+    Commitment.confirmed => 1,
+    Commitment.processed => 0,
+  };
+}

--- a/packages/solana_kit_rpc_types/lib/src/encoded_bytes.dart
+++ b/packages/solana_kit_rpc_types/lib/src/encoded_bytes.dart
@@ -1,0 +1,22 @@
+/// A base58-encoded byte string.
+extension type const Base58EncodedBytes(String value) implements String {}
+
+/// A base64-encoded byte string.
+extension type const Base64EncodedBytes(String value) implements String {}
+
+/// A base64-encoded zstd-compressed byte string.
+extension type const Base64EncodedZStdCompressedBytes(String value)
+    implements String {}
+
+/// A tuple of base58-encoded data and the encoding label `'base58'`.
+typedef Base58EncodedDataResponse = (Base58EncodedBytes data, String encoding);
+
+/// A tuple of base64-encoded data and the encoding label `'base64'`.
+typedef Base64EncodedDataResponse = (Base64EncodedBytes data, String encoding);
+
+/// A tuple of base64-encoded zstd-compressed data and the encoding label
+/// `'base64+zstd'`.
+typedef Base64EncodedZStdCompressedDataResponse = (
+  Base64EncodedZStdCompressedBytes data,
+  String encoding,
+);

--- a/packages/solana_kit_rpc_types/lib/src/lamports.dart
+++ b/packages/solana_kit_rpc_types/lib/src/lamports.dart
@@ -1,0 +1,208 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+/// Represents an integer value denominated in Lamports (ie. 1e-9 SOL).
+///
+/// It is represented as a [BigInt] in client code and a `u64` in server code.
+extension type const Lamports(BigInt value) implements Object {}
+
+/// Largest possible value to be represented by a u64.
+final BigInt _maxU64Value = BigInt.parse('18446744073709551615'); // 2^64 - 1
+
+/// Memoized U64 encoder/decoder instances.
+FixedSizeEncoder<BigInt>? _memoizedU64Encoder;
+FixedSizeDecoder<BigInt>? _memoizedU64Decoder;
+
+FixedSizeEncoder<BigInt> _getMemoizedU64Encoder() {
+  return _memoizedU64Encoder ??= getU64Encoder();
+}
+
+FixedSizeDecoder<BigInt> _getMemoizedU64Decoder() {
+  return _memoizedU64Decoder ??= getU64Decoder();
+}
+
+/// Returns `true` if [putativeLamports] is within the valid range for
+/// [Lamports] (0 to 2^64-1).
+bool isLamports(BigInt putativeLamports) {
+  return putativeLamports >= BigInt.zero && putativeLamports <= _maxU64Value;
+}
+
+/// Asserts that [putativeLamports] is a valid number of [Lamports].
+///
+/// Throws a [SolanaError] with code [SolanaErrorCode.lamportsOutOfRange] if
+/// the value is negative or exceeds the u64 maximum.
+void assertIsLamports(BigInt putativeLamports) {
+  if (putativeLamports < BigInt.zero || putativeLamports > _maxU64Value) {
+    throw SolanaError(SolanaErrorCode.lamportsOutOfRange);
+  }
+}
+
+/// Combines asserting that a [BigInt] is a possible number of [Lamports]
+/// with coercing it to the [Lamports] type. It's best used with untrusted
+/// input.
+Lamports lamports(BigInt putativeLamports) {
+  assertIsLamports(putativeLamports);
+  return Lamports(putativeLamports);
+}
+
+/// Returns a fixed-size encoder that encodes a 64-bit [Lamports] value to
+/// 8 bytes in little endian order.
+FixedSizeEncoder<Lamports> getDefaultLamportsEncoder() {
+  return _lamportsEncoderForBigInt(_getMemoizedU64Encoder())
+      as FixedSizeEncoder<Lamports>;
+}
+
+/// Returns an encoder that encodes a [Lamports] value to a byte array using
+/// the provided [innerEncoder].
+///
+/// The inner encoder determines how the numeric value is encoded. It can be
+/// an encoder for [BigInt] (e.g. u64) or [num] (e.g. u8, u16).
+Encoder<Lamports> getLamportsEncoder(Encoder<Object?> innerEncoder) {
+  if (innerEncoder is Encoder<BigInt>) {
+    return _lamportsEncoderForBigInt(innerEncoder);
+  }
+  return _lamportsEncoderForNum(innerEncoder as Encoder<num>);
+}
+
+Encoder<Lamports> _lamportsEncoderForBigInt(Encoder<BigInt> innerEncoder) {
+  return transformEncoder<BigInt, Lamports>(innerEncoder, (l) => l.value);
+}
+
+Encoder<Lamports> _lamportsEncoderForNum(Encoder<num> innerEncoder) {
+  return switch (innerEncoder) {
+    FixedSizeEncoder<num>() => FixedSizeEncoder<Lamports>(
+      fixedSize: innerEncoder.fixedSize,
+      write: (value, bytes, offset) =>
+          innerEncoder.write(value.value.toInt(), bytes, offset),
+    ),
+    VariableSizeEncoder<num>() => VariableSizeEncoder<Lamports>(
+      getSizeFromValue: (value) =>
+          innerEncoder.getSizeFromValue(value.value.toInt()),
+      write: (value, bytes, offset) =>
+          innerEncoder.write(value.value.toInt(), bytes, offset),
+      maxSize: innerEncoder.maxSize,
+    ),
+  };
+}
+
+/// Returns a fixed-size decoder that decodes a byte array representing a
+/// 64-bit little endian number to a [Lamports] value.
+FixedSizeDecoder<Lamports> getDefaultLamportsDecoder() {
+  return _lamportsDecoderForBigInt(_getMemoizedU64Decoder())
+      as FixedSizeDecoder<Lamports>;
+}
+
+/// Returns a decoder that converts an array of bytes representing a number
+/// to a [Lamports] value using the provided [innerDecoder].
+///
+/// The inner decoder determines how many bits are used to decode the numeric
+/// value. It can be a decoder for [BigInt] (e.g. u64) or [int] (e.g. u8,
+/// u16).
+Decoder<Lamports> getLamportsDecoder(Decoder<Object?> innerDecoder) {
+  if (innerDecoder is Decoder<BigInt>) {
+    return _lamportsDecoderForBigInt(innerDecoder);
+  }
+  return _lamportsDecoderForInt(innerDecoder as Decoder<int>);
+}
+
+Decoder<Lamports> _lamportsDecoderForBigInt(Decoder<BigInt> innerDecoder) {
+  return transformDecoder<BigInt, Lamports>(
+    innerDecoder,
+    (value, bytes, offset) => lamports(value),
+  );
+}
+
+Decoder<Lamports> _lamportsDecoderForInt(Decoder<int> innerDecoder) {
+  return switch (innerDecoder) {
+    FixedSizeDecoder<int>() => FixedSizeDecoder<Lamports>(
+      fixedSize: innerDecoder.fixedSize,
+      read: (Uint8List bytes, int offset) {
+        final (value, newOffset) = innerDecoder.read(bytes, offset);
+        return (lamports(BigInt.from(value)), newOffset);
+      },
+    ),
+    VariableSizeDecoder<int>() => VariableSizeDecoder<Lamports>(
+      read: (Uint8List bytes, int offset) {
+        final (value, newOffset) = innerDecoder.read(bytes, offset);
+        return (lamports(BigInt.from(value)), newOffset);
+      },
+      maxSize: innerDecoder.maxSize,
+    ),
+  };
+}
+
+/// Returns a fixed-size codec that encodes from or decodes to a 64-bit
+/// [Lamports] value.
+FixedSizeCodec<Lamports, Lamports> getDefaultLamportsCodec() {
+  return combineCodec(getDefaultLamportsEncoder(), getDefaultLamportsDecoder())
+      as FixedSizeCodec<Lamports, Lamports>;
+}
+
+/// Returns a codec that encodes from or decodes to a [Lamports] value using
+/// the provided [innerCodec].
+///
+/// The inner codec can be for [BigInt] (e.g. u64) or [num]/[int] (e.g. u8,
+/// u16).
+Codec<Lamports, Lamports> getLamportsCodec(Object innerCodec) {
+  if (innerCodec is Codec<BigInt, BigInt>) {
+    return _lamportsCodecForBigInt(innerCodec);
+  }
+  // For num/int codecs (u8, u16, u32, etc.)
+  final codec = innerCodec as Codec<num, int>;
+  return _lamportsCodecForNum(codec);
+}
+
+Codec<Lamports, Lamports> _lamportsCodecForBigInt(
+  Codec<BigInt, BigInt> innerCodec,
+) {
+  return switch (innerCodec) {
+    FixedSizeCodec<BigInt, BigInt>() => FixedSizeCodec<Lamports, Lamports>(
+      fixedSize: innerCodec.fixedSize,
+      write: (value, bytes, offset) =>
+          innerCodec.write(value.value, bytes, offset),
+      read: (Uint8List bytes, int offset) {
+        final (value, newOffset) = innerCodec.read(bytes, offset);
+        return (lamports(value), newOffset);
+      },
+    ),
+    VariableSizeCodec<BigInt, BigInt>() =>
+      VariableSizeCodec<Lamports, Lamports>(
+        getSizeFromValue: (value) => innerCodec.getSizeFromValue(value.value),
+        write: (value, bytes, offset) =>
+            innerCodec.write(value.value, bytes, offset),
+        read: (Uint8List bytes, int offset) {
+          final (value, newOffset) = innerCodec.read(bytes, offset);
+          return (lamports(value), newOffset);
+        },
+        maxSize: innerCodec.maxSize,
+      ),
+  };
+}
+
+Codec<Lamports, Lamports> _lamportsCodecForNum(Codec<num, int> innerCodec) {
+  return switch (innerCodec) {
+    FixedSizeCodec<num, int>() => FixedSizeCodec<Lamports, Lamports>(
+      fixedSize: innerCodec.fixedSize,
+      write: (value, bytes, offset) =>
+          innerCodec.write(value.value.toInt(), bytes, offset),
+      read: (Uint8List bytes, int offset) {
+        final (value, newOffset) = innerCodec.read(bytes, offset);
+        return (lamports(BigInt.from(value)), newOffset);
+      },
+    ),
+    VariableSizeCodec<num, int>() => VariableSizeCodec<Lamports, Lamports>(
+      getSizeFromValue: (value) =>
+          innerCodec.getSizeFromValue(value.value.toInt()),
+      write: (value, bytes, offset) =>
+          innerCodec.write(value.value.toInt(), bytes, offset),
+      read: (Uint8List bytes, int offset) {
+        final (value, newOffset) = innerCodec.read(bytes, offset);
+        return (lamports(BigInt.from(value)), newOffset);
+      },
+      maxSize: innerCodec.maxSize,
+    ),
+  };
+}

--- a/packages/solana_kit_rpc_types/lib/src/rpc_response.dart
+++ b/packages/solana_kit_rpc_types/lib/src/rpc_response.dart
@@ -1,0 +1,21 @@
+import 'package:solana_kit_rpc_types/src/typed_numbers.dart';
+
+/// Context information included with every RPC response.
+class RpcResponseContext {
+  const RpcResponseContext({required this.slot});
+
+  /// The slot at which the response was generated.
+  final Slot slot;
+}
+
+/// A standard Solana RPC response wrapper containing a [context] and a
+/// [value].
+class SolanaRpcResponse<TValue> {
+  const SolanaRpcResponse({required this.context, required this.value});
+
+  /// The context in which this response was generated.
+  final RpcResponseContext context;
+
+  /// The response value.
+  final TValue value;
+}

--- a/packages/solana_kit_rpc_types/lib/src/stringified_bigint.dart
+++ b/packages/solana_kit_rpc_types/lib/src/stringified_bigint.dart
@@ -1,0 +1,30 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+/// Represents a `BigInt` which has been encoded as a string for transit over a
+/// transport that does not support `BigInt` values natively. The JSON-RPC is
+/// such a transport.
+extension type const StringifiedBigInt(String value) implements String {}
+
+/// Returns `true` if [putativeBigInt] can be parsed as a [BigInt].
+bool isStringifiedBigInt(String putativeBigInt) {
+  return BigInt.tryParse(putativeBigInt) != null;
+}
+
+/// Asserts that [putativeBigInt] can be parsed as a [BigInt].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.malformedBigintString] if the string cannot be parsed.
+void assertIsStringifiedBigInt(String putativeBigInt) {
+  if (BigInt.tryParse(putativeBigInt) == null) {
+    throw SolanaError(SolanaErrorCode.malformedBigintString, {
+      'value': putativeBigInt,
+    });
+  }
+}
+
+/// Combines asserting that a string will parse as a `BigInt` with coercing
+/// it to the [StringifiedBigInt] type. It's best used with untrusted input.
+StringifiedBigInt stringifiedBigInt(String putativeBigInt) {
+  assertIsStringifiedBigInt(putativeBigInt);
+  return StringifiedBigInt(putativeBigInt);
+}

--- a/packages/solana_kit_rpc_types/lib/src/stringified_number.dart
+++ b/packages/solana_kit_rpc_types/lib/src/stringified_number.dart
@@ -1,0 +1,30 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+/// Represents a number which has been encoded as a string for transit over a
+/// transport where loss of precision when using the native number type is a
+/// concern. The JSON-RPC is such a transport.
+extension type const StringifiedNumber(String value) implements String {}
+
+/// Returns `true` if [putativeNumber] can be parsed as a number.
+bool isStringifiedNumber(String putativeNumber) {
+  return double.tryParse(putativeNumber) != null;
+}
+
+/// Asserts that [putativeNumber] can be parsed as a number.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.malformedNumberString] if the string cannot be parsed.
+void assertIsStringifiedNumber(String putativeNumber) {
+  if (double.tryParse(putativeNumber) == null) {
+    throw SolanaError(SolanaErrorCode.malformedNumberString, {
+      'value': putativeNumber,
+    });
+  }
+}
+
+/// Combines asserting that a string will parse as a number with coercing
+/// it to the [StringifiedNumber] type. It's best used with untrusted input.
+StringifiedNumber stringifiedNumber(String putativeNumber) {
+  assertIsStringifiedNumber(putativeNumber);
+  return StringifiedNumber(putativeNumber);
+}

--- a/packages/solana_kit_rpc_types/lib/src/token_amount.dart
+++ b/packages/solana_kit_rpc_types/lib/src/token_amount.dart
@@ -1,0 +1,35 @@
+import 'package:solana_kit_rpc_types/src/stringified_bigint.dart';
+import 'package:solana_kit_rpc_types/src/stringified_number.dart';
+
+/// Represents a token amount as returned by the Solana RPC.
+class TokenAmount {
+  const TokenAmount({
+    required this.amount,
+    required this.decimals,
+    required this.uiAmountString,
+    @Deprecated('Use uiAmountString instead') this.uiAmount,
+  });
+
+  /// The quantity, in fractional units.
+  ///
+  /// If the token in question is configured to have 6 decimal places, the
+  /// value `1_000_000` would indicate a balance of one whole token.
+  final StringifiedBigInt amount;
+
+  /// A power of ten, the inverse of which defines the smallest fractional
+  /// unit of this token.
+  ///
+  /// A token configured to have 6 decimals is made up of fractional units
+  /// each representing 10^(-6) tokens.
+  final int decimals;
+
+  /// The balance as a floating-point number.
+  @Deprecated('Use uiAmountString instead')
+  final double? uiAmount;
+
+  /// The balance of whole tokens, as a string.
+  ///
+  /// The string representation will use a decimal when necessary, but will
+  /// never contain trailing zeros to the right of the decimal place.
+  final StringifiedNumber uiAmountString;
+}

--- a/packages/solana_kit_rpc_types/lib/src/token_balance.dart
+++ b/packages/solana_kit_rpc_types/lib/src/token_balance.dart
@@ -1,0 +1,30 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+import 'package:solana_kit_rpc_types/src/token_amount.dart';
+
+/// Represents a token balance for an account at a specific index in a
+/// transaction.
+class TokenBalance {
+  const TokenBalance({
+    required this.accountIndex,
+    required this.mint,
+    required this.uiTokenAmount,
+    this.owner,
+    this.programId,
+  });
+
+  /// Index of the account in which the token balance is provided for.
+  final int accountIndex;
+
+  /// Address of the token's mint.
+  final Address mint;
+
+  /// Address of token balance's owner.
+  final Address? owner;
+
+  /// Address of the Token program that owns the account.
+  final Address? programId;
+
+  /// The token amount details.
+  final TokenAmount uiTokenAmount;
+}

--- a/packages/solana_kit_rpc_types/lib/src/transaction_error.dart
+++ b/packages/solana_kit_rpc_types/lib/src/transaction_error.dart
@@ -1,0 +1,216 @@
+/// Represents an instruction-level error returned by the Solana runtime.
+///
+/// This is a sealed class hierarchy where most variants are simple string
+/// labels, while [InstructionErrorCustom] carries a custom program error
+/// code.
+sealed class InstructionError {
+  const InstructionError();
+
+  /// The string label for this instruction error (e.g. 'GenericError').
+  String get label;
+}
+
+/// A custom program error with a numeric code.
+class InstructionErrorCustom extends InstructionError {
+  const InstructionErrorCustom(this.code);
+
+  /// The custom error code from the program.
+  final int code;
+
+  @override
+  String get label => 'Custom';
+}
+
+/// A simple instruction error identified by its string label.
+class InstructionErrorSimple extends InstructionError {
+  const InstructionErrorSimple(this.label);
+
+  @override
+  final String label;
+}
+
+/// All known simple instruction error labels as constants.
+abstract final class InstructionErrorLabel {
+  static const String accountAlreadyInitialized = 'AccountAlreadyInitialized';
+  static const String accountBorrowFailed = 'AccountBorrowFailed';
+  static const String accountBorrowOutstanding = 'AccountBorrowOutstanding';
+  static const String accountDataSizeChanged = 'AccountDataSizeChanged';
+  static const String accountDataTooSmall = 'AccountDataTooSmall';
+  static const String accountNotExecutable = 'AccountNotExecutable';
+  static const String accountNotRentExempt = 'AccountNotRentExempt';
+  static const String arithmeticOverflow = 'ArithmeticOverflow';
+  static const String borshIoError = 'BorshIoError';
+  static const String builtinProgramsMustConsumeComputeUnits =
+      'BuiltinProgramsMustConsumeComputeUnits';
+  static const String callDepth = 'CallDepth';
+  static const String computationalBudgetExceeded =
+      'ComputationalBudgetExceeded';
+  static const String duplicateAccountIndex = 'DuplicateAccountIndex';
+  static const String duplicateAccountOutOfSync = 'DuplicateAccountOutOfSync';
+  static const String executableAccountNotRentExempt =
+      'ExecutableAccountNotRentExempt';
+  static const String executableDataModified = 'ExecutableDataModified';
+  static const String executableLamportChange = 'ExecutableLamportChange';
+  static const String executableModified = 'ExecutableModified';
+  static const String externalAccountDataModified =
+      'ExternalAccountDataModified';
+  static const String externalAccountLamportSpend =
+      'ExternalAccountLamportSpend';
+  static const String genericError = 'GenericError';
+  static const String illegalOwner = 'IllegalOwner';
+  static const String immutable = 'Immutable';
+  static const String incorrectAuthority = 'IncorrectAuthority';
+  static const String incorrectProgramId = 'IncorrectProgramId';
+  static const String insufficientFunds = 'InsufficientFunds';
+  static const String invalidAccountData = 'InvalidAccountData';
+  static const String invalidAccountOwner = 'InvalidAccountOwner';
+  static const String invalidArgument = 'InvalidArgument';
+  static const String invalidError = 'InvalidError';
+  static const String invalidInstructionData = 'InvalidInstructionData';
+  static const String invalidRealloc = 'InvalidRealloc';
+  static const String invalidSeeds = 'InvalidSeeds';
+  static const String maxAccountsDataAllocationsExceeded =
+      'MaxAccountsDataAllocationsExceeded';
+  static const String maxAccountsExceeded = 'MaxAccountsExceeded';
+  static const String maxInstructionTraceLengthExceeded =
+      'MaxInstructionTraceLengthExceeded';
+  static const String maxSeedLengthExceeded = 'MaxSeedLengthExceeded';
+  static const String missingAccount = 'MissingAccount';
+  static const String missingRequiredSignature = 'MissingRequiredSignature';
+  static const String modifiedProgramId = 'ModifiedProgramId';
+  static const String notEnoughAccountKeys = 'NotEnoughAccountKeys';
+  static const String privilegeEscalation = 'PrivilegeEscalation';
+  static const String programEnvironmentSetupFailure =
+      'ProgramEnvironmentSetupFailure';
+  static const String programFailedToCompile = 'ProgramFailedToCompile';
+  static const String programFailedToComplete = 'ProgramFailedToComplete';
+  static const String readonlyDataModified = 'ReadonlyDataModified';
+  static const String readonlyLamportChange = 'ReadonlyLamportChange';
+  static const String reentrancyNotAllowed = 'ReentrancyNotAllowed';
+  static const String rentEpochModified = 'RentEpochModified';
+  static const String unbalancedInstruction = 'UnbalancedInstruction';
+  static const String uninitializedAccount = 'UninitializedAccount';
+  static const String unsupportedProgramId = 'UnsupportedProgramId';
+  static const String unsupportedSysvar = 'UnsupportedSysvar';
+}
+
+/// Represents a transaction-level error returned by the Solana runtime.
+///
+/// This is a sealed class hierarchy where most variants are simple string
+/// labels, while some carry additional structured data.
+sealed class TransactionError {
+  const TransactionError();
+
+  /// The string label for this transaction error.
+  String get label;
+}
+
+/// A simple transaction error identified by its string label.
+class TransactionErrorSimple extends TransactionError {
+  const TransactionErrorSimple(this.label);
+
+  @override
+  final String label;
+}
+
+/// A transaction error indicating a duplicate instruction at the given index.
+class TransactionErrorDuplicateInstruction extends TransactionError {
+  const TransactionErrorDuplicateInstruction(this.instructionIndex);
+
+  /// The index of the duplicate instruction.
+  final int instructionIndex;
+
+  @override
+  String get label => 'DuplicateInstruction';
+}
+
+/// A transaction error wrapping an instruction-level error.
+class TransactionErrorInstructionError extends TransactionError {
+  const TransactionErrorInstructionError(
+    this.instructionIndex,
+    this.instructionError,
+  );
+
+  /// The index of the instruction that caused the error.
+  final int instructionIndex;
+
+  /// The instruction-level error.
+  final InstructionError instructionError;
+
+  @override
+  String get label => 'InstructionError';
+}
+
+/// A transaction error indicating insufficient funds for rent at the given
+/// account index.
+class TransactionErrorInsufficientFundsForRent extends TransactionError {
+  const TransactionErrorInsufficientFundsForRent(this.accountIndex);
+
+  /// The index of the account with insufficient funds for rent.
+  final int accountIndex;
+
+  @override
+  String get label => 'InsufficientFundsForRent';
+}
+
+/// A transaction error indicating that program execution is temporarily
+/// restricted for the given account index.
+class TransactionErrorProgramExecutionTemporarilyRestricted
+    extends TransactionError {
+  const TransactionErrorProgramExecutionTemporarilyRestricted(
+    this.accountIndex,
+  );
+
+  /// The index of the restricted account.
+  final int accountIndex;
+
+  @override
+  String get label => 'ProgramExecutionTemporarilyRestricted';
+}
+
+/// All known simple transaction error labels as constants.
+abstract final class TransactionErrorLabel {
+  static const String accountBorrowOutstanding = 'AccountBorrowOutstanding';
+  static const String accountInUse = 'AccountInUse';
+  static const String accountLoadedTwice = 'AccountLoadedTwice';
+  static const String accountNotFound = 'AccountNotFound';
+  static const String addressLookupTableNotFound = 'AddressLookupTableNotFound';
+  static const String alreadyProcessed = 'AlreadyProcessed';
+  static const String blockhashNotFound = 'BlockhashNotFound';
+  static const String callChainTooDeep = 'CallChainTooDeep';
+  static const String clusterMaintenance = 'ClusterMaintenance';
+  static const String insufficientFundsForFee = 'InsufficientFundsForFee';
+  static const String invalidAccountForFee = 'InvalidAccountForFee';
+  static const String invalidAccountIndex = 'InvalidAccountIndex';
+  static const String invalidAddressLookupTableData =
+      'InvalidAddressLookupTableData';
+  static const String invalidAddressLookupTableIndex =
+      'InvalidAddressLookupTableIndex';
+  static const String invalidAddressLookupTableOwner =
+      'InvalidAddressLookupTableOwner';
+  static const String invalidLoadedAccountsDataSizeLimit =
+      'InvalidLoadedAccountsDataSizeLimit';
+  static const String invalidProgramForExecution = 'InvalidProgramForExecution';
+  static const String invalidRentPayingAccount = 'InvalidRentPayingAccount';
+  static const String invalidWritableAccount = 'InvalidWritableAccount';
+  static const String maxLoadedAccountsDataSizeExceeded =
+      'MaxLoadedAccountsDataSizeExceeded';
+  static const String missingSignatureForFee = 'MissingSignatureForFee';
+  static const String programAccountNotFound = 'ProgramAccountNotFound';
+  static const String resanitizationNeeded = 'ResanitizationNeeded';
+  static const String sanitizeFailure = 'SanitizeFailure';
+  static const String signatureFailure = 'SignatureFailure';
+  static const String tooManyAccountLocks = 'TooManyAccountLocks';
+  static const String unbalancedTransaction = 'UnbalancedTransaction';
+  static const String unsupportedVersion = 'UnsupportedVersion';
+  static const String wouldExceedAccountDataBlockLimit =
+      'WouldExceedAccountDataBlockLimit';
+  static const String wouldExceedAccountDataTotalLimit =
+      'WouldExceedAccountDataTotalLimit';
+  static const String wouldExceedMaxAccountCostLimit =
+      'WouldExceedMaxAccountCostLimit';
+  static const String wouldExceedMaxBlockCostLimit =
+      'WouldExceedMaxBlockCostLimit';
+  static const String wouldExceedMaxVoteCostLimit =
+      'WouldExceedMaxVoteCostLimit';
+}

--- a/packages/solana_kit_rpc_types/lib/src/transaction_types.dart
+++ b/packages/solana_kit_rpc_types/lib/src/transaction_types.dart
@@ -1,0 +1,229 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+import 'package:solana_kit_rpc_types/src/encoded_bytes.dart';
+import 'package:solana_kit_rpc_types/src/lamports.dart';
+import 'package:solana_kit_rpc_types/src/token_balance.dart';
+import 'package:solana_kit_rpc_types/src/transaction_error.dart';
+import 'package:solana_kit_rpc_types/src/typed_numbers.dart';
+
+// ---------------------------------------------------------------------------
+// Transaction Version
+// ---------------------------------------------------------------------------
+
+/// The version of a transaction.
+///
+/// Either [TransactionVersionLegacy] or [TransactionVersionV0].
+sealed class TransactionVersion {
+  const TransactionVersion();
+}
+
+/// Legacy transaction version.
+class TransactionVersionLegacy extends TransactionVersion {
+  const TransactionVersionLegacy();
+
+  @override
+  String toString() => 'legacy';
+}
+
+/// Version 0 transaction.
+class TransactionVersionV0 extends TransactionVersion {
+  const TransactionVersionV0();
+
+  @override
+  String toString() => '0';
+}
+
+// ---------------------------------------------------------------------------
+// Address Table Lookup
+// ---------------------------------------------------------------------------
+
+/// An address lookup table reference within a versioned transaction.
+class AddressTableLookup {
+  const AddressTableLookup({
+    required this.accountKey,
+    required this.readonlyIndexes,
+    required this.writableIndexes,
+  });
+
+  /// Address of the address lookup table account.
+  final Address accountKey;
+
+  /// Indexes of accounts in a lookup table to load as read-only.
+  final List<int> readonlyIndexes;
+
+  /// Indexes of accounts in a lookup table to load as writable.
+  final List<int> writableIndexes;
+}
+
+// ---------------------------------------------------------------------------
+// Reward
+// ---------------------------------------------------------------------------
+
+/// Represents a reward credited or debited to an account.
+sealed class Reward {
+  const Reward();
+
+  /// The number of reward lamports credited or debited to the account.
+  SignedLamports get rewardLamports;
+
+  /// The account balance in lamports after the reward was applied.
+  Lamports get postBalance;
+
+  /// The address of the account that received the reward.
+  Address get pubkey;
+
+  /// The type of reward.
+  String get rewardType;
+}
+
+/// A fee or rent reward (no commission).
+class RewardFeeOrRent extends Reward {
+  const RewardFeeOrRent({
+    required this.rewardLamports,
+    required this.postBalance,
+    required this.pubkey,
+    required this.rewardType,
+  });
+
+  @override
+  final SignedLamports rewardLamports;
+
+  @override
+  final Lamports postBalance;
+
+  @override
+  final Address pubkey;
+
+  @override
+  final String rewardType;
+}
+
+/// A voting or staking reward (includes commission).
+class RewardVotingOrStaking extends Reward {
+  const RewardVotingOrStaking({
+    required this.rewardLamports,
+    required this.postBalance,
+    required this.pubkey,
+    required this.rewardType,
+    required this.commission,
+  });
+
+  @override
+  final SignedLamports rewardLamports;
+
+  @override
+  final Lamports postBalance;
+
+  @override
+  final Address pubkey;
+
+  @override
+  final String rewardType;
+
+  /// The vote account commission when the reward was credited.
+  final int commission;
+}
+
+// ---------------------------------------------------------------------------
+// Transaction Status (deprecated)
+// ---------------------------------------------------------------------------
+
+/// Deprecated transaction status type.
+@Deprecated('Use TransactionError instead')
+sealed class TransactionStatus {
+  @Deprecated('Use TransactionError instead')
+  const TransactionStatus();
+}
+
+/// Transaction succeeded.
+@Deprecated('Use TransactionError instead')
+class TransactionStatusOk extends TransactionStatus {
+  @Deprecated('Use TransactionError instead')
+  const TransactionStatusOk();
+}
+
+/// Transaction failed with an error.
+@Deprecated('Use TransactionError instead')
+class TransactionStatusErr extends TransactionStatus {
+  @Deprecated('Use TransactionError instead')
+  const TransactionStatusErr(this.error);
+
+  /// The error that caused the transaction to fail.
+  final TransactionError error;
+}
+
+// ---------------------------------------------------------------------------
+// Transaction Meta
+// ---------------------------------------------------------------------------
+
+/// Base transaction metadata shared by all transaction detail levels.
+class TransactionForAccountsMetaBase {
+  const TransactionForAccountsMetaBase({
+    required this.err,
+    required this.fee,
+    required this.postBalances,
+    required this.preBalances,
+    this.postTokenBalances,
+    this.preTokenBalances,
+  });
+
+  /// Error if transaction failed, `null` if transaction succeeded.
+  final TransactionError? err;
+
+  /// The fee this transaction was charged, in lamports.
+  final Lamports fee;
+
+  /// Account balances after the transaction was processed.
+  final List<Lamports> postBalances;
+
+  /// List of token balances from after the transaction was processed.
+  final List<TokenBalance>? postTokenBalances;
+
+  /// Account balances from before the transaction was processed.
+  final List<Lamports> preBalances;
+
+  /// List of token balances from before the transaction was processed.
+  final List<TokenBalance>? preTokenBalances;
+}
+
+// ---------------------------------------------------------------------------
+// Return Data
+// ---------------------------------------------------------------------------
+
+/// Return data from a transaction.
+class ReturnData {
+  const ReturnData({required this.data, required this.programId});
+
+  /// The return data as a base64-encoded response.
+  final Base64EncodedDataResponse data;
+
+  /// The address of the program that generated the return data.
+  final Address programId;
+}
+
+// ---------------------------------------------------------------------------
+// Parsed Account
+// ---------------------------------------------------------------------------
+
+/// A parsed account key in a transaction.
+class TransactionParsedAccount {
+  const TransactionParsedAccount({
+    required this.pubkey,
+    required this.signer,
+    required this.writable,
+    required this.source,
+  });
+
+  /// The address of the account.
+  final Address pubkey;
+
+  /// Whether this account is required to sign the transaction.
+  final bool signer;
+
+  /// Whether this account must be loaded with a write-lock.
+  final bool writable;
+
+  /// Indicates whether the account was statically declared in the transaction
+  /// message or loaded from an address lookup table.
+  final String source;
+}

--- a/packages/solana_kit_rpc_types/lib/src/typed_numbers.dart
+++ b/packages/solana_kit_rpc_types/lib/src/typed_numbers.dart
@@ -1,0 +1,24 @@
+/// Represents a slot number on the Solana blockchain.
+typedef Slot = BigInt;
+
+/// Represents an epoch number on the Solana blockchain.
+typedef Epoch = BigInt;
+
+/// Represents a quantity of micro-lamports (0.000001 lamports).
+///
+/// Micro-lamports are used for priority fee calculations. The value must be
+/// in the range 0 to 2^64-1.
+extension type const MicroLamports(BigInt value) implements Object {}
+
+/// Represents a signed quantity of lamports that can be negative.
+///
+/// This is used in contexts where a balance change can be either positive
+/// or negative, such as reward amounts.
+typedef SignedLamports = BigInt;
+
+/// A floating-point number returned by the RPC.
+///
+/// Beware that floating-point value precision can vary widely. For precision
+/// of 1 decimal place, anything above 562949953421311 and for precision of
+/// 2 decimal places, anything above 70368744177663 can be truncated or rounded.
+typedef F64UnsafeSeeDocumentation = double;

--- a/packages/solana_kit_rpc_types/lib/src/unix_timestamp.dart
+++ b/packages/solana_kit_rpc_types/lib/src/unix_timestamp.dart
@@ -1,0 +1,39 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+/// Represents a Unix timestamp in seconds.
+///
+/// It is represented as a [BigInt] in client code and an `i64` in server code.
+extension type const UnixTimestamp(BigInt value) implements Object {}
+
+/// Largest possible value to be represented by an i64.
+final BigInt _maxI64Value = BigInt.parse('9223372036854775807'); // 2^63 - 1
+
+/// Smallest possible value to be represented by an i64.
+final BigInt _minI64Value = BigInt.parse('-9223372036854775808'); // -(2^63)
+
+/// Returns `true` if [putativeTimestamp] is within the i64 range and thus
+/// a valid [UnixTimestamp].
+bool isUnixTimestamp(BigInt putativeTimestamp) {
+  return putativeTimestamp >= _minI64Value && putativeTimestamp <= _maxI64Value;
+}
+
+/// Asserts that [putativeTimestamp] is a valid [UnixTimestamp] within the i64
+/// range.
+///
+/// Throws a [SolanaError] with code [SolanaErrorCode.timestampOutOfRange] if
+/// the value is outside the valid range.
+void assertIsUnixTimestamp(BigInt putativeTimestamp) {
+  if (putativeTimestamp < _minI64Value || putativeTimestamp > _maxI64Value) {
+    throw SolanaError(SolanaErrorCode.timestampOutOfRange, {
+      'value': putativeTimestamp,
+    });
+  }
+}
+
+/// Combines asserting that a [BigInt] represents a Unix timestamp with
+/// coercing it to the [UnixTimestamp] type. It's best used with untrusted
+/// input.
+UnixTimestamp unixTimestamp(BigInt putativeTimestamp) {
+  assertIsUnixTimestamp(putativeTimestamp);
+  return UnixTimestamp(putativeTimestamp);
+}

--- a/packages/solana_kit_rpc_types/pubspec.yaml
+++ b/packages/solana_kit_rpc_types/pubspec.yaml
@@ -8,7 +8,12 @@ environment:
 resolution: workspace
 
 dependencies:
+  solana_kit_addresses:
+  solana_kit_codecs_core:
+  solana_kit_codecs_numbers:
+  solana_kit_codecs_strings:
   solana_kit_errors:
 
 dev_dependencies:
   solana_kit_lints:
+  test: ^1.25.0

--- a/packages/solana_kit_rpc_types/test/blockhash_test.dart
+++ b/packages/solana_kit_rpc_types/test/blockhash_test.dart
@@ -1,0 +1,197 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('assertIsBlockhash()', () {
+    test('throws when supplied a non-base58 string', () {
+      // This string is 41 chars (within 32-44 range) but contains
+      // invalid base58 chars (hyphens), so it throws a codec error.
+      expect(
+        () => assertIsBlockhash('not-a-base-58-encoded-string-but-nice-try'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.codecsInvalidStringForBase,
+          ),
+        ),
+      );
+    });
+
+    test('throws when the encoded string is of length 31', () {
+      expect(
+        () => assertIsBlockhash('1' * 31),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.blockhashStringLengthOutOfRange,
+          ),
+        ),
+      );
+    });
+
+    test('throws when the encoded string is of length 45', () {
+      expect(
+        () => assertIsBlockhash('1' * 45),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.blockhashStringLengthOutOfRange,
+          ),
+        ),
+      );
+    });
+
+    test('throws when the decoded byte array has a length of 31 bytes', () {
+      // 31-byte decoded value
+      expect(
+        () => assertIsBlockhash('tVojvhToWjQ8Xvo4UPx2Xz9eRy7auyYMmZBjc2XfN'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.invalidBlockhashByteLength,
+          ),
+        ),
+      );
+    });
+
+    test('throws when the decoded byte array has a length of 33 bytes', () {
+      expect(
+        () => assertIsBlockhash('JJEfe6DcPM2ziB2vfUWDV6aHVerXRGkv3TcyvJUNGHZz'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.invalidBlockhashByteLength,
+          ),
+        ),
+      );
+    });
+
+    test('does not throw when supplied a base-58 encoded hash', () {
+      expect(
+        () => assertIsBlockhash('11111111111111111111111111111111'),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('isBlockhash()', () {
+    test('returns true for a valid blockhash', () {
+      expect(isBlockhash('11111111111111111111111111111111'), isTrue);
+    });
+
+    test('returns false for a too-short string', () {
+      expect(isBlockhash('1' * 31), isFalse);
+    });
+
+    test('returns false for a too-long string', () {
+      expect(isBlockhash('1' * 45), isFalse);
+    });
+
+    test('returns false for a non-base58 string', () {
+      expect(isBlockhash('not-a-base-58-encoded-string'), isFalse);
+    });
+  });
+
+  group('blockhash()', () {
+    test('creates a Blockhash from a valid string', () {
+      const hash = '11111111111111111111111111111111';
+      final bh = blockhash(hash);
+      expect(bh.value, equals(hash));
+    });
+
+    test('throws for an invalid string', () {
+      expect(() => blockhash('invalid'), throwsA(isA<SolanaError>()));
+    });
+  });
+
+  group('getBlockhashCodec()', () {
+    late FixedSizeCodec<Blockhash, Blockhash> codec;
+
+    setUp(() {
+      codec = getBlockhashCodec();
+    });
+
+    test('serializes a base58 encoded blockhash into a 32-byte buffer', () {
+      const bh = Blockhash('4wBqpZM9xaSheZzJSMawUHDgZ7miWfSsxmfVF5jJpYP');
+      expect(
+        codec.encode(bh),
+        equals(
+          Uint8List.fromList([
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, //
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          ]),
+        ),
+      );
+    });
+
+    test('deserializes a byte buffer representing a blockhash '
+        'into a base58 encoded blockhash', () {
+      final bytes = Uint8List.fromList([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, //
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
+        // Extra bytes not part of the blockhash
+        33, 34,
+      ]);
+      expect(
+        codec.decode(bytes),
+        equals(const Blockhash('4wBqpZM9xaSheZzJSMawUKKwhdpChKbZ5eu5ky4Vigw')),
+      );
+    });
+
+    test(
+      'fatals when trying to deserialize a byte buffer shorter than 32 bytes',
+      () {
+        final tooShortBuffer = Uint8List(31);
+        expect(
+          () => codec.decode(tooShortBuffer),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.codecsInvalidByteLength,
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('getBlockhashComparator()', () {
+    test('sorts base 58 blockhashes', () {
+      final input = [
+        'Ht1VrhoyhwMGMpBBi89BPdJp5R39Mu49suKx3A22W9Qs',
+        'J9ZSLc9qPg3FR8UqfN6ae1QkVReUmnpLgQqFkGEPqmod',
+        '6JYSQqSHY1E5JDwEfgWMieozqA1KCwiP2cH69to9eWKH',
+        '7YR1xA7yzFAT4yQCsS4rpowjU1tsh5YUJd9hWMHRppcX',
+        '7grJ9YUAEHxckLFqCY7fq8cM1UrragNSuPH1dvwJ8EEK',
+        'AJBPNWCjVLwxff2eJynW56cMRCGmyU4y3vbuvtVdgVgb',
+        'B8A2zUEDtJjR7nrokNUJYhgUQiwEBzC88rZc6WUE5ZeF',
+        'BKggsVVp7yLmXtPuBDtC3FXBzvLyyye3Q2tFKUUGCHLj',
+        'Ds72joawSKQ9nCDAAmGMKFiwiY6HR7PDzYDHDzZom3tj',
+        'F1zKr4ZUYo5UAnH1fvYaD6R7ne137NYfS1r5HrCb8NpF',
+      ]..sort(getBlockhashComparator());
+
+      expect(input, [
+        '6JYSQqSHY1E5JDwEfgWMieozqA1KCwiP2cH69to9eWKH',
+        '7grJ9YUAEHxckLFqCY7fq8cM1UrragNSuPH1dvwJ8EEK',
+        '7YR1xA7yzFAT4yQCsS4rpowjU1tsh5YUJd9hWMHRppcX',
+        'AJBPNWCjVLwxff2eJynW56cMRCGmyU4y3vbuvtVdgVgb',
+        'B8A2zUEDtJjR7nrokNUJYhgUQiwEBzC88rZc6WUE5ZeF',
+        'BKggsVVp7yLmXtPuBDtC3FXBzvLyyye3Q2tFKUUGCHLj',
+        'Ds72joawSKQ9nCDAAmGMKFiwiY6HR7PDzYDHDzZom3tj',
+        'F1zKr4ZUYo5UAnH1fvYaD6R7ne137NYfS1r5HrCb8NpF',
+        'Ht1VrhoyhwMGMpBBi89BPdJp5R39Mu49suKx3A22W9Qs',
+        'J9ZSLc9qPg3FR8UqfN6ae1QkVReUmnpLgQqFkGEPqmod',
+      ]);
+    });
+  });
+}

--- a/packages/solana_kit_rpc_types/test/coercions_test.dart
+++ b/packages/solana_kit_rpc_types/test/coercions_test.dart
@@ -1,0 +1,87 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('coercions', () {
+    group('lamports', () {
+      test('can coerce to Lamports', () {
+        final coerced = lamports(BigInt.from(1234));
+        expect(coerced.value, equals(BigInt.from(1234)));
+      });
+
+      test('throws on invalid Lamports', () {
+        expect(
+          () => lamports(-BigInt.from(5)),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.lamportsOutOfRange,
+            ),
+          ),
+        );
+      });
+    });
+
+    group('stringifiedBigInt', () {
+      test('can coerce to StringifiedBigInt', () {
+        final coerced = stringifiedBigInt('1234');
+        expect(coerced, equals('1234'));
+      });
+
+      test('throws on invalid StringifiedBigInt', () {
+        expect(
+          () => stringifiedBigInt('test'),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.malformedBigintString,
+            ),
+          ),
+        );
+      });
+    });
+
+    group('stringifiedNumber', () {
+      test('can coerce to StringifiedNumber', () {
+        final coerced = stringifiedNumber('1234');
+        expect(coerced, equals('1234'));
+      });
+
+      test('throws on invalid StringifiedNumber', () {
+        expect(
+          () => stringifiedNumber('test'),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.malformedNumberString,
+            ),
+          ),
+        );
+      });
+    });
+
+    group('unixTimestamp', () {
+      test('can coerce to UnixTimestamp', () {
+        final coerced = unixTimestamp(BigInt.from(1234));
+        expect(coerced.value, equals(BigInt.from(1234)));
+      });
+
+      test('throws on an out-of-range UnixTimestamp', () {
+        expect(
+          () => unixTimestamp(BigInt.two.pow(63)),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.timestampOutOfRange,
+            ),
+          ),
+        );
+      });
+    });
+  });
+}

--- a/packages/solana_kit_rpc_types/test/commitment_test.dart
+++ b/packages/solana_kit_rpc_types/test/commitment_test.dart
@@ -1,0 +1,43 @@
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('commitmentComparator', () {
+    test(
+      'sorts commitments according to their level of finality ascending',
+      () {
+        final commitments = [
+          Commitment.finalized,
+          Commitment.processed,
+          Commitment.confirmed,
+        ]..sort(commitmentComparator);
+        expect(commitments, [
+          Commitment.processed,
+          Commitment.confirmed,
+          Commitment.finalized,
+        ]);
+      },
+    );
+
+    test('returns 0 for equal commitments', () {
+      expect(
+        commitmentComparator(Commitment.confirmed, Commitment.confirmed),
+        equals(0),
+      );
+    });
+
+    test('returns -1 when first is less final', () {
+      expect(
+        commitmentComparator(Commitment.processed, Commitment.confirmed),
+        equals(-1),
+      );
+    });
+
+    test('returns 1 when first is more final', () {
+      expect(
+        commitmentComparator(Commitment.finalized, Commitment.confirmed),
+        equals(1),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_rpc_types/test/lamports_test.dart
+++ b/packages/solana_kit_rpc_types/test/lamports_test.dart
@@ -1,0 +1,313 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('assertIsLamports()', () {
+    test('throws when supplied a negative number', () {
+      expect(
+        () => assertIsLamports(-BigInt.one),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.lamportsOutOfRange,
+          ),
+        ),
+      );
+      expect(
+        () => assertIsLamports(-BigInt.from(1000)),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.lamportsOutOfRange,
+          ),
+        ),
+      );
+    });
+
+    test('throws when supplied a too large number', () {
+      expect(
+        () => assertIsLamports(BigInt.two.pow(64)),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.lamportsOutOfRange,
+          ),
+        ),
+      );
+    });
+
+    test('does not throw when supplied zero lamports', () {
+      expect(() => assertIsLamports(BigInt.zero), returnsNormally);
+    });
+
+    test(
+      'does not throw when supplied a valid non-zero number of lamports',
+      () {
+        expect(
+          () => assertIsLamports(BigInt.from(1000000000)),
+          returnsNormally,
+        );
+      },
+    );
+
+    test('does not throw when supplied the max valid number of lamports', () {
+      expect(
+        () => assertIsLamports(BigInt.two.pow(64) - BigInt.one),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('isLamports()', () {
+    test('returns true for zero', () {
+      expect(isLamports(BigInt.zero), isTrue);
+    });
+
+    test('returns true for a valid value', () {
+      expect(isLamports(BigInt.from(1000000000)), isTrue);
+    });
+
+    test('returns true for max u64', () {
+      expect(isLamports(BigInt.two.pow(64) - BigInt.one), isTrue);
+    });
+
+    test('returns false for negative', () {
+      expect(isLamports(-BigInt.one), isFalse);
+    });
+
+    test('returns false for too large', () {
+      expect(isLamports(BigInt.two.pow(64)), isFalse);
+    });
+  });
+
+  group('lamports()', () {
+    test('can coerce to Lamports', () {
+      final coerced = lamports(BigInt.from(1234));
+      expect(coerced.value, equals(BigInt.from(1234)));
+    });
+
+    test('throws on invalid Lamports', () {
+      expect(
+        () => lamports(-BigInt.from(5)),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.lamportsOutOfRange,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('getDefaultLamportsEncoder', () {
+    test('encodes a lamports value using the default u64 encoder', () {
+      final lamportsValue = lamports(BigInt.from(1000000000));
+      final encoder = getDefaultLamportsEncoder();
+      final buffer = encoder.encode(lamportsValue);
+      expect(buffer, equals(Uint8List.fromList([0, 202, 154, 59, 0, 0, 0, 0])));
+    });
+
+    test('has a fixed size of 8', () {
+      final encoder = getDefaultLamportsEncoder();
+      expect(encoder.fixedSize, equals(8));
+    });
+  });
+
+  group('getLamportsEncoder', () {
+    test('encodes a lamports value using a passed u8 encoder', () {
+      final lamportsValue = lamports(BigInt.from(100));
+      final encoder = getLamportsEncoder(getU8Encoder());
+      final buffer = encoder.encode(lamportsValue);
+      expect(buffer, equals(Uint8List.fromList([100])));
+    });
+
+    test('encodes a lamports value using a passed big-endian u16 encoder', () {
+      final lamportsValue = lamports(BigInt.from(100));
+      final encoder = getLamportsEncoder(
+        getU16Encoder(const NumberCodecConfig(endian: Endian.big)),
+      );
+      final buffer = encoder.encode(lamportsValue);
+      expect(buffer, equals(Uint8List.fromList([0, 100])));
+    });
+
+    test('encodes a lamports value using a passed u64 encoder', () {
+      final lamportsValue = lamports(
+        BigInt.parse('ffffffffffffffff', radix: 16),
+      );
+      final encoder = getLamportsEncoder(getU64Encoder());
+      final buffer = encoder.encode(lamportsValue);
+      expect(
+        buffer,
+        equals(Uint8List.fromList([255, 255, 255, 255, 255, 255, 255, 255])),
+      );
+    });
+
+    test('has a fixed size of 1 for a passed u8 encoder', () {
+      final encoder = getLamportsEncoder(getU8Encoder());
+      expect((encoder as FixedSizeEncoder).fixedSize, equals(1));
+    });
+  });
+
+  group('getDefaultLamportsDecoder', () {
+    test('decodes an 8-byte buffer into a lamports value '
+        'using the default u64 decoder', () {
+      final buffer = Uint8List.fromList([0, 29, 50, 247, 69, 0, 0, 0]);
+      final decoder = getDefaultLamportsDecoder();
+      final lamportsValue = decoder.decode(buffer);
+      expect(lamportsValue, equals(lamports(BigInt.from(300500000000))));
+    });
+
+    test('has a fixed size of 8', () {
+      final decoder = getDefaultLamportsDecoder();
+      expect(decoder.fixedSize, equals(8));
+    });
+  });
+
+  group('getLamportsDecoder', () {
+    test('decodes a 1-byte buffer into a lamports value using u8 decoder', () {
+      final buffer = Uint8List.fromList([100]);
+      final decoder = getLamportsDecoder(getU8Decoder());
+      final lamportsValue = decoder.decode(buffer);
+      expect(lamportsValue, equals(lamports(BigInt.from(100))));
+    });
+
+    test('decodes a 2-byte buffer into a lamports value '
+        'using big-endian u16 decoder', () {
+      final buffer = Uint8List.fromList([0, 100]);
+      final decoder = getLamportsDecoder(
+        getU16Decoder(const NumberCodecConfig(endian: Endian.big)),
+      );
+      final lamportsValue = decoder.decode(buffer);
+      expect(lamportsValue, equals(lamports(BigInt.from(100))));
+    });
+
+    test(
+      'decodes an 8-byte buffer into a lamports value using u64 decoder',
+      () {
+        final buffer = Uint8List.fromList([
+          255,
+          255,
+          255,
+          255,
+          255,
+          255,
+          255,
+          255,
+        ]);
+        final decoder = getLamportsDecoder(getU64Decoder());
+        final lamportsValue = decoder.decode(buffer);
+        expect(
+          lamportsValue,
+          equals(lamports(BigInt.parse('ffffffffffffffff', radix: 16))),
+        );
+      },
+    );
+
+    test('has a fixed size of 1 for a passed u8 decoder', () {
+      final decoder = getLamportsDecoder(getU8Decoder());
+      expect((decoder as FixedSizeDecoder).fixedSize, equals(1));
+    });
+  });
+
+  group('getDefaultLamportsCodec', () {
+    test('encodes a lamports value using the default u64 encoder', () {
+      final lamportsValue = lamports(BigInt.from(1000000000));
+      final codec = getDefaultLamportsCodec();
+      final buffer = codec.encode(lamportsValue);
+      expect(buffer, equals(Uint8List.fromList([0, 202, 154, 59, 0, 0, 0, 0])));
+    });
+
+    test('decodes an 8-byte buffer into a lamports value '
+        'using the default u64 decoder', () {
+      final buffer = Uint8List.fromList([0, 29, 50, 247, 69, 0, 0, 0]);
+      final codec = getDefaultLamportsCodec();
+      final lamportsValue = codec.decode(buffer);
+      expect(lamportsValue, equals(lamports(BigInt.from(300500000000))));
+    });
+
+    test('has a fixed size of 8', () {
+      final codec = getDefaultLamportsCodec();
+      expect(codec.fixedSize, equals(8));
+    });
+  });
+
+  group('getLamportsCodec', () {
+    test('encodes a lamports value using a passed u8 codec', () {
+      final lamportsValue = lamports(BigInt.from(100));
+      final codec = getLamportsCodec(getU8Codec());
+      final buffer = codec.encode(lamportsValue);
+      expect(buffer, equals(Uint8List.fromList([100])));
+    });
+
+    test('encodes a lamports value using a passed big-endian u16 codec', () {
+      final lamportsValue = lamports(BigInt.from(100));
+      final codec = getLamportsCodec(
+        getU16Codec(const NumberCodecConfig(endian: Endian.big)),
+      );
+      final buffer = codec.encode(lamportsValue);
+      expect(buffer, equals(Uint8List.fromList([0, 100])));
+    });
+
+    test('encodes a lamports value using a passed u64 codec', () {
+      final lamportsValue = lamports(
+        BigInt.parse('ffffffffffffffff', radix: 16),
+      );
+      final codec = getLamportsCodec(getU64Codec());
+      final buffer = codec.encode(lamportsValue);
+      expect(
+        buffer,
+        equals(Uint8List.fromList([255, 255, 255, 255, 255, 255, 255, 255])),
+      );
+    });
+
+    test('decodes a 1-byte buffer into a lamports value using u8 codec', () {
+      final buffer = Uint8List.fromList([100]);
+      final codec = getLamportsCodec(getU8Codec());
+      final lamportsValue = codec.decode(buffer);
+      expect(lamportsValue, equals(lamports(BigInt.from(100))));
+    });
+
+    test('decodes a 2-byte buffer into a lamports value '
+        'using big-endian u16 codec', () {
+      final buffer = Uint8List.fromList([0, 100]);
+      final codec = getLamportsCodec(
+        getU16Codec(const NumberCodecConfig(endian: Endian.big)),
+      );
+      final lamportsValue = codec.decode(buffer);
+      expect(lamportsValue, equals(lamports(BigInt.from(100))));
+    });
+
+    test('decodes an 8-byte buffer into a lamports value using u64 codec', () {
+      final buffer = Uint8List.fromList([
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+        255,
+      ]);
+      final codec = getLamportsCodec(getU64Codec());
+      final lamportsValue = codec.decode(buffer);
+      expect(
+        lamportsValue,
+        equals(lamports(BigInt.parse('ffffffffffffffff', radix: 16))),
+      );
+    });
+
+    test('has a fixed size of 1 for a passed u8 codec', () {
+      final codec = getLamportsCodec(getU8Codec());
+      expect((codec as FixedSizeCodec).fixedSize, equals(1));
+    });
+  });
+}

--- a/packages/solana_kit_rpc_types/test/stringified_bigint_test.dart
+++ b/packages/solana_kit_rpc_types/test/stringified_bigint_test.dart
@@ -1,0 +1,93 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('assertIsStringifiedBigInt()', () {
+    test("throws when supplied a string that can't parse as a number", () {
+      expect(
+        () => assertIsStringifiedBigInt('abc'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.malformedBigintString,
+          ),
+        ),
+      );
+      expect(
+        () => assertIsStringifiedBigInt('123a'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.malformedBigintString,
+          ),
+        ),
+      );
+    });
+
+    test("throws when supplied a string that can't parse as an integer", () {
+      expect(
+        () => assertIsStringifiedBigInt('123.0'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.malformedBigintString,
+          ),
+        ),
+      );
+      expect(
+        () => assertIsStringifiedBigInt('123.5'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.malformedBigintString,
+          ),
+        ),
+      );
+    });
+
+    test('does not throw when supplied a string that parses as an integer', () {
+      expect(() => assertIsStringifiedBigInt('-123'), returnsNormally);
+      expect(() => assertIsStringifiedBigInt('0'), returnsNormally);
+      expect(() => assertIsStringifiedBigInt('123'), returnsNormally);
+    });
+  });
+
+  group('isStringifiedBigInt()', () {
+    test('returns true for valid integer strings', () {
+      expect(isStringifiedBigInt('0'), isTrue);
+      expect(isStringifiedBigInt('123'), isTrue);
+      expect(isStringifiedBigInt('-456'), isTrue);
+    });
+
+    test('returns false for non-integer strings', () {
+      expect(isStringifiedBigInt('abc'), isFalse);
+      expect(isStringifiedBigInt('123.5'), isFalse);
+      expect(isStringifiedBigInt(''), isFalse);
+    });
+  });
+
+  group('stringifiedBigInt()', () {
+    test('can coerce to StringifiedBigInt', () {
+      final coerced = stringifiedBigInt('1234');
+      expect(coerced.value, equals('1234'));
+    });
+
+    test('throws on invalid StringifiedBigInt', () {
+      expect(
+        () => stringifiedBigInt('test'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.malformedBigintString,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_rpc_types/test/stringified_number_test.dart
+++ b/packages/solana_kit_rpc_types/test/stringified_number_test.dart
@@ -1,0 +1,76 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('assertIsStringifiedNumber()', () {
+    test("throws when supplied a string that can't parse as a number", () {
+      expect(
+        () => assertIsStringifiedNumber('abc'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.malformedNumberString,
+          ),
+        ),
+      );
+      expect(
+        () => assertIsStringifiedNumber('123a'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.malformedNumberString,
+          ),
+        ),
+      );
+    });
+
+    test('does not throw when supplied a string that parses as a float', () {
+      expect(() => assertIsStringifiedNumber('123.0'), returnsNormally);
+      expect(() => assertIsStringifiedNumber('123.5'), returnsNormally);
+    });
+
+    test('does not throw when supplied a string that parses as an integer', () {
+      expect(() => assertIsStringifiedNumber('-123'), returnsNormally);
+      expect(() => assertIsStringifiedNumber('0'), returnsNormally);
+      expect(() => assertIsStringifiedNumber('123'), returnsNormally);
+    });
+  });
+
+  group('isStringifiedNumber()', () {
+    test('returns true for valid number strings', () {
+      expect(isStringifiedNumber('0'), isTrue);
+      expect(isStringifiedNumber('123'), isTrue);
+      expect(isStringifiedNumber('-456'), isTrue);
+      expect(isStringifiedNumber('123.5'), isTrue);
+      expect(isStringifiedNumber('-42.1'), isTrue);
+    });
+
+    test('returns false for non-number strings', () {
+      expect(isStringifiedNumber('abc'), isFalse);
+      expect(isStringifiedNumber('123a'), isFalse);
+    });
+  });
+
+  group('stringifiedNumber()', () {
+    test('can coerce to StringifiedNumber', () {
+      final coerced = stringifiedNumber('1234');
+      expect(coerced.value, equals('1234'));
+    });
+
+    test('throws on invalid StringifiedNumber', () {
+      expect(
+        () => stringifiedNumber('test'),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.malformedNumberString,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_rpc_types/test/unix_timestamp_test.dart
+++ b/packages/solana_kit_rpc_types/test/unix_timestamp_test.dart
@@ -1,0 +1,85 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('assertIsUnixTimestamp()', () {
+    test('throws when supplied a too large number', () {
+      expect(
+        () => assertIsUnixTimestamp(BigInt.two.pow(63)),
+        throwsA(isA<SolanaError>()),
+      );
+      expect(
+        () => assertIsUnixTimestamp(BigInt.parse('9223372036854775808')),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('throws when supplied a too small number', () {
+      expect(
+        () => assertIsUnixTimestamp(-BigInt.two.pow(63) - BigInt.one),
+        throwsA(isA<SolanaError>()),
+      );
+      expect(
+        () => assertIsUnixTimestamp(BigInt.parse('-9223372036854775809')),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('does not throw when supplied a zero timestamp', () {
+      expect(() => assertIsUnixTimestamp(BigInt.zero), returnsNormally);
+    });
+
+    test('does not throw when supplied a valid non-zero timestamp', () {
+      expect(
+        () => assertIsUnixTimestamp(BigInt.from(1000000000)),
+        returnsNormally,
+      );
+    });
+
+    test('does not throw when supplied the max valid timestamp', () {
+      expect(
+        () => assertIsUnixTimestamp(BigInt.two.pow(63) - BigInt.one),
+        returnsNormally,
+      );
+      expect(
+        () => assertIsUnixTimestamp(BigInt.parse('9223372036854775807')),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('isUnixTimestamp()', () {
+    test('returns true for valid timestamps', () {
+      expect(isUnixTimestamp(BigInt.zero), isTrue);
+      expect(isUnixTimestamp(BigInt.from(1000000000)), isTrue);
+      expect(isUnixTimestamp(BigInt.two.pow(63) - BigInt.one), isTrue);
+      expect(isUnixTimestamp(-BigInt.two.pow(63)), isTrue);
+    });
+
+    test('returns false for out-of-range timestamps', () {
+      expect(isUnixTimestamp(BigInt.two.pow(63)), isFalse);
+      expect(isUnixTimestamp(-BigInt.two.pow(63) - BigInt.one), isFalse);
+    });
+  });
+
+  group('unixTimestamp()', () {
+    test('can coerce to UnixTimestamp', () {
+      final coerced = unixTimestamp(BigInt.from(1234));
+      expect(coerced.value, equals(BigInt.from(1234)));
+    });
+
+    test('throws on an out-of-range UnixTimestamp', () {
+      expect(
+        () => unixTimestamp(BigInt.two.pow(63)),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.timestampOutOfRange,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -178,10 +178,10 @@
 
 ### solana_kit_rpc_types (~20 source files, ~11 test files)
 
-- [ ] T065 [P] [US2] Port Commitment, Lamports, UnixTimestamp, Blockhash, TransactionVersion types from `.repos/kit/packages/rpc-types/src/` to `packages/solana_kit_rpc_types/lib/src/`
-- [ ] T066 [US2] Port TokenAmount, AccountInfoBase, SimulatedTransactionAccountInfo and remaining types in `packages/solana_kit_rpc_types/lib/src/`
-- [ ] T067 [US2] Update barrel export `packages/solana_kit_rpc_types/lib/solana_kit_rpc_types.dart`
-- [ ] T068 [US2] Port all 11 test files from `.repos/kit/packages/rpc-types/src/__tests__/` to `packages/solana_kit_rpc_types/test/`
+- [x] T065 [P] [US2] Port Commitment, Lamports, UnixTimestamp, Blockhash, TransactionVersion types from `.repos/kit/packages/rpc-types/src/` to `packages/solana_kit_rpc_types/lib/src/`
+- [x] T066 [US2] Port TokenAmount, AccountInfoBase, SimulatedTransactionAccountInfo and remaining types in `packages/solana_kit_rpc_types/lib/src/`
+- [x] T067 [US2] Update barrel export `packages/solana_kit_rpc_types/lib/solana_kit_rpc_types.dart`
+- [x] T068 [US2] Port all 11 test files from `.repos/kit/packages/rpc-types/src/__tests__/` to `packages/solana_kit_rpc_types/test/`
 
 ### solana_kit_rpc_spec (~4 source files, ~6 test files)
 


### PR DESCRIPTION
## Summary

- Implements `solana_kit_rpc_types` ported from `@solana/rpc-types`
- Core branded types: `Blockhash`, `Lamports`, `UnixTimestamp`, `StringifiedBigInt`, `StringifiedNumber`
- `Commitment` enum with comparator, `Slot`, `Epoch`, `MicroLamports` types
- Encoded data types, account info variants, token amount/balance types
- `TransactionError` and `InstructionError` sealed class hierarchies
- Cluster URL types, `SolanaRpcResponse<T>`, account filters
- 85 tests passing

## Test plan

- [x] `dart test packages/solana_kit_rpc_types` — 85 tests pass
- [x] `dart analyze packages/solana_kit_rpc_types` — no issues
- [x] `dart format --set-exit-if-changed packages/solana_kit_rpc_types` — clean