### PR TITLE
✨ feat: implement RPC parsed types package

### DIFF
--- a/.changeset/rpc-parsed-types.md
+++ b/.changeset/rpc-parsed-types.md
@@ -1,0 +1,14 @@
+---
+solana_kit_rpc_parsed_types: minor
+---
+
+Implement RPC parsed types package ported from `@solana/rpc-parsed-types`.
+
+**solana_kit_rpc_parsed_types** (32 tests):
+
+- Typed representations of JSON-parsed account data from the Solana RPC
+- Address lookup table, BPF upgradeable loader, config, nonce, stake, sysvar, token, and vote account types
+- Sealed class hierarchies for discriminated unions enabling exhaustive pattern matching
+- `RpcParsedType<TType, TInfo>` and `RpcParsedInfo<TInfo>` base classes
+- All 10 sysvar account types: clock, epochRewards, epochSchedule, fees, lastRestartSlot, recentBlockhashes, rent, slotHashes, slotHistory, stakeHistory
+- Token program accounts: account, mint, multisig with `TokenAccountState` enum

--- a/packages/solana_kit_rpc_parsed_types/lib/solana_kit_rpc_parsed_types.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/solana_kit_rpc_parsed_types.dart
@@ -1,1 +1,9 @@
-
+export 'src/address_lookup_table_accounts.dart';
+export 'src/bpf_upgradeable_loader_accounts.dart';
+export 'src/config_accounts.dart';
+export 'src/nonce_accounts.dart';
+export 'src/rpc_parsed_type.dart';
+export 'src/stake_accounts.dart';
+export 'src/sysvar_accounts.dart';
+export 'src/token_accounts.dart';
+export 'src/vote_accounts.dart';

--- a/packages/solana_kit_rpc_parsed_types/lib/src/address_lookup_table_accounts.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/src/address_lookup_table_accounts.dart
@@ -1,0 +1,37 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/src/rpc_parsed_type.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Parsed account data for an address lookup table account.
+///
+/// This type represents the JSON-parsed data returned by the Solana RPC for
+/// address lookup table accounts.
+typedef JsonParsedAddressLookupTableAccount =
+    RpcParsedInfo<JsonParsedAddressLookupTableInfo>;
+
+/// The info payload for a parsed address lookup table account.
+class JsonParsedAddressLookupTableInfo {
+  /// Creates a new [JsonParsedAddressLookupTableInfo].
+  const JsonParsedAddressLookupTableInfo({
+    required this.addresses,
+    required this.deactivationSlot,
+    required this.lastExtendedSlot,
+    required this.lastExtendedSlotStartIndex,
+    this.authority,
+  });
+
+  /// The list of addresses stored in the lookup table.
+  final List<Address> addresses;
+
+  /// The optional authority address that can modify this lookup table.
+  final Address? authority;
+
+  /// The slot at which the lookup table was deactivated.
+  final StringifiedBigInt deactivationSlot;
+
+  /// The last slot in which the lookup table was extended.
+  final StringifiedBigInt lastExtendedSlot;
+
+  /// The start index of the last extension within the slot.
+  final int lastExtendedSlotStartIndex;
+}

--- a/packages/solana_kit_rpc_parsed_types/lib/src/bpf_upgradeable_loader_accounts.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/src/bpf_upgradeable_loader_accounts.dart
@@ -1,0 +1,56 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/src/rpc_parsed_type.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Parsed account data for a BPF Upgradeable Loader program account.
+///
+/// This is a discriminated union that can be either a [JsonParsedBpfProgram]
+/// ('program') or a [JsonParsedBpfProgramData] ('programData').
+sealed class JsonParsedBpfUpgradeableLoaderProgramAccount {
+  const JsonParsedBpfUpgradeableLoaderProgramAccount();
+}
+
+/// A parsed BPF Upgradeable Loader 'program' variant.
+class JsonParsedBpfProgram
+    extends RpcParsedType<String, JsonParsedBpfProgramInfo>
+    implements JsonParsedBpfUpgradeableLoaderProgramAccount {
+  /// Creates a new [JsonParsedBpfProgram].
+  const JsonParsedBpfProgram({required super.info}) : super(type: 'program');
+}
+
+/// The info payload for a parsed BPF program account.
+class JsonParsedBpfProgramInfo {
+  /// Creates a new [JsonParsedBpfProgramInfo].
+  const JsonParsedBpfProgramInfo({required this.programData});
+
+  /// The address of the program data account.
+  final Address programData;
+}
+
+/// A parsed BPF Upgradeable Loader 'programData' variant.
+class JsonParsedBpfProgramData
+    extends RpcParsedType<String, JsonParsedBpfProgramDataInfo>
+    implements JsonParsedBpfUpgradeableLoaderProgramAccount {
+  /// Creates a new [JsonParsedBpfProgramData].
+  const JsonParsedBpfProgramData({required super.info})
+    : super(type: 'programData');
+}
+
+/// The info payload for a parsed BPF program data account.
+class JsonParsedBpfProgramDataInfo {
+  /// Creates a new [JsonParsedBpfProgramDataInfo].
+  const JsonParsedBpfProgramDataInfo({
+    required this.data,
+    required this.slot,
+    this.authority,
+  });
+
+  /// The optional upgrade authority address.
+  final Address? authority;
+
+  /// The program data as a base64-encoded data response.
+  final Base64EncodedDataResponse data;
+
+  /// The slot at which the program was last deployed or upgraded.
+  final Slot slot;
+}

--- a/packages/solana_kit_rpc_parsed_types/lib/src/config_accounts.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/src/config_accounts.dart
@@ -1,0 +1,77 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/src/rpc_parsed_type.dart';
+
+/// Parsed account data for a Config program account.
+///
+/// This is a discriminated union that can be either a
+/// [JsonParsedStakeConfig] ('stakeConfig') or a
+/// [JsonParsedValidatorInfo] ('validatorInfo').
+sealed class JsonParsedConfigProgramAccount {
+  const JsonParsedConfigProgramAccount();
+}
+
+/// A parsed Config program 'stakeConfig' variant.
+class JsonParsedStakeConfig
+    extends RpcParsedType<String, JsonParsedStakeConfigInfo>
+    implements JsonParsedConfigProgramAccount {
+  /// Creates a new [JsonParsedStakeConfig].
+  const JsonParsedStakeConfig({required super.info})
+    : super(type: 'stakeConfig');
+}
+
+/// The info payload for a parsed stake config account.
+class JsonParsedStakeConfigInfo {
+  /// Creates a new [JsonParsedStakeConfigInfo].
+  const JsonParsedStakeConfigInfo({
+    required this.slashPenalty,
+    required this.warmupCooldownRate,
+  });
+
+  /// The slash penalty percentage.
+  final int slashPenalty;
+
+  /// The warmup/cooldown rate.
+  final double warmupCooldownRate;
+}
+
+/// A parsed Config program 'validatorInfo' variant.
+class JsonParsedValidatorInfo
+    extends RpcParsedType<String, JsonParsedValidatorInfoData>
+    implements JsonParsedConfigProgramAccount {
+  /// Creates a new [JsonParsedValidatorInfo].
+  const JsonParsedValidatorInfo({required super.info})
+    : super(type: 'validatorInfo');
+}
+
+/// The info payload for a parsed validator info account.
+class JsonParsedValidatorInfoData {
+  /// Creates a new [JsonParsedValidatorInfoData].
+  const JsonParsedValidatorInfoData({
+    required this.configData,
+    required this.keys,
+  });
+
+  /// The config data associated with the validator.
+  ///
+  /// This is an opaque value whose structure depends on the validator's
+  /// configuration.
+  final Object? configData;
+
+  /// The list of keys associated with this validator info.
+  final List<JsonParsedValidatorInfoKey> keys;
+}
+
+/// A key entry in a parsed validator info account.
+class JsonParsedValidatorInfoKey {
+  /// Creates a new [JsonParsedValidatorInfoKey].
+  const JsonParsedValidatorInfoKey({
+    required this.pubkey,
+    required this.signer,
+  });
+
+  /// The public key address.
+  final Address pubkey;
+
+  /// Whether this key is a signer.
+  final bool signer;
+}

--- a/packages/solana_kit_rpc_parsed_types/lib/src/nonce_accounts.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/src/nonce_accounts.dart
@@ -1,0 +1,37 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/src/rpc_parsed_type.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Parsed account data for a nonce account.
+///
+/// This type represents the JSON-parsed data returned by the Solana RPC for
+/// nonce accounts.
+typedef JsonParsedNonceAccount = RpcParsedInfo<JsonParsedNonceInfo>;
+
+/// The info payload for a parsed nonce account.
+class JsonParsedNonceInfo {
+  /// Creates a new [JsonParsedNonceInfo].
+  const JsonParsedNonceInfo({
+    required this.authority,
+    required this.blockhash,
+    required this.feeCalculator,
+  });
+
+  /// The authority address that can advance the nonce.
+  final Address authority;
+
+  /// The stored blockhash.
+  final Blockhash blockhash;
+
+  /// The fee calculator associated with this nonce.
+  final JsonParsedNonceFeeCalculator feeCalculator;
+}
+
+/// The fee calculator within a nonce account.
+class JsonParsedNonceFeeCalculator {
+  /// Creates a new [JsonParsedNonceFeeCalculator].
+  const JsonParsedNonceFeeCalculator({required this.lamportsPerSignature});
+
+  /// The fee in lamports charged per signature.
+  final StringifiedBigInt lamportsPerSignature;
+}

--- a/packages/solana_kit_rpc_parsed_types/lib/src/rpc_parsed_type.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/src/rpc_parsed_type.dart
@@ -1,0 +1,30 @@
+/// A parsed RPC account type with both a [type] discriminator and an [info]
+/// payload.
+///
+/// This is the base class for parsed account data returned by the Solana RPC
+/// when accounts are requested with `jsonParsed` encoding. The [TType] type
+/// parameter is a string literal that discriminates the variant, and [TInfo]
+/// carries the parsed data.
+class RpcParsedType<TType extends String, TInfo extends Object> {
+  /// Creates a new [RpcParsedType] with the given [type] and [info].
+  const RpcParsedType({required this.type, required this.info});
+
+  /// The type discriminator for this parsed account variant.
+  final TType type;
+
+  /// The parsed account data.
+  final TInfo info;
+}
+
+/// A parsed RPC account type that carries only an [info] payload without a
+/// type discriminator.
+///
+/// Used for account types where there is only a single variant (e.g. nonce
+/// accounts, vote accounts, address lookup table accounts).
+class RpcParsedInfo<TInfo extends Object> {
+  /// Creates a new [RpcParsedInfo] with the given [info].
+  const RpcParsedInfo({required this.info});
+
+  /// The parsed account data.
+  final TInfo info;
+}

--- a/packages/solana_kit_rpc_parsed_types/lib/src/stake_accounts.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/src/stake_accounts.dart
@@ -1,0 +1,137 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/src/rpc_parsed_type.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Parsed account data for a Stake program account.
+///
+/// This is a discriminated union that can be either a
+/// [JsonParsedDelegatedStake] ('delegated') or a
+/// [JsonParsedInitializedStake] ('initialized').
+sealed class JsonParsedStakeProgramAccount {
+  const JsonParsedStakeProgramAccount();
+}
+
+/// A parsed Stake program 'delegated' variant.
+class JsonParsedDelegatedStake
+    extends RpcParsedType<String, JsonParsedStakeAccountInfo>
+    implements JsonParsedStakeProgramAccount {
+  /// Creates a new [JsonParsedDelegatedStake].
+  const JsonParsedDelegatedStake({required super.info})
+    : super(type: 'delegated');
+}
+
+/// A parsed Stake program 'initialized' variant.
+class JsonParsedInitializedStake
+    extends RpcParsedType<String, JsonParsedStakeAccountInfo>
+    implements JsonParsedStakeProgramAccount {
+  /// Creates a new [JsonParsedInitializedStake].
+  const JsonParsedInitializedStake({required super.info})
+    : super(type: 'initialized');
+}
+
+/// The info payload for a parsed stake account.
+class JsonParsedStakeAccountInfo {
+  /// Creates a new [JsonParsedStakeAccountInfo].
+  const JsonParsedStakeAccountInfo({required this.meta, this.stake});
+
+  /// The stake account metadata.
+  final JsonParsedStakeMeta meta;
+
+  /// The stake delegation data, or `null` if not yet delegated.
+  final JsonParsedStakeData? stake;
+}
+
+/// Metadata for a parsed stake account.
+class JsonParsedStakeMeta {
+  /// Creates a new [JsonParsedStakeMeta].
+  const JsonParsedStakeMeta({
+    required this.authorized,
+    required this.lockup,
+    required this.rentExemptReserve,
+  });
+
+  /// The authorized staker and withdrawer.
+  final JsonParsedStakeAuthorized authorized;
+
+  /// The lockup configuration.
+  final JsonParsedStakeLockup lockup;
+
+  /// The rent-exempt reserve amount.
+  final StringifiedBigInt rentExemptReserve;
+}
+
+/// The authorized staker and withdrawer for a stake account.
+class JsonParsedStakeAuthorized {
+  /// Creates a new [JsonParsedStakeAuthorized].
+  const JsonParsedStakeAuthorized({
+    required this.staker,
+    required this.withdrawer,
+  });
+
+  /// The address authorized to stake.
+  final Address staker;
+
+  /// The address authorized to withdraw.
+  final Address withdrawer;
+}
+
+/// The lockup configuration for a stake account.
+class JsonParsedStakeLockup {
+  /// Creates a new [JsonParsedStakeLockup].
+  const JsonParsedStakeLockup({
+    required this.custodian,
+    required this.epoch,
+    required this.unixTimestamp,
+  });
+
+  /// The custodian address that can modify the lockup.
+  final Address custodian;
+
+  /// The epoch at which the lockup expires.
+  final BigInt epoch;
+
+  /// The Unix timestamp at which the lockup expires.
+  final UnixTimestamp unixTimestamp;
+}
+
+/// The stake delegation data for a stake account.
+class JsonParsedStakeData {
+  /// Creates a new [JsonParsedStakeData].
+  const JsonParsedStakeData({
+    required this.creditsObserved,
+    required this.delegation,
+  });
+
+  /// The total credits observed.
+  final BigInt creditsObserved;
+
+  /// The delegation details.
+  final JsonParsedStakeDelegation delegation;
+}
+
+/// The delegation details for a stake account.
+class JsonParsedStakeDelegation {
+  /// Creates a new [JsonParsedStakeDelegation].
+  const JsonParsedStakeDelegation({
+    required this.activationEpoch,
+    required this.deactivationEpoch,
+    required this.stake,
+    required this.voter,
+    required this.warmupCooldownRate,
+  });
+
+  /// The epoch in which the stake was activated.
+  final StringifiedBigInt activationEpoch;
+
+  /// The epoch in which the stake was deactivated.
+  final StringifiedBigInt deactivationEpoch;
+
+  /// The amount of stake delegated.
+  final StringifiedBigInt stake;
+
+  /// The vote account to which the stake is delegated.
+  final Address voter;
+
+  /// The warmup/cooldown rate.
+  final double warmupCooldownRate;
+}

--- a/packages/solana_kit_rpc_parsed_types/lib/src/sysvar_accounts.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/src/sysvar_accounts.dart
@@ -1,0 +1,339 @@
+import 'package:solana_kit_rpc_parsed_types/src/rpc_parsed_type.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Parsed account data for a sysvar account.
+///
+/// This is a discriminated union covering all sysvar account types:
+/// - [JsonParsedClockSysvar] ('clock')
+/// - [JsonParsedEpochRewardsSysvar] ('epochRewards')
+/// - [JsonParsedEpochScheduleSysvar] ('epochSchedule')
+/// - [JsonParsedFeesSysvar] ('fees') - deprecated
+/// - [JsonParsedLastRestartSlotSysvar] ('lastRestartSlot')
+/// - [JsonParsedRecentBlockhashesSysvar] ('recentBlockhashes') - deprecated
+/// - [JsonParsedRentSysvar] ('rent')
+/// - [JsonParsedSlotHashesSysvar] ('slotHashes')
+/// - [JsonParsedSlotHistorySysvar] ('slotHistory')
+/// - [JsonParsedStakeHistorySysvar] ('stakeHistory')
+sealed class JsonParsedSysvarAccount {
+  const JsonParsedSysvarAccount();
+}
+
+// ---------------------------------------------------------------------------
+// Clock
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'clock' variant.
+class JsonParsedClockSysvar extends RpcParsedType<String, JsonParsedClockInfo>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedClockSysvar].
+  const JsonParsedClockSysvar({required super.info}) : super(type: 'clock');
+}
+
+/// The info payload for the clock sysvar.
+class JsonParsedClockInfo {
+  /// Creates a new [JsonParsedClockInfo].
+  const JsonParsedClockInfo({
+    required this.epoch,
+    required this.epochStartTimestamp,
+    required this.leaderScheduleEpoch,
+    required this.slot,
+    required this.unixTimestamp,
+  });
+
+  /// The current epoch.
+  final Epoch epoch;
+
+  /// The Unix timestamp at the start of the current epoch.
+  final UnixTimestamp epochStartTimestamp;
+
+  /// The epoch for which the leader schedule is valid.
+  final Epoch leaderScheduleEpoch;
+
+  /// The current slot.
+  final Slot slot;
+
+  /// The current Unix timestamp.
+  final UnixTimestamp unixTimestamp;
+}
+
+// ---------------------------------------------------------------------------
+// Epoch Schedule
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'epochSchedule' variant.
+class JsonParsedEpochScheduleSysvar
+    extends RpcParsedType<String, JsonParsedEpochScheduleInfo>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedEpochScheduleSysvar].
+  const JsonParsedEpochScheduleSysvar({required super.info})
+    : super(type: 'epochSchedule');
+}
+
+/// The info payload for the epoch schedule sysvar.
+class JsonParsedEpochScheduleInfo {
+  /// Creates a new [JsonParsedEpochScheduleInfo].
+  const JsonParsedEpochScheduleInfo({
+    required this.firstNormalEpoch,
+    required this.firstNormalSlot,
+    required this.leaderScheduleSlotOffset,
+    required this.slotsPerEpoch,
+    required this.warmup,
+  });
+
+  /// The first epoch that is not in the warmup period.
+  final Epoch firstNormalEpoch;
+
+  /// The first slot that is not in the warmup period.
+  final Slot firstNormalSlot;
+
+  /// The number of slots ahead the leader schedule is computed.
+  final BigInt leaderScheduleSlotOffset;
+
+  /// The number of slots per epoch.
+  final BigInt slotsPerEpoch;
+
+  /// Whether the cluster is in the warmup period.
+  final bool warmup;
+}
+
+// ---------------------------------------------------------------------------
+// Fees (deprecated)
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'fees' variant.
+///
+/// This sysvar is deprecated.
+class JsonParsedFeesSysvar extends RpcParsedType<String, JsonParsedFeesInfo>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedFeesSysvar].
+  const JsonParsedFeesSysvar({required super.info}) : super(type: 'fees');
+}
+
+/// The info payload for the fees sysvar (deprecated).
+class JsonParsedFeesInfo {
+  /// Creates a new [JsonParsedFeesInfo].
+  const JsonParsedFeesInfo({required this.feeCalculator});
+
+  /// The fee calculator.
+  final JsonParsedFeeCalculator feeCalculator;
+}
+
+/// A fee calculator containing the lamports per signature.
+class JsonParsedFeeCalculator {
+  /// Creates a new [JsonParsedFeeCalculator].
+  const JsonParsedFeeCalculator({required this.lamportsPerSignature});
+
+  /// The fee in lamports charged per signature.
+  final StringifiedBigInt lamportsPerSignature;
+}
+
+// ---------------------------------------------------------------------------
+// Recent Blockhashes (deprecated)
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'recentBlockhashes' variant.
+///
+/// This sysvar is deprecated.
+class JsonParsedRecentBlockhashesSysvar
+    extends RpcParsedType<String, List<JsonParsedRecentBlockhashEntry>>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedRecentBlockhashesSysvar].
+  const JsonParsedRecentBlockhashesSysvar({required super.info})
+    : super(type: 'recentBlockhashes');
+}
+
+/// An entry in the recent blockhashes sysvar (deprecated).
+class JsonParsedRecentBlockhashEntry {
+  /// Creates a new [JsonParsedRecentBlockhashEntry].
+  const JsonParsedRecentBlockhashEntry({
+    required this.blockhash,
+    required this.feeCalculator,
+  });
+
+  /// The blockhash.
+  final Blockhash blockhash;
+
+  /// The fee calculator associated with this blockhash.
+  final JsonParsedFeeCalculator feeCalculator;
+}
+
+// ---------------------------------------------------------------------------
+// Rent
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'rent' variant.
+class JsonParsedRentSysvar extends RpcParsedType<String, JsonParsedRentInfo>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedRentSysvar].
+  const JsonParsedRentSysvar({required super.info}) : super(type: 'rent');
+}
+
+/// The info payload for the rent sysvar.
+class JsonParsedRentInfo {
+  /// Creates a new [JsonParsedRentInfo].
+  const JsonParsedRentInfo({
+    required this.burnPercent,
+    required this.exemptionThreshold,
+    required this.lamportsPerByteYear,
+  });
+
+  /// The percentage of collected rent to burn.
+  final int burnPercent;
+
+  /// The exemption threshold multiplier.
+  final double exemptionThreshold;
+
+  /// The lamports charged per byte-year.
+  final StringifiedBigInt lamportsPerByteYear;
+}
+
+// ---------------------------------------------------------------------------
+// Slot Hashes
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'slotHashes' variant.
+class JsonParsedSlotHashesSysvar
+    extends RpcParsedType<String, List<JsonParsedSlotHashEntry>>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedSlotHashesSysvar].
+  const JsonParsedSlotHashesSysvar({required super.info})
+    : super(type: 'slotHashes');
+}
+
+/// An entry in the slot hashes sysvar.
+class JsonParsedSlotHashEntry {
+  /// Creates a new [JsonParsedSlotHashEntry].
+  const JsonParsedSlotHashEntry({required this.hash, required this.slot});
+
+  /// The hash of the slot.
+  final String hash;
+
+  /// The slot number.
+  final Slot slot;
+}
+
+// ---------------------------------------------------------------------------
+// Slot History
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'slotHistory' variant.
+class JsonParsedSlotHistorySysvar
+    extends RpcParsedType<String, JsonParsedSlotHistoryInfo>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedSlotHistorySysvar].
+  const JsonParsedSlotHistorySysvar({required super.info})
+    : super(type: 'slotHistory');
+}
+
+/// The info payload for the slot history sysvar.
+class JsonParsedSlotHistoryInfo {
+  /// Creates a new [JsonParsedSlotHistoryInfo].
+  const JsonParsedSlotHistoryInfo({required this.bits, required this.nextSlot});
+
+  /// The bit vector representing slot history.
+  final String bits;
+
+  /// The next slot to be recorded.
+  final Slot nextSlot;
+}
+
+// ---------------------------------------------------------------------------
+// Stake History
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'stakeHistory' variant.
+class JsonParsedStakeHistorySysvar
+    extends RpcParsedType<String, List<JsonParsedStakeHistoryEntry>>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedStakeHistorySysvar].
+  const JsonParsedStakeHistorySysvar({required super.info})
+    : super(type: 'stakeHistory');
+}
+
+/// An entry in the stake history sysvar.
+class JsonParsedStakeHistoryEntry {
+  /// Creates a new [JsonParsedStakeHistoryEntry].
+  const JsonParsedStakeHistoryEntry({
+    required this.epoch,
+    required this.stakeHistory,
+  });
+
+  /// The epoch number.
+  final Epoch epoch;
+
+  /// The stake history for this epoch.
+  final JsonParsedStakeHistoryData stakeHistory;
+}
+
+/// The stake history data for a single epoch.
+class JsonParsedStakeHistoryData {
+  /// Creates a new [JsonParsedStakeHistoryData].
+  const JsonParsedStakeHistoryData({
+    required this.activating,
+    required this.deactivating,
+    required this.effective,
+  });
+
+  /// The amount of stake activating.
+  final BigInt activating;
+
+  /// The amount of stake deactivating.
+  final BigInt deactivating;
+
+  /// The effective stake.
+  final BigInt effective;
+}
+
+// ---------------------------------------------------------------------------
+// Last Restart Slot
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'lastRestartSlot' variant.
+class JsonParsedLastRestartSlotSysvar
+    extends RpcParsedType<String, JsonParsedLastRestartSlotInfo>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedLastRestartSlotSysvar].
+  const JsonParsedLastRestartSlotSysvar({required super.info})
+    : super(type: 'lastRestartSlot');
+}
+
+/// The info payload for the last restart slot sysvar.
+class JsonParsedLastRestartSlotInfo {
+  /// Creates a new [JsonParsedLastRestartSlotInfo].
+  const JsonParsedLastRestartSlotInfo({required this.lastRestartSlot});
+
+  /// The last restart slot.
+  final Slot lastRestartSlot;
+}
+
+// ---------------------------------------------------------------------------
+// Epoch Rewards
+// ---------------------------------------------------------------------------
+
+/// A parsed sysvar 'epochRewards' variant.
+class JsonParsedEpochRewardsSysvar
+    extends RpcParsedType<String, JsonParsedEpochRewardsInfo>
+    implements JsonParsedSysvarAccount {
+  /// Creates a new [JsonParsedEpochRewardsSysvar].
+  const JsonParsedEpochRewardsSysvar({required super.info})
+    : super(type: 'epochRewards');
+}
+
+/// The info payload for the epoch rewards sysvar.
+class JsonParsedEpochRewardsInfo {
+  /// Creates a new [JsonParsedEpochRewardsInfo].
+  const JsonParsedEpochRewardsInfo({
+    required this.distributedRewards,
+    required this.distributionCompleteBlockHeight,
+    required this.totalRewards,
+  });
+
+  /// The total rewards distributed so far.
+  final BigInt distributedRewards;
+
+  /// The block height at which distribution will be complete.
+  final BigInt distributionCompleteBlockHeight;
+
+  /// The total rewards for the epoch.
+  final BigInt totalRewards;
+}

--- a/packages/solana_kit_rpc_parsed_types/lib/src/token_accounts.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/src/token_accounts.dart
@@ -1,0 +1,151 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/src/rpc_parsed_type.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// The state of a token account.
+enum TokenAccountState {
+  /// The account is frozen and cannot be used.
+  frozen,
+
+  /// The account is initialized and can be used.
+  initialized,
+
+  /// The account has not been initialized.
+  uninitialized,
+}
+
+/// Parsed account data for a Token program account.
+///
+/// This is a discriminated union that can be:
+/// - [JsonParsedTokenAccountVariant] ('account')
+/// - [JsonParsedMintAccount] ('mint')
+/// - [JsonParsedMultisigAccount] ('multisig')
+sealed class JsonParsedTokenProgramAccount {
+  const JsonParsedTokenProgramAccount();
+}
+
+/// A parsed Token program 'account' variant.
+class JsonParsedTokenAccountVariant
+    extends RpcParsedType<String, JsonParsedTokenAccount>
+    implements JsonParsedTokenProgramAccount {
+  /// Creates a new [JsonParsedTokenAccountVariant].
+  const JsonParsedTokenAccountVariant({required super.info})
+    : super(type: 'account');
+}
+
+/// The info payload for a parsed token account.
+class JsonParsedTokenAccount {
+  /// Creates a new [JsonParsedTokenAccount].
+  const JsonParsedTokenAccount({
+    required this.isNative,
+    required this.mint,
+    required this.owner,
+    required this.state,
+    required this.tokenAmount,
+    this.closeAuthority,
+    this.delegate,
+    this.delegatedAmount,
+    this.extensions,
+    this.rentExemptReserve,
+  });
+
+  /// The optional close authority address.
+  final Address? closeAuthority;
+
+  /// The optional delegate address.
+  final Address? delegate;
+
+  /// The amount delegated, if any.
+  final TokenAmount? delegatedAmount;
+
+  /// The list of token extensions, if any.
+  final List<Object?>? extensions;
+
+  /// Whether this is a native SOL token account.
+  final bool isNative;
+
+  /// The mint address for this token account.
+  final Address mint;
+
+  /// The owner address of this token account.
+  final Address owner;
+
+  /// The rent-exempt reserve amount, if applicable.
+  final TokenAmount? rentExemptReserve;
+
+  /// The state of the token account.
+  final TokenAccountState state;
+
+  /// The token balance.
+  final TokenAmount tokenAmount;
+}
+
+/// A parsed Token program 'mint' variant.
+class JsonParsedMintAccount extends RpcParsedType<String, JsonParsedMintInfo>
+    implements JsonParsedTokenProgramAccount {
+  /// Creates a new [JsonParsedMintAccount].
+  const JsonParsedMintAccount({required super.info}) : super(type: 'mint');
+}
+
+/// The info payload for a parsed mint account.
+class JsonParsedMintInfo {
+  /// Creates a new [JsonParsedMintInfo].
+  const JsonParsedMintInfo({
+    required this.decimals,
+    required this.isInitialized,
+    required this.supply,
+    this.extensions,
+    this.freezeAuthority,
+    this.mintAuthority,
+  });
+
+  /// The number of decimal places.
+  final int decimals;
+
+  /// The list of token extensions, if any.
+  final List<Object?>? extensions;
+
+  /// The freeze authority address, or `null` if none.
+  final Address? freezeAuthority;
+
+  /// Whether the mint is initialized.
+  final bool isInitialized;
+
+  /// The mint authority address, or `null` if none.
+  final Address? mintAuthority;
+
+  /// The total supply.
+  final StringifiedBigInt supply;
+}
+
+/// A parsed Token program 'multisig' variant.
+class JsonParsedMultisigAccount
+    extends RpcParsedType<String, JsonParsedMultisigInfo>
+    implements JsonParsedTokenProgramAccount {
+  /// Creates a new [JsonParsedMultisigAccount].
+  const JsonParsedMultisigAccount({required super.info})
+    : super(type: 'multisig');
+}
+
+/// The info payload for a parsed multisig account.
+class JsonParsedMultisigInfo {
+  /// Creates a new [JsonParsedMultisigInfo].
+  const JsonParsedMultisigInfo({
+    required this.isInitialized,
+    required this.numRequiredSigners,
+    required this.numValidSigners,
+    required this.signers,
+  });
+
+  /// Whether the multisig is initialized.
+  final bool isInitialized;
+
+  /// The number of required signers.
+  final int numRequiredSigners;
+
+  /// The number of valid signers.
+  final int numValidSigners;
+
+  /// The list of signer addresses.
+  final List<Address> signers;
+}

--- a/packages/solana_kit_rpc_parsed_types/lib/src/vote_accounts.dart
+++ b/packages/solana_kit_rpc_parsed_types/lib/src/vote_accounts.dart
@@ -1,0 +1,129 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/src/rpc_parsed_type.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Parsed account data for a vote account.
+///
+/// This type represents the JSON-parsed data returned by the Solana RPC for
+/// vote accounts.
+typedef JsonParsedVoteAccount = RpcParsedInfo<JsonParsedVoteInfo>;
+
+/// The info payload for a parsed vote account.
+class JsonParsedVoteInfo {
+  /// Creates a new [JsonParsedVoteInfo].
+  const JsonParsedVoteInfo({
+    required this.authorizedVoters,
+    required this.authorizedWithdrawer,
+    required this.commission,
+    required this.epochCredits,
+    required this.lastTimestamp,
+    required this.nodePubkey,
+    required this.priorVoters,
+    required this.votes,
+    this.rootSlot,
+  });
+
+  /// The list of authorized voters and their epochs.
+  final List<JsonParsedAuthorizedVoter> authorizedVoters;
+
+  /// The address authorized to withdraw from this vote account.
+  final Address authorizedWithdrawer;
+
+  /// The commission percentage (0-100).
+  final int commission;
+
+  /// The list of epoch credits.
+  final List<JsonParsedEpochCredit> epochCredits;
+
+  /// The last timestamp recorded by this vote account.
+  final JsonParsedLastTimestamp lastTimestamp;
+
+  /// The node public key.
+  final Address nodePubkey;
+
+  /// The list of prior voters.
+  final List<JsonParsedPriorVoter> priorVoters;
+
+  /// The root slot, or `null` if none.
+  final Slot? rootSlot;
+
+  /// The list of votes.
+  final List<JsonParsedVote> votes;
+}
+
+/// An authorized voter entry in a vote account.
+class JsonParsedAuthorizedVoter {
+  /// Creates a new [JsonParsedAuthorizedVoter].
+  const JsonParsedAuthorizedVoter({
+    required this.authorizedVoter,
+    required this.epoch,
+  });
+
+  /// The authorized voter address.
+  final Address authorizedVoter;
+
+  /// The epoch for which this voter is authorized.
+  final Epoch epoch;
+}
+
+/// An epoch credit entry in a vote account.
+class JsonParsedEpochCredit {
+  /// Creates a new [JsonParsedEpochCredit].
+  const JsonParsedEpochCredit({
+    required this.credits,
+    required this.epoch,
+    required this.previousCredits,
+  });
+
+  /// The credits earned in this epoch.
+  final StringifiedBigInt credits;
+
+  /// The epoch number.
+  final Epoch epoch;
+
+  /// The credits from the previous epoch.
+  final StringifiedBigInt previousCredits;
+}
+
+/// The last timestamp recorded by a vote account.
+class JsonParsedLastTimestamp {
+  /// Creates a new [JsonParsedLastTimestamp].
+  const JsonParsedLastTimestamp({required this.slot, required this.timestamp});
+
+  /// The slot at which the timestamp was recorded.
+  final Slot slot;
+
+  /// The Unix timestamp.
+  final UnixTimestamp timestamp;
+}
+
+/// A prior voter entry in a vote account.
+class JsonParsedPriorVoter {
+  /// Creates a new [JsonParsedPriorVoter].
+  const JsonParsedPriorVoter({
+    required this.authorizedPubkey,
+    required this.epochOfLastAuthorizedSwitch,
+    required this.targetEpoch,
+  });
+
+  /// The public key of the prior authorized voter.
+  final Address authorizedPubkey;
+
+  /// The epoch of the last authorized switch.
+  final Epoch epochOfLastAuthorizedSwitch;
+
+  /// The target epoch.
+  final Epoch targetEpoch;
+}
+
+/// A vote entry in a vote account.
+class JsonParsedVote {
+  /// Creates a new [JsonParsedVote].
+  const JsonParsedVote({required this.confirmationCount, required this.slot});
+
+  /// The number of confirmations.
+  final int confirmationCount;
+
+  /// The slot that was voted on.
+  final Slot slot;
+}

--- a/packages/solana_kit_rpc_parsed_types/pubspec.yaml
+++ b/packages/solana_kit_rpc_parsed_types/pubspec.yaml
@@ -8,7 +8,10 @@ environment:
 resolution: workspace
 
 dependencies:
+  solana_kit_addresses:
   solana_kit_errors:
+  solana_kit_rpc_types:
 
 dev_dependencies:
   solana_kit_lints:
+  test: ^1.25.8

--- a/packages/solana_kit_rpc_parsed_types/test/address_lookup_table_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/address_lookup_table_accounts_test.dart
@@ -1,0 +1,54 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonParsedAddressLookupTableAccount', () {
+    test('can be constructed with all fields', () {
+      const account = JsonParsedAddressLookupTableAccount(
+        info: JsonParsedAddressLookupTableInfo(
+          addresses: [
+            Address('F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn'),
+            Address('FWscgV4VDSsMxkQg7jZ4HksqjLyadJS5RiCnAVZv2se9'),
+          ],
+          authority: Address('4msgK65vdz5ADUAB3eTQGpF388NuQUAoknLxutUQJd5B'),
+          deactivationSlot: StringifiedBigInt('204699277'),
+          lastExtendedSlot: StringifiedBigInt('204699234'),
+          lastExtendedSlotStartIndex: 20,
+        ),
+      );
+
+      expect(account.info.addresses, hasLength(2));
+      expect(
+        account.info.addresses[0].value,
+        'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn',
+      );
+      expect(
+        account.info.addresses[1].value,
+        'FWscgV4VDSsMxkQg7jZ4HksqjLyadJS5RiCnAVZv2se9',
+      );
+      expect(
+        account.info.authority?.value,
+        '4msgK65vdz5ADUAB3eTQGpF388NuQUAoknLxutUQJd5B',
+      );
+      expect(account.info.deactivationSlot.value, '204699277');
+      expect(account.info.lastExtendedSlot.value, '204699234');
+      expect(account.info.lastExtendedSlotStartIndex, 20);
+    });
+
+    test('can be constructed without optional authority', () {
+      const account = JsonParsedAddressLookupTableAccount(
+        info: JsonParsedAddressLookupTableInfo(
+          addresses: [],
+          deactivationSlot: StringifiedBigInt('0'),
+          lastExtendedSlot: StringifiedBigInt('0'),
+          lastExtendedSlotStartIndex: 0,
+        ),
+      );
+
+      expect(account.info.authority, isNull);
+      expect(account.info.addresses, isEmpty);
+    });
+  });
+}

--- a/packages/solana_kit_rpc_parsed_types/test/bpf_upgradeable_loader_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/bpf_upgradeable_loader_accounts_test.dart
@@ -1,0 +1,64 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonParsedBpfUpgradeableLoaderProgramAccount', () {
+    test('can construct a program account', () {
+      const account = JsonParsedBpfProgram(
+        info: JsonParsedBpfProgramInfo(
+          programData: Address('3vnUTQbDuCgfVn7yQcigUwMQNGkLBZ7GfKWb3gYbAY23'),
+        ),
+      );
+
+      expect(account.type, 'program');
+      expect(
+        account.info.programData.value,
+        '3vnUTQbDuCgfVn7yQcigUwMQNGkLBZ7GfKWb3gYbAY23',
+      );
+      expect(account, isA<JsonParsedBpfUpgradeableLoaderProgramAccount>());
+    });
+
+    test('can construct a programData account', () {
+      final account = JsonParsedBpfProgramData(
+        info: JsonParsedBpfProgramDataInfo(
+          authority: const Address(
+            '7g4Los4WMQnpxYiBJpU1HejBiM6xCk5RDFGCABhWE9M6',
+          ),
+          data: (const Base64EncodedBytes('f0VMRgIBAAAAAAAAA'), 'base64'),
+          slot: BigInt.from(259942942),
+        ),
+      );
+
+      expect(account.type, 'programData');
+      expect(
+        account.info.authority?.value,
+        '7g4Los4WMQnpxYiBJpU1HejBiM6xCk5RDFGCABhWE9M6',
+      );
+      expect(account.info.slot, BigInt.from(259942942));
+      expect(account, isA<JsonParsedBpfUpgradeableLoaderProgramAccount>());
+    });
+
+    test('can discriminate via sealed class', () {
+      const JsonParsedBpfUpgradeableLoaderProgramAccount account =
+          JsonParsedBpfProgram(
+            info: JsonParsedBpfProgramInfo(
+              programData: Address(
+                '3vnUTQbDuCgfVn7yQcigUwMQNGkLBZ7GfKWb3gYbAY23',
+              ),
+            ),
+          );
+
+      switch (account) {
+        case JsonParsedBpfProgram(:final info):
+          expect(
+            info.programData.value,
+            '3vnUTQbDuCgfVn7yQcigUwMQNGkLBZ7GfKWb3gYbAY23',
+          );
+        case JsonParsedBpfProgramData():
+          fail('Expected program, got programData');
+      }
+    });
+  });
+}

--- a/packages/solana_kit_rpc_parsed_types/test/config_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/config_accounts_test.dart
@@ -1,0 +1,68 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonParsedConfigProgramAccount', () {
+    test('can construct a stakeConfig account', () {
+      const account = JsonParsedStakeConfig(
+        info: JsonParsedStakeConfigInfo(
+          slashPenalty: 12,
+          warmupCooldownRate: 0.25,
+        ),
+      );
+
+      expect(account.type, 'stakeConfig');
+      expect(account.info.slashPenalty, 12);
+      expect(account.info.warmupCooldownRate, 0.25);
+      expect(account, isA<JsonParsedConfigProgramAccount>());
+    });
+
+    test('can construct a validatorInfo account', () {
+      const account = JsonParsedValidatorInfo(
+        info: JsonParsedValidatorInfoData(
+          configData: {
+            'name': 'HoldTheNode',
+            'website': 'https://holdthenode.com',
+          },
+          keys: [
+            JsonParsedValidatorInfoKey(
+              pubkey: Address('Va1idator1nfo111111111111111111111111111111'),
+              signer: false,
+            ),
+            JsonParsedValidatorInfoKey(
+              pubkey: Address('5hvJ19nRgtzAkosb5bcx9bqeN2QA1Qwxq4M349Q2L6s2'),
+              signer: true,
+            ),
+          ],
+        ),
+      );
+
+      expect(account.type, 'validatorInfo');
+      expect(account.info.keys, hasLength(2));
+      expect(
+        account.info.keys[0].pubkey.value,
+        'Va1idator1nfo111111111111111111111111111111',
+      );
+      expect(account.info.keys[0].signer, isFalse);
+      expect(account.info.keys[1].signer, isTrue);
+      expect(account, isA<JsonParsedConfigProgramAccount>());
+    });
+
+    test('can discriminate via sealed class', () {
+      const JsonParsedConfigProgramAccount account = JsonParsedStakeConfig(
+        info: JsonParsedStakeConfigInfo(
+          slashPenalty: 12,
+          warmupCooldownRate: 0.25,
+        ),
+      );
+
+      switch (account) {
+        case JsonParsedStakeConfig(:final info):
+          expect(info.slashPenalty, 12);
+        case JsonParsedValidatorInfo():
+          fail('Expected stakeConfig, got validatorInfo');
+      }
+    });
+  });
+}

--- a/packages/solana_kit_rpc_parsed_types/test/nonce_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/nonce_accounts_test.dart
@@ -1,0 +1,30 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonParsedNonceAccount', () {
+    test('can be constructed with all fields', () {
+      const account = JsonParsedNonceAccount(
+        info: JsonParsedNonceInfo(
+          authority: Address('3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe'),
+          blockhash: Blockhash('TcVy2wVcs7WqWVopv8LAJBHQfqVYZrm8UDqjDvBFQt8'),
+          feeCalculator: JsonParsedNonceFeeCalculator(
+            lamportsPerSignature: StringifiedBigInt('5000'),
+          ),
+        ),
+      );
+
+      expect(
+        account.info.authority.value,
+        '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe',
+      );
+      expect(
+        account.info.blockhash.value,
+        'TcVy2wVcs7WqWVopv8LAJBHQfqVYZrm8UDqjDvBFQt8',
+      );
+      expect(account.info.feeCalculator.lamportsPerSignature.value, '5000');
+    });
+  });
+}

--- a/packages/solana_kit_rpc_parsed_types/test/rpc_parsed_type_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/rpc_parsed_type_test.dart
@@ -1,0 +1,21 @@
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RpcParsedType', () {
+    test('stores type and info', () {
+      const parsed = RpcParsedType(type: 'myType', info: 'myInfo');
+
+      expect(parsed.type, 'myType');
+      expect(parsed.info, 'myInfo');
+    });
+  });
+
+  group('RpcParsedInfo', () {
+    test('stores info', () {
+      const parsed = RpcParsedInfo(info: 'myInfo');
+
+      expect(parsed.info, 'myInfo');
+    });
+  });
+}

--- a/packages/solana_kit_rpc_parsed_types/test/stake_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/stake_accounts_test.dart
@@ -1,0 +1,99 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonParsedStakeProgramAccount', () {
+    JsonParsedStakeAccountInfo createStakeInfo() {
+      return JsonParsedStakeAccountInfo(
+        meta: JsonParsedStakeMeta(
+          authorized: const JsonParsedStakeAuthorized(
+            staker: Address('3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V'),
+            withdrawer: Address('3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V'),
+          ),
+          lockup: JsonParsedStakeLockup(
+            custodian: const Address('11111111111111111111111111111111'),
+            epoch: BigInt.zero,
+            unixTimestamp: UnixTimestamp(BigInt.zero),
+          ),
+          rentExemptReserve: const StringifiedBigInt('2282880'),
+        ),
+        stake: JsonParsedStakeData(
+          creditsObserved: BigInt.from(169965713),
+          delegation: const JsonParsedStakeDelegation(
+            activationEpoch: StringifiedBigInt('386'),
+            deactivationEpoch: StringifiedBigInt('471'),
+            stake: StringifiedBigInt('8007935'),
+            voter: Address('CertusDeBmqN8ZawdkxK5kFGMwBXdudvWHYwtNgNhvLu'),
+            warmupCooldownRate: 0.25,
+          ),
+        ),
+      );
+    }
+
+    test('can construct an initialized stake account', () {
+      final account = JsonParsedInitializedStake(info: createStakeInfo());
+
+      expect(account.type, 'initialized');
+      expect(
+        account.info.meta.authorized.staker.value,
+        '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+      );
+      expect(account.info.meta.rentExemptReserve.value, '2282880');
+      expect(account.info.stake?.delegation.stake.value, '8007935');
+      expect(account, isA<JsonParsedStakeProgramAccount>());
+    });
+
+    test('can construct a delegated stake account', () {
+      final account = JsonParsedDelegatedStake(info: createStakeInfo());
+
+      expect(account.type, 'delegated');
+      expect(
+        account.info.meta.authorized.staker.value,
+        '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+      );
+      expect(account.info.stake?.delegation.warmupCooldownRate, 0.25);
+      expect(account, isA<JsonParsedStakeProgramAccount>());
+    });
+
+    test('can construct a stake account without delegation', () {
+      final account = JsonParsedInitializedStake(
+        info: JsonParsedStakeAccountInfo(
+          meta: JsonParsedStakeMeta(
+            authorized: const JsonParsedStakeAuthorized(
+              staker: Address('3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V'),
+              withdrawer: Address(
+                '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+              ),
+            ),
+            lockup: JsonParsedStakeLockup(
+              custodian: const Address('11111111111111111111111111111111'),
+              epoch: BigInt.zero,
+              unixTimestamp: UnixTimestamp(BigInt.zero),
+            ),
+            rentExemptReserve: const StringifiedBigInt('2282880'),
+          ),
+        ),
+      );
+
+      expect(account.info.stake, isNull);
+    });
+
+    test('can discriminate via sealed class', () {
+      final JsonParsedStakeProgramAccount account = JsonParsedInitializedStake(
+        info: createStakeInfo(),
+      );
+
+      switch (account) {
+        case JsonParsedInitializedStake(:final info):
+          expect(
+            info.meta.authorized.staker.value,
+            '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+          );
+        case JsonParsedDelegatedStake():
+          fail('Expected initialized, got delegated');
+      }
+    });
+  });
+}

--- a/packages/solana_kit_rpc_parsed_types/test/sysvar_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/sysvar_accounts_test.dart
@@ -1,0 +1,228 @@
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonParsedSysvarAccount', () {
+    test('can construct a clock sysvar', () {
+      final account = JsonParsedClockSysvar(
+        info: JsonParsedClockInfo(
+          epoch: BigInt.zero,
+          epochStartTimestamp: UnixTimestamp(BigInt.from(1704907181)),
+          leaderScheduleEpoch: BigInt.one,
+          slot: BigInt.from(90829),
+          unixTimestamp: UnixTimestamp(BigInt.from(1704998009)),
+        ),
+      );
+
+      expect(account.type, 'clock');
+      expect(account.info.epoch, BigInt.zero);
+      expect(account.info.epochStartTimestamp.value, BigInt.from(1704907181));
+      expect(account.info.leaderScheduleEpoch, BigInt.one);
+      expect(account.info.slot, BigInt.from(90829));
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can construct an epochSchedule sysvar', () {
+      final account = JsonParsedEpochScheduleSysvar(
+        info: JsonParsedEpochScheduleInfo(
+          firstNormalEpoch: BigInt.zero,
+          firstNormalSlot: BigInt.zero,
+          leaderScheduleSlotOffset: BigInt.from(432000),
+          slotsPerEpoch: BigInt.from(432000),
+          warmup: false,
+        ),
+      );
+
+      expect(account.type, 'epochSchedule');
+      expect(account.info.firstNormalEpoch, BigInt.zero);
+      expect(account.info.slotsPerEpoch, BigInt.from(432000));
+      expect(account.info.warmup, isFalse);
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can construct a fees sysvar (deprecated)', () {
+      const account = JsonParsedFeesSysvar(
+        info: JsonParsedFeesInfo(
+          feeCalculator: JsonParsedFeeCalculator(
+            lamportsPerSignature: StringifiedBigInt('0'),
+          ),
+        ),
+      );
+
+      expect(account.type, 'fees');
+      expect(account.info.feeCalculator.lamportsPerSignature.value, '0');
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can construct a recentBlockhashes sysvar (deprecated)', () {
+      const account = JsonParsedRecentBlockhashesSysvar(
+        info: [
+          JsonParsedRecentBlockhashEntry(
+            blockhash: Blockhash(
+              'Gy5GKD5p7UmUWF2BEm3TAUP4PSLTw9puSUbuoH5xPdzk',
+            ),
+            feeCalculator: JsonParsedFeeCalculator(
+              lamportsPerSignature: StringifiedBigInt('5000'),
+            ),
+          ),
+          JsonParsedRecentBlockhashEntry(
+            blockhash: Blockhash(
+              'FvNKRQk7TuFXVmXEM4XEubXdYREaeiWX56SL97taEhAQ',
+            ),
+            feeCalculator: JsonParsedFeeCalculator(
+              lamportsPerSignature: StringifiedBigInt('5000'),
+            ),
+          ),
+        ],
+      );
+
+      expect(account.type, 'recentBlockhashes');
+      expect(account.info, hasLength(2));
+      expect(
+        account.info[0].blockhash.value,
+        'Gy5GKD5p7UmUWF2BEm3TAUP4PSLTw9puSUbuoH5xPdzk',
+      );
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can construct a rent sysvar', () {
+      const account = JsonParsedRentSysvar(
+        info: JsonParsedRentInfo(
+          burnPercent: 50,
+          exemptionThreshold: 2,
+          lamportsPerByteYear: StringifiedBigInt('3480'),
+        ),
+      );
+
+      expect(account.type, 'rent');
+      expect(account.info.burnPercent, 50);
+      expect(account.info.exemptionThreshold, 2.0);
+      expect(account.info.lamportsPerByteYear.value, '3480');
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can construct a slotHashes sysvar', () {
+      final account = JsonParsedSlotHashesSysvar(
+        info: [
+          JsonParsedSlotHashEntry(
+            hash: 'BAwX3h9EtGqBGnvXqgBoTZL19iHY8PKeCS9AVWFsVLQ8',
+            slot: BigInt.from(149694),
+          ),
+          JsonParsedSlotHashEntry(
+            hash: '7HdyQAb5kaZ9RjTuX8uejYXj86J3P2foNfDkqLAFNYFF',
+            slot: BigInt.from(149693),
+          ),
+        ],
+      );
+
+      expect(account.type, 'slotHashes');
+      expect(account.info, hasLength(2));
+      expect(
+        account.info[0].hash,
+        'BAwX3h9EtGqBGnvXqgBoTZL19iHY8PKeCS9AVWFsVLQ8',
+      );
+      expect(account.info[0].slot, BigInt.from(149694));
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can construct a slotHistory sysvar', () {
+      final account = JsonParsedSlotHistorySysvar(
+        info: JsonParsedSlotHistoryInfo(
+          bits: '1111100000',
+          nextSlot: BigInt.from(150104),
+        ),
+      );
+
+      expect(account.type, 'slotHistory');
+      expect(account.info.bits, '1111100000');
+      expect(account.info.nextSlot, BigInt.from(150104));
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can construct a stakeHistory sysvar', () {
+      final account = JsonParsedStakeHistorySysvar(
+        info: [
+          JsonParsedStakeHistoryEntry(
+            epoch: BigInt.from(683),
+            stakeHistory: JsonParsedStakeHistoryData(
+              activating: BigInt.zero,
+              deactivating: BigInt.zero,
+              effective: BigInt.from(6561315032320),
+            ),
+          ),
+          JsonParsedStakeHistoryEntry(
+            epoch: BigInt.from(682),
+            stakeHistory: JsonParsedStakeHistoryData(
+              activating: BigInt.zero,
+              deactivating: BigInt.zero,
+              effective: BigInt.from(506560815032320),
+            ),
+          ),
+        ],
+      );
+
+      expect(account.type, 'stakeHistory');
+      expect(account.info, hasLength(2));
+      expect(account.info[0].epoch, BigInt.from(683));
+      expect(
+        account.info[0].stakeHistory.effective,
+        BigInt.from(6561315032320),
+      );
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can construct a lastRestartSlot sysvar', () {
+      final account = JsonParsedLastRestartSlotSysvar(
+        info: JsonParsedLastRestartSlotInfo(lastRestartSlot: BigInt.zero),
+      );
+
+      expect(account.type, 'lastRestartSlot');
+      expect(account.info.lastRestartSlot, BigInt.zero);
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can construct an epochRewards sysvar', () {
+      final account = JsonParsedEpochRewardsSysvar(
+        info: JsonParsedEpochRewardsInfo(
+          distributedRewards: BigInt.from(100),
+          distributionCompleteBlockHeight: BigInt.from(1000),
+          totalRewards: BigInt.from(200),
+        ),
+      );
+
+      expect(account.type, 'epochRewards');
+      expect(account.info.distributedRewards, BigInt.from(100));
+      expect(account.info.distributionCompleteBlockHeight, BigInt.from(1000));
+      expect(account.info.totalRewards, BigInt.from(200));
+      expect(account, isA<JsonParsedSysvarAccount>());
+    });
+
+    test('can discriminate via sealed class', () {
+      final JsonParsedSysvarAccount account = JsonParsedClockSysvar(
+        info: JsonParsedClockInfo(
+          epoch: BigInt.zero,
+          epochStartTimestamp: UnixTimestamp(BigInt.from(1704907181)),
+          leaderScheduleEpoch: BigInt.one,
+          slot: BigInt.from(90829),
+          unixTimestamp: UnixTimestamp(BigInt.from(1704998009)),
+        ),
+      );
+
+      switch (account) {
+        case JsonParsedClockSysvar(:final info):
+          expect(info.epoch, BigInt.zero);
+        case JsonParsedEpochRewardsSysvar():
+        case JsonParsedEpochScheduleSysvar():
+        case JsonParsedFeesSysvar():
+        case JsonParsedLastRestartSlotSysvar():
+        case JsonParsedRecentBlockhashesSysvar():
+        case JsonParsedRentSysvar():
+        case JsonParsedSlotHashesSysvar():
+        case JsonParsedSlotHistorySysvar():
+        case JsonParsedStakeHistorySysvar():
+          fail('Expected clock sysvar');
+      }
+    });
+  });
+}

--- a/packages/solana_kit_rpc_parsed_types/test/token_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/token_accounts_test.dart
@@ -1,0 +1,103 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonParsedTokenProgramAccount', () {
+    test('can construct a token account', () {
+      const account = JsonParsedTokenAccountVariant(
+        info: JsonParsedTokenAccount(
+          isNative: false,
+          mint: Address('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr'),
+          owner: Address('6UsGbaMgchgj4wiwKKuE1v5URHdcDfEiMSM25QpesKir'),
+          state: TokenAccountState.initialized,
+          tokenAmount: TokenAmount(
+            amount: StringifiedBigInt('9999999779500000'),
+            decimals: 6,
+            uiAmountString: StringifiedNumber('9999999779.5'),
+          ),
+        ),
+      );
+
+      expect(account.type, 'account');
+      expect(
+        account.info.mint.value,
+        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+      );
+      expect(
+        account.info.owner.value,
+        '6UsGbaMgchgj4wiwKKuE1v5URHdcDfEiMSM25QpesKir',
+      );
+      expect(account.info.isNative, isFalse);
+      expect(account.info.state, TokenAccountState.initialized);
+      expect(account.info.tokenAmount.amount.value, '9999999779500000');
+      expect(account.info.tokenAmount.decimals, 6);
+      expect(account, isA<JsonParsedTokenProgramAccount>());
+    });
+
+    test('can construct a mint account', () {
+      const account = JsonParsedMintAccount(
+        info: JsonParsedMintInfo(
+          decimals: 6,
+          isInitialized: true,
+          supply: StringifiedBigInt('1792635195340523528'),
+          mintAuthority: Address(
+            'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+          ),
+        ),
+      );
+
+      expect(account.type, 'mint');
+      expect(account.info.decimals, 6);
+      expect(account.info.isInitialized, isTrue);
+      expect(account.info.supply.value, '1792635195340523528');
+      expect(
+        account.info.mintAuthority?.value,
+        'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+      );
+      expect(account.info.freezeAuthority, isNull);
+      expect(account, isA<JsonParsedTokenProgramAccount>());
+    });
+
+    test('can construct a multisig account', () {
+      const account = JsonParsedMultisigAccount(
+        info: JsonParsedMultisigInfo(
+          isInitialized: true,
+          numRequiredSigners: 2,
+          numValidSigners: 2,
+          signers: [
+            Address('Fkc4FN7PPhyGsAcHPW3dBBJ4BvtYkDr2rBFBgFpvy3nB'),
+            Address('5scSndUhfZJ8j8wZz5UNHhvuPBhvN1RboTdkKSvFHLtW'),
+          ],
+        ),
+      );
+
+      expect(account.type, 'multisig');
+      expect(account.info.isInitialized, isTrue);
+      expect(account.info.numRequiredSigners, 2);
+      expect(account.info.numValidSigners, 2);
+      expect(account.info.signers, hasLength(2));
+      expect(account, isA<JsonParsedTokenProgramAccount>());
+    });
+
+    test('can discriminate via sealed class', () {
+      const JsonParsedTokenProgramAccount account = JsonParsedMintAccount(
+        info: JsonParsedMintInfo(
+          decimals: 6,
+          isInitialized: true,
+          supply: StringifiedBigInt('1792635195340523528'),
+        ),
+      );
+
+      switch (account) {
+        case JsonParsedMintAccount(:final info):
+          expect(info.supply.value, '1792635195340523528');
+        case JsonParsedTokenAccountVariant():
+          fail('Expected mint, got account');
+        case JsonParsedMultisigAccount():
+          fail('Expected mint, got multisig');
+      }
+    });
+  });
+}

--- a/packages/solana_kit_rpc_parsed_types/test/vote_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/vote_accounts_test.dart
@@ -1,0 +1,104 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonParsedVoteAccount', () {
+    test('can be constructed with all fields', () {
+      final account = JsonParsedVoteAccount(
+        info: JsonParsedVoteInfo(
+          authorizedVoters: [
+            JsonParsedAuthorizedVoter(
+              authorizedVoter: const Address(
+                'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+              ),
+              epoch: BigInt.from(529),
+            ),
+          ],
+          authorizedWithdrawer: const Address(
+            'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+          ),
+          commission: 50,
+          epochCredits: [
+            JsonParsedEpochCredit(
+              credits: const StringifiedBigInt('68697256'),
+              epoch: BigInt.from(466),
+              previousCredits: const StringifiedBigInt('68325825'),
+            ),
+            JsonParsedEpochCredit(
+              credits: const StringifiedBigInt('69068118'),
+              epoch: BigInt.from(467),
+              previousCredits: const StringifiedBigInt('68697256'),
+            ),
+          ],
+          lastTimestamp: JsonParsedLastTimestamp(
+            slot: BigInt.from(228884530),
+            timestamp: UnixTimestamp(BigInt.from(1689090220)),
+          ),
+          nodePubkey: const Address(
+            'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+          ),
+          priorVoters: [],
+          rootSlot: BigInt.from(228884499),
+          votes: [
+            JsonParsedVote(confirmationCount: 31, slot: BigInt.from(228884500)),
+            JsonParsedVote(confirmationCount: 30, slot: BigInt.from(228884501)),
+          ],
+        ),
+      );
+
+      expect(account.info.authorizedVoters, hasLength(1));
+      expect(
+        account.info.authorizedVoters[0].authorizedVoter.value,
+        'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+      );
+      expect(account.info.authorizedVoters[0].epoch, BigInt.from(529));
+      expect(
+        account.info.authorizedWithdrawer.value,
+        'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+      );
+      expect(account.info.commission, 50);
+      expect(account.info.epochCredits, hasLength(2));
+      expect(account.info.epochCredits[0].credits.value, '68697256');
+      expect(account.info.lastTimestamp.slot, BigInt.from(228884530));
+      expect(
+        account.info.lastTimestamp.timestamp.value,
+        BigInt.from(1689090220),
+      );
+      expect(
+        account.info.nodePubkey.value,
+        'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+      );
+      expect(account.info.priorVoters, isEmpty);
+      expect(account.info.rootSlot, BigInt.from(228884499));
+      expect(account.info.votes, hasLength(2));
+      expect(account.info.votes[0].confirmationCount, 31);
+      expect(account.info.votes[0].slot, BigInt.from(228884500));
+    });
+
+    test('can be constructed with null rootSlot', () {
+      final account = JsonParsedVoteAccount(
+        info: JsonParsedVoteInfo(
+          authorizedVoters: [],
+          authorizedWithdrawer: const Address(
+            'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+          ),
+          commission: 0,
+          epochCredits: [],
+          lastTimestamp: JsonParsedLastTimestamp(
+            slot: BigInt.zero,
+            timestamp: UnixTimestamp(BigInt.zero),
+          ),
+          nodePubkey: const Address(
+            'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+          ),
+          priorVoters: [],
+          votes: [],
+        ),
+      );
+
+      expect(account.info.rootSlot, isNull);
+    });
+  });
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -191,9 +191,9 @@
 
 ### solana_kit_rpc_parsed_types (~10 source files, ~8 test files)
 
-- [ ] T072 [P] [US2] Port parsed account types (token, stake, vote, etc.) from `.repos/kit/packages/rpc-parsed-types/src/` to `packages/solana_kit_rpc_parsed_types/lib/src/`
-- [ ] T073 [US2] Update barrel export `packages/solana_kit_rpc_parsed_types/lib/solana_kit_rpc_parsed_types.dart`
-- [ ] T074 [US2] Port all 8 test files from `.repos/kit/packages/rpc-parsed-types/src/__tests__/` to `packages/solana_kit_rpc_parsed_types/test/`
+- [x] T072 [P] [US2] Port parsed account types (token, stake, vote, etc.) from `.repos/kit/packages/rpc-parsed-types/src/` to `packages/solana_kit_rpc_parsed_types/lib/src/`
+- [x] T073 [US2] Update barrel export `packages/solana_kit_rpc_parsed_types/lib/solana_kit_rpc_parsed_types.dart`
+- [x] T074 [US2] Port all 8 test files from `.repos/kit/packages/rpc-parsed-types/src/__tests__/` to `packages/solana_kit_rpc_parsed_types/test/`
 
 ### solana_kit_rpc_transformers (~16 source files, ~7 test files)
 


### PR DESCRIPTION
## Summary

- Implements `solana_kit_rpc_parsed_types` ported from `@solana/rpc-parsed-types`
- Typed JSON-parsed account data for 8 Solana program types
- Sealed class hierarchies for discriminated unions (BPF loader, config, stake, sysvar, token)
- All 10 sysvar types, token program accounts (account/mint/multisig), stake delegations
- 32 tests passing

## Test plan

- [x] `dart test packages/solana_kit_rpc_parsed_types` — 32 tests pass
- [x] `dart analyze packages/solana_kit_rpc_parsed_types` — no issues
- [x] `dart format --set-exit-if-changed packages/solana_kit_rpc_parsed_types` — clean