### PR TITLE
✨ feat: implement RPC transformers package

### DIFF
--- a/.changeset/rpc-transformers.md
+++ b/.changeset/rpc-transformers.md
@@ -1,0 +1,14 @@
+---
+solana_kit_rpc_transformers: minor
+---
+
+Implement RPC transformers package ported from `@solana/rpc-transformers`.
+
+**solana_kit_rpc_transformers** (524 tests):
+
+- Request transformers: BigInt downcast, integer overflow detection, default commitment injection
+- Response transformers: BigInt upcast, JSON-RPC error throwing with Solana error unwrapping, result extraction
+- Tree traversal utilities with key path wildcards for deep object walking
+- Default commitment handling for 39 RPC methods with per-method config position mapping
+- Preflight error unwrapping from `-32002` JSON-RPC errors
+- Composable transformer pipelines via `getDefaultRequestTransformerForSolanaRpc` and `getDefaultResponseTransformerForSolanaRpc`

--- a/packages/solana_kit_rpc_transformers/lib/solana_kit_rpc_transformers.dart
+++ b/packages/solana_kit_rpc_transformers/lib/solana_kit_rpc_transformers.dart
@@ -1,1 +1,18 @@
+/// Request and response transformers for the Solana JSON-RPC API.
+///
+/// This package provides helpers for transforming Solana JSON RPC and RPC
+/// Subscriptions requests, responses, and notifications in various ways
+/// appropriate for use in a Dart application.
+library;
 
+export 'src/request_transformer.dart';
+export 'src/request_transformer_bigint_downcast.dart';
+export 'src/request_transformer_default_commitment.dart';
+export 'src/request_transformer_integer_overflow.dart';
+export 'src/request_transformer_options_object_position_config.dart';
+export 'src/response_transformer.dart';
+export 'src/response_transformer_allowed_numeric_values.dart';
+export 'src/response_transformer_bigint_upcast.dart';
+export 'src/response_transformer_result.dart';
+export 'src/response_transformer_throw_solana_error.dart';
+export 'src/tree_traversal.dart';

--- a/packages/solana_kit_rpc_transformers/lib/src/request_transformer.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/request_transformer.dart
@@ -1,0 +1,58 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/src/request_transformer_bigint_downcast.dart';
+import 'package:solana_kit_rpc_transformers/src/request_transformer_default_commitment.dart';
+import 'package:solana_kit_rpc_transformers/src/request_transformer_integer_overflow.dart';
+import 'package:solana_kit_rpc_transformers/src/request_transformer_options_object_position_config.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Configuration for the default request transformer.
+class RequestTransformerConfig {
+  /// Creates a new [RequestTransformerConfig].
+  const RequestTransformerConfig({
+    this.defaultCommitment,
+    this.onIntegerOverflow,
+  });
+
+  /// An optional [Commitment] value to use as the default when none is
+  /// supplied by the caller.
+  final Commitment? defaultCommitment;
+
+  /// An optional function that will be called whenever a [BigInt] input
+  /// exceeds that which can be expressed using JavaScript numbers.
+  ///
+  /// This is used in the default Solana RPC API to throw an exception rather
+  /// than to allow truncated values to propagate through a program.
+  final IntegerOverflowHandler? onIntegerOverflow;
+}
+
+/// Returns the default request transformer for the Solana RPC API.
+///
+/// Under the hood, this function composes multiple
+/// [RpcRequestTransformer]s together: the integer overflow checker,
+/// the BigInt downcast transformer, and the default commitment transformer.
+RpcRequestTransformer getDefaultRequestTransformerForSolanaRpc([
+  RequestTransformerConfig? config,
+]) {
+  final handleIntegerOverflow = config?.onIntegerOverflow;
+  return (RpcRequest<Object?> request) {
+    var result = request;
+
+    // Step 1: Check for integer overflow (if handler provided).
+    if (handleIntegerOverflow != null) {
+      result = getIntegerOverflowRequestTransformer(handleIntegerOverflow)(
+        result,
+      );
+    }
+
+    // Step 2: Downcast BigInt values to int.
+    result = getBigIntDowncastRequestTransformer()(result);
+
+    // Step 3: Apply default commitment.
+    result = getDefaultCommitmentRequestTransformer(
+      optionsObjectPositionByMethod: OPTIONS_OBJECT_POSITION_BY_METHOD,
+      defaultCommitment: config?.defaultCommitment,
+    )(result);
+
+    return result;
+  };
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/request_transformer_bigint_downcast.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/request_transformer_bigint_downcast.dart
@@ -1,0 +1,14 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+import 'package:solana_kit_rpc_transformers/src/request_transformer_bigint_downcast_internal.dart';
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+
+/// Creates a transformer that downcasts all [BigInt] values to [int].
+///
+/// This is necessary because JSON encoding does not support [BigInt] values
+/// directly.
+RpcRequestTransformer getBigIntDowncastRequestTransformer() {
+  return getTreeWalkerRequestTransformer([
+    downcastNodeToNumberIfBigint,
+  ], const TraversalState(keyPath: []));
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/request_transformer_bigint_downcast_internal.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/request_transformer_bigint_downcast_internal.dart
@@ -1,0 +1,9 @@
+/// Downcasts a [BigInt] value to a [num] (specifically an [int]).
+///
+/// If the value is not a [BigInt], it is returned as-is.
+Object? downcastNodeToNumberIfBigint(Object? value, _) {
+  if (value is BigInt) {
+    return value.toInt();
+  }
+  return value;
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/request_transformer_default_commitment.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/request_transformer_default_commitment.dart
@@ -1,0 +1,42 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/src/request_transformer_default_commitment_internal.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Creates a transformer that adds the provided default commitment to the
+/// configuration object of the request when applicable.
+///
+/// For the `sendTransaction` method, the commitment property name is
+/// `preflightCommitment` instead of `commitment`.
+RpcRequestTransformer getDefaultCommitmentRequestTransformer({
+  required Map<String, int> optionsObjectPositionByMethod,
+  Commitment? defaultCommitment,
+}) {
+  return (RpcRequest<Object?> request) {
+    final params = request.params;
+
+    // We only apply default commitment to list parameters.
+    if (params is! List) {
+      return request;
+    }
+
+    // Find the position of the options object in the parameters and abort if
+    // not found.
+    final optionsObjectPositionInParams =
+        optionsObjectPositionByMethod[request.methodName];
+    if (optionsObjectPositionInParams == null) {
+      return request;
+    }
+
+    return RpcRequest(
+      methodName: request.methodName,
+      params: applyDefaultCommitment(
+        commitmentPropertyName: request.methodName == 'sendTransaction'
+            ? 'preflightCommitment'
+            : 'commitment',
+        optionsObjectPositionInParams: optionsObjectPositionInParams,
+        overrideCommitment: defaultCommitment,
+        params: List<Object?>.of(params),
+      ),
+    );
+  };
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/request_transformer_default_commitment_internal.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/request_transformer_default_commitment_internal.dart
@@ -1,0 +1,70 @@
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Applies a default commitment to the params list at the given position.
+///
+/// This function handles several cases:
+/// - If no config object exists, it creates one with the default commitment.
+/// - If the config object already has a commitment that is `finalized` or
+///   `null`, it removes the commitment (since `finalized` is the server
+///   default).
+/// - If the config object has a different commitment, it leaves it as-is.
+/// - If the override commitment is `finalized`, no default is applied (since
+///   it is the server default).
+List<Object?> applyDefaultCommitment({
+  required String commitmentPropertyName,
+  required List<Object?> params,
+  required int optionsObjectPositionInParams,
+  Commitment? overrideCommitment,
+}) {
+  final paramInTargetPosition = optionsObjectPositionInParams < params.length
+      ? params[optionsObjectPositionInParams]
+      : null;
+
+  // Check that the param is either undefined or is a Map (not an array or
+  // primitive).
+  if (paramInTargetPosition == null ||
+      (paramInTargetPosition is Map<String, Object?> &&
+          paramInTargetPosition is! List)) {
+    final configMap = paramInTargetPosition as Map<String, Object?>?;
+
+    if (configMap != null && configMap.containsKey(commitmentPropertyName)) {
+      // The config object already has a commitment set.
+      final existingCommitment = configMap[commitmentPropertyName];
+
+      if (existingCommitment == null ||
+          existingCommitment == Commitment.finalized.name) {
+        // Delete the commitment property; `finalized` is already the server
+        // default.
+        final nextParams = List<Object?>.of(params);
+        final rest = Map<String, Object?>.of(configMap)
+          ..remove(commitmentPropertyName);
+
+        if (rest.isNotEmpty) {
+          nextParams[optionsObjectPositionInParams] = rest;
+        } else {
+          if (optionsObjectPositionInParams == nextParams.length - 1) {
+            nextParams.removeAt(nextParams.length - 1);
+          } else {
+            nextParams[optionsObjectPositionInParams] = null;
+          }
+        }
+        return nextParams;
+      }
+    } else if (overrideCommitment != null &&
+        overrideCommitment != Commitment.finalized) {
+      // Apply the default commitment.
+      final nextParams = List<Object?>.of(params);
+      // Ensure the list is long enough.
+      while (nextParams.length <= optionsObjectPositionInParams) {
+        nextParams.add(null);
+      }
+      nextParams[optionsObjectPositionInParams] = <String, Object?>{
+        if (configMap != null) ...configMap,
+        commitmentPropertyName: overrideCommitment.name,
+      };
+      return nextParams;
+    }
+  }
+
+  return params;
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/request_transformer_integer_overflow.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/request_transformer_integer_overflow.dart
@@ -1,0 +1,31 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+import 'package:solana_kit_rpc_transformers/src/request_transformer_integer_overflow_internal.dart';
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+
+/// A callback function that is invoked when an integer overflow is detected
+/// in request parameters.
+///
+/// The [request] is the original RPC request, [keyPath] indicates the
+/// location of the overflowing value in the parameter tree, and [value]
+/// is the [BigInt] value that exceeded the safe integer range.
+typedef IntegerOverflowHandler =
+    void Function(RpcRequest<Object?> request, KeyPath keyPath, BigInt value);
+
+/// Creates a transformer that traverses the request parameters and executes
+/// the provided handler when an integer overflow is detected.
+///
+/// An integer overflow occurs when a [BigInt] value exceeds
+/// `Number.MAX_SAFE_INTEGER` (2^53 - 1) or is below its negative counterpart.
+RpcRequestTransformer getIntegerOverflowRequestTransformer(
+  IntegerOverflowHandler onIntegerOverflow,
+) {
+  return (RpcRequest<Object?> request) {
+    final transformer = getTreeWalkerRequestTransformer([
+      getIntegerOverflowNodeVisitor(
+        (keyPath, value) => onIntegerOverflow(request, keyPath, value),
+      ),
+    ], const TraversalState(keyPath: []));
+    return transformer(request);
+  };
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/request_transformer_integer_overflow_internal.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/request_transformer_integer_overflow_internal.dart
@@ -1,0 +1,23 @@
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+
+/// JavaScript's `Number.MAX_SAFE_INTEGER` equivalent.
+///
+/// In the TS SDK, this is `2^53 - 1`, which is the largest integer that can be
+/// represented exactly as a JavaScript `Number`.
+const int _maxSafeInteger = 9007199254740991; // 2^53 - 1
+
+/// Creates a node visitor that calls [onIntegerOverflow] when a [BigInt] value
+/// exceeds the safe integer range (`-2^53 + 1` to `2^53 - 1`).
+NodeVisitor getIntegerOverflowNodeVisitor(
+  void Function(KeyPath keyPath, BigInt value) onIntegerOverflow,
+) {
+  return (Object? value, TraversalState state) {
+    if (value is BigInt) {
+      if (value > BigInt.from(_maxSafeInteger) ||
+          value < BigInt.from(-_maxSafeInteger)) {
+        onIntegerOverflow(state.keyPath, value);
+      }
+    }
+    return value;
+  };
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/request_transformer_options_object_position_config.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/request_transformer_options_object_position_config.dart
@@ -1,0 +1,47 @@
+/// Maps RPC method names to the index of the options/config object in their
+/// parameter lists.
+///
+/// This is used by the default commitment transformer to know where to insert
+/// or modify commitment values.
+// ignore: constant_identifier_names
+const Map<String, int> OPTIONS_OBJECT_POSITION_BY_METHOD = {
+  'accountNotifications': 1,
+  'blockNotifications': 1,
+  'getAccountInfo': 1,
+  'getBalance': 1,
+  'getBlock': 1,
+  'getBlockHeight': 0,
+  'getBlockProduction': 0,
+  'getBlocks': 2,
+  'getBlocksWithLimit': 2,
+  'getEpochInfo': 0,
+  'getFeeForMessage': 1,
+  'getInflationGovernor': 0,
+  'getInflationReward': 1,
+  'getLargestAccounts': 0,
+  'getLatestBlockhash': 0,
+  'getLeaderSchedule': 1,
+  'getMinimumBalanceForRentExemption': 1,
+  'getMultipleAccounts': 1,
+  'getProgramAccounts': 1,
+  'getSignaturesForAddress': 1,
+  'getSlot': 0,
+  'getSlotLeader': 0,
+  'getStakeMinimumDelegation': 0,
+  'getSupply': 0,
+  'getTokenAccountBalance': 1,
+  'getTokenAccountsByDelegate': 2,
+  'getTokenAccountsByOwner': 2,
+  'getTokenLargestAccounts': 1,
+  'getTokenSupply': 1,
+  'getTransaction': 1,
+  'getTransactionCount': 0,
+  'getVoteAccounts': 0,
+  'isBlockhashValid': 1,
+  'logsNotifications': 1,
+  'programNotifications': 1,
+  'requestAirdrop': 2,
+  'sendTransaction': 1,
+  'signatureNotifications': 1,
+  'simulateTransaction': 1,
+};

--- a/packages/solana_kit_rpc_transformers/lib/src/response_transformer.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/response_transformer.dart
@@ -1,0 +1,71 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+import 'package:solana_kit_rpc_transformers/src/response_transformer_allowed_numeric_values.dart';
+import 'package:solana_kit_rpc_transformers/src/response_transformer_bigint_upcast.dart';
+import 'package:solana_kit_rpc_transformers/src/response_transformer_result.dart';
+import 'package:solana_kit_rpc_transformers/src/response_transformer_throw_solana_error.dart';
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+
+/// Configuration for the default response transformer.
+class ResponseTransformerConfig {
+  /// Creates a new [ResponseTransformerConfig].
+  const ResponseTransformerConfig({this.allowedNumericKeyPaths});
+
+  /// An optional map from the name of an API method to a list of [KeyPath]s
+  /// pointing to values in the response that should materialize in the
+  /// application as [int] instead of [BigInt].
+  final AllowedNumericKeypaths? allowedNumericKeyPaths;
+}
+
+/// Returns the default response transformer for the Solana RPC API.
+///
+/// Under the hood, this function composes multiple response transformers
+/// together: the throw-on-error transformer, the result extractor, and
+/// the BigInt upcast transformer.
+RpcResponseTransformer<Object?> getDefaultResponseTransformerForSolanaRpc([
+  ResponseTransformerConfig? config,
+]) {
+  return (Object? response, RpcRequest<Object?> request) {
+    final methodName = request.methodName;
+    final keyPaths =
+        config?.allowedNumericKeyPaths != null && methodName.isNotEmpty
+        ? config!.allowedNumericKeyPaths![methodName]
+        : null;
+
+    // Step 1: Throw on error.
+    var result = getThrowSolanaErrorResponseTransformer()(response, request);
+
+    // Step 2: Extract result.
+    result = getResultResponseTransformer()(result, request);
+
+    // Step 3: BigInt upcast.
+    result = getBigIntUpcastResponseTransformer(keyPaths ?? [])(
+      result,
+      request,
+    );
+
+    return result;
+  };
+}
+
+/// Returns the default response transformer for the Solana RPC Subscriptions
+/// API.
+///
+/// Under the hood, this function composes the BigInt upcast transformer.
+RpcResponseTransformer<Object?>
+getDefaultResponseTransformerForSolanaRpcSubscriptions([
+  ResponseTransformerConfig? config,
+]) {
+  return (Object? response, RpcRequest<Object?> request) {
+    final methodName = request.methodName;
+    final keyPaths =
+        config?.allowedNumericKeyPaths != null && methodName.isNotEmpty
+        ? config!.allowedNumericKeyPaths![methodName]
+        : null;
+
+    return getBigIntUpcastResponseTransformer(keyPaths ?? [])(
+      response,
+      request,
+    );
+  };
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/response_transformer_allowed_numeric_values.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/response_transformer_allowed_numeric_values.dart
@@ -1,0 +1,107 @@
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+
+/// A mapping from API method names to the key paths whose values should
+/// remain as [int] (rather than being upcast to [BigInt]).
+typedef AllowedNumericKeypaths = Map<String, List<KeyPath>>;
+
+/// Numeric values nested in `jsonParsed` token accounts.
+final List<KeyPath> jsonParsedTokenAccountsConfigs = [
+  // parsed Token/Token22 token account
+  ['data', 'parsed', 'info', 'tokenAmount', 'decimals'],
+  ['data', 'parsed', 'info', 'tokenAmount', 'uiAmount'],
+  ['data', 'parsed', 'info', 'rentExemptReserve', 'decimals'],
+  ['data', 'parsed', 'info', 'rentExemptReserve', 'uiAmount'],
+  ['data', 'parsed', 'info', 'delegatedAmount', 'decimals'],
+  ['data', 'parsed', 'info', 'delegatedAmount', 'uiAmount'],
+  [
+    'data',
+    'parsed',
+    'info',
+    'extensions',
+    KEYPATH_WILDCARD,
+    'state',
+    'olderTransferFee',
+    'transferFeeBasisPoints',
+  ],
+  [
+    'data',
+    'parsed',
+    'info',
+    'extensions',
+    KEYPATH_WILDCARD,
+    'state',
+    'newerTransferFee',
+    'transferFeeBasisPoints',
+  ],
+  [
+    'data',
+    'parsed',
+    'info',
+    'extensions',
+    KEYPATH_WILDCARD,
+    'state',
+    'preUpdateAverageRate',
+  ],
+  [
+    'data',
+    'parsed',
+    'info',
+    'extensions',
+    KEYPATH_WILDCARD,
+    'state',
+    'currentRate',
+  ],
+];
+
+/// Numeric values nested in `jsonParsed` accounts (includes token accounts).
+final List<KeyPath> jsonParsedAccountsConfigs = [
+  ...jsonParsedTokenAccountsConfigs,
+  // parsed AddressTableLookup account
+  ['data', 'parsed', 'info', 'lastExtendedSlotStartIndex'],
+  // parsed Config account
+  ['data', 'parsed', 'info', 'slashPenalty'],
+  ['data', 'parsed', 'info', 'warmupCooldownRate'],
+  // parsed Token/Token22 mint account
+  ['data', 'parsed', 'info', 'decimals'],
+  // parsed Token/Token22 multisig account
+  ['data', 'parsed', 'info', 'numRequiredSigners'],
+  ['data', 'parsed', 'info', 'numValidSigners'],
+  // parsed Stake account
+  ['data', 'parsed', 'info', 'stake', 'delegation', 'warmupCooldownRate'],
+  // parsed Sysvar rent account
+  ['data', 'parsed', 'info', 'exemptionThreshold'],
+  ['data', 'parsed', 'info', 'burnPercent'],
+  // parsed Vote account
+  ['data', 'parsed', 'info', 'commission'],
+  ['data', 'parsed', 'info', 'votes', KEYPATH_WILDCARD, 'confirmationCount'],
+];
+
+/// Numeric values in inner instructions.
+final List<KeyPath> innerInstructionsConfigs = [
+  ['index'],
+  ['instructions', KEYPATH_WILDCARD, 'accounts', KEYPATH_WILDCARD],
+  ['instructions', KEYPATH_WILDCARD, 'programIdIndex'],
+  ['instructions', KEYPATH_WILDCARD, 'stackHeight'],
+];
+
+/// Numeric values in transaction messages.
+final List<KeyPath> messageConfig = [
+  [
+    'addressTableLookups',
+    KEYPATH_WILDCARD,
+    'writableIndexes',
+    KEYPATH_WILDCARD,
+  ],
+  [
+    'addressTableLookups',
+    KEYPATH_WILDCARD,
+    'readonlyIndexes',
+    KEYPATH_WILDCARD,
+  ],
+  ['header', 'numReadonlySignedAccounts'],
+  ['header', 'numReadonlyUnsignedAccounts'],
+  ['header', 'numRequiredSignatures'],
+  ['instructions', KEYPATH_WILDCARD, 'accounts', KEYPATH_WILDCARD],
+  ['instructions', KEYPATH_WILDCARD, 'programIdIndex'],
+  ['instructions', KEYPATH_WILDCARD, 'stackHeight'],
+];

--- a/packages/solana_kit_rpc_transformers/lib/src/response_transformer_bigint_upcast.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/response_transformer_bigint_upcast.dart
@@ -1,0 +1,19 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+import 'package:solana_kit_rpc_transformers/src/response_transformer_bigint_upcast_internal.dart';
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+
+/// Returns a transformer that upcasts all integer values to [BigInt] unless
+/// they match within the provided [KeyPath]s.
+///
+/// In other words, the provided [KeyPath]s will remain as [int] values; any
+/// other numeric value will be upcasted to a [BigInt].
+///
+/// You can use [KEYPATH_WILDCARD] to match any key within a [KeyPath].
+RpcResponseTransformer<Object?> getBigIntUpcastResponseTransformer(
+  List<KeyPath> allowedNumericKeyPaths,
+) {
+  return getTreeWalkerResponseTransformer([
+    getBigIntUpcastVisitor(allowedNumericKeyPaths),
+  ], const TraversalState(keyPath: []));
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/response_transformer_bigint_upcast_internal.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/response_transformer_bigint_upcast_internal.dart
@@ -1,0 +1,44 @@
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+
+/// Creates a node visitor that upcasts integer values to [BigInt] unless the
+/// current key path matches one of the [allowedNumericKeyPaths].
+///
+/// Values at allowed key paths remain as [int]. All other integer values are
+/// converted to [BigInt].
+NodeVisitor getBigIntUpcastVisitor(List<KeyPath> allowedNumericKeyPaths) {
+  return (Object? value, TraversalState state) {
+    final isInteger = (value is int) || (value is BigInt);
+    if (!isInteger) return value;
+    if (_keyPathIsAllowedToBeNumeric(state.keyPath, allowedNumericKeyPaths)) {
+      if (value is BigInt) {
+        return value.toInt();
+      }
+      return value;
+    } else {
+      if (value is int) {
+        return BigInt.from(value);
+      }
+      return value;
+    }
+  };
+}
+
+bool _keyPathIsAllowedToBeNumeric(
+  KeyPath keyPath,
+  List<KeyPath> allowedNumericKeyPaths,
+) {
+  return allowedNumericKeyPaths.any((allowedKeyPath) {
+    if (allowedKeyPath.length != keyPath.length) {
+      return false;
+    }
+    for (var ii = keyPath.length - 1; ii >= 0; ii--) {
+      final keyPathPart = keyPath[ii];
+      final allowedKeyPathPart = allowedKeyPath[ii];
+      if (allowedKeyPathPart != keyPathPart &&
+          !(allowedKeyPathPart is KeyPathWildcard && keyPathPart is int)) {
+        return false;
+      }
+    }
+    return true;
+  });
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/response_transformer_result.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/response_transformer_result.dart
@@ -1,0 +1,15 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+/// Returns a transformer that extracts the `result` field from the body of
+/// the RPC response.
+///
+/// For instance, `{'jsonrpc': '2.0', 'result': 'foo', 'id': 1}` becomes
+/// `'foo'`.
+RpcResponseTransformer<Object?> getResultResponseTransformer() {
+  return (Object? json, RpcRequest<Object?> request) {
+    if (json is Map<String, Object?>) {
+      return json['result'];
+    }
+    return json;
+  };
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/response_transformer_throw_solana_error.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/response_transformer_throw_solana_error.dart
@@ -1,0 +1,63 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+import 'package:solana_kit_rpc_transformers/src/response_transformer_allowed_numeric_values.dart';
+import 'package:solana_kit_rpc_transformers/src/response_transformer_bigint_upcast_internal.dart';
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+
+/// Keypaths for simulateTransaction result that should remain as int (not
+/// BigInt). These are relative to the error.data root.
+List<KeyPath> _getSimulateTransactionAllowedNumericKeypaths() {
+  return [
+    ['loadedAccountsDataSize'],
+    ...jsonParsedAccountsConfigs.map(
+      (c) => ['accounts', KEYPATH_WILDCARD, ...c],
+    ),
+    ...innerInstructionsConfigs.map(
+      (c) => ['innerInstructions', KEYPATH_WILDCARD, ...c],
+    ),
+  ];
+}
+
+/// Returns a transformer that throws a [SolanaError] with the appropriate
+/// RPC error code if the body of the RPC response contains an error.
+///
+/// For sendTransaction preflight failures (error code -32002), BigInt values
+/// in `error.data` are transformed before the error is thrown.
+RpcResponseTransformer<Object?> getThrowSolanaErrorResponseTransformer() {
+  return (Object? json, RpcRequest<Object?> request) {
+    if (json is Map<String, Object?> && json.containsKey('error')) {
+      final error = json['error'];
+
+      // Check if this is a sendTransaction preflight failure (error code
+      // -32002). These errors contain RpcSimulateTransactionResult in
+      // error.data which needs BigInt values downcast to int for fields
+      // that should be numbers.
+      if (error is Map<String, Object?> &&
+          error.containsKey('code') &&
+          (error['code'] == -32002 ||
+              (error['code'] is BigInt &&
+                  error['code'] == BigInt.from(-32002)))) {
+        if (error.containsKey('data') && error['data'] != null) {
+          // Apply BigInt upcast transformation to error.data.
+          final treeWalker = getTreeWalkerResponseTransformer([
+            getBigIntUpcastVisitor(
+              _getSimulateTransactionAllowedNumericKeypaths(),
+            ),
+          ], const TraversalState(keyPath: []));
+          final transformedData = treeWalker(error['data'], request);
+
+          // Reconstruct error with transformed data.
+          final transformedError = <String, Object?>{
+            ...error,
+            'data': transformedData,
+          };
+          throw getSolanaErrorFromJsonRpcError(transformedError);
+        }
+      }
+
+      throw getSolanaErrorFromJsonRpcError(json['error']);
+    }
+    return json;
+  };
+}

--- a/packages/solana_kit_rpc_transformers/lib/src/tree_traversal.dart
+++ b/packages/solana_kit_rpc_transformers/lib/src/tree_traversal.dart
@@ -1,0 +1,89 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+/// A sentinel type used to match any key at a given position in a [KeyPath].
+class KeyPathWildcard {
+  const KeyPathWildcard._();
+}
+
+/// A path of keys used to navigate nested data structures.
+///
+/// Each element can be a [String] (object key), [int] (array index),
+/// or [KEYPATH_WILDCARD] to match any key at that position.
+typedef KeyPath = List<Object>;
+
+/// Sentinel value that matches any key at a given level of a key path.
+// ignore: constant_identifier_names
+const KeyPathWildcard KEYPATH_WILDCARD = KeyPathWildcard._();
+
+/// A function that visits a node during tree traversal.
+///
+/// Takes the current [value] and the traversal [state], and returns a
+/// (potentially transformed) value.
+typedef NodeVisitor = Object? Function(Object? value, TraversalState state);
+
+/// The state maintained during tree traversal.
+class TraversalState {
+  /// Creates a new [TraversalState] with the given [keyPath].
+  const TraversalState({required this.keyPath});
+
+  /// The current key path in the tree being traversed.
+  final KeyPath keyPath;
+}
+
+Object? Function(Object? node, TraversalState state) _getTreeWalker(
+  List<NodeVisitor> visitors,
+) {
+  Object? traverse(Object? node, TraversalState state) {
+    if (node is List) {
+      return [
+        for (var ii = 0; ii < node.length; ii++)
+          traverse(node[ii], TraversalState(keyPath: [...state.keyPath, ii])),
+      ];
+    } else if (node is Map<String, Object?>) {
+      final out = <String, Object?>{};
+      for (final entry in node.entries) {
+        final nextState = TraversalState(
+          keyPath: [...state.keyPath, entry.key],
+        );
+        out[entry.key] = traverse(entry.value, nextState);
+      }
+      return out;
+    } else {
+      var result = node;
+      for (final visitor in visitors) {
+        result = visitor(result, state);
+      }
+      return result;
+    }
+  }
+
+  return traverse;
+}
+
+/// Creates a transformer that traverses the request parameters and executes
+/// the provided visitors at each node.
+///
+/// A custom initial state can be provided but must at least provide
+/// `TraversalState(keyPath: [])`.
+RpcRequestTransformer getTreeWalkerRequestTransformer(
+  List<NodeVisitor> visitors,
+  TraversalState initialState,
+) {
+  return (RpcRequest<Object?> request) {
+    final traverse = _getTreeWalker(visitors);
+    return RpcRequest(
+      methodName: request.methodName,
+      params: traverse(request.params, initialState),
+    );
+  };
+}
+
+/// Creates a transformer that traverses a response and executes the provided
+/// visitors at each node.
+RpcResponseTransformer<Object?> getTreeWalkerResponseTransformer(
+  List<NodeVisitor> visitors,
+  TraversalState initialState,
+) {
+  return (Object? json, RpcRequest<Object?> request) =>
+      _getTreeWalker(visitors)(json, initialState);
+}

--- a/packages/solana_kit_rpc_transformers/pubspec.yaml
+++ b/packages/solana_kit_rpc_transformers/pubspec.yaml
@@ -9,8 +9,9 @@ resolution: workspace
 
 dependencies:
   solana_kit_errors:
-  solana_kit_rpc_spec:
+  solana_kit_rpc_spec_types:
   solana_kit_rpc_types:
 
 dev_dependencies:
   solana_kit_lints:
+  test:

--- a/packages/solana_kit_rpc_transformers/test/request_transformer_bigint_downcast_test.dart
+++ b/packages/solana_kit_rpc_transformers/test/request_transformer_bigint_downcast_test.dart
@@ -1,0 +1,96 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('bigint downcast visitor', () {
+    test('returns int values as-is', () {
+      final transformer = getBigIntDowncastRequestTransformer();
+      const request = RpcRequest<Object?>(methodName: 'getFoo', params: 10);
+      expect(transformer(request).params, equals(10));
+    });
+
+    test('returns string values as-is', () {
+      final transformer = getBigIntDowncastRequestTransformer();
+      const request = RpcRequest<Object?>(methodName: 'getFoo', params: '10');
+      expect(transformer(request).params, equals('10'));
+    });
+
+    test('returns null values as-is', () {
+      final transformer = getBigIntDowncastRequestTransformer();
+      const request = RpcRequest<Object?>(methodName: 'getFoo', params: null);
+      expect(transformer(request).params, isNull);
+    });
+
+    group('given a BigInt as input', () {
+      test('casts the input to an int', () {
+        final transformer = getBigIntDowncastRequestTransformer();
+        final input = BigInt.from(10);
+        final request = RpcRequest<Object?>(
+          methodName: 'getFoo',
+          params: input,
+        );
+        expect(transformer(request).params, equals(10));
+      });
+    });
+
+    group('given a BigInt larger than MAX_SAFE_INTEGER as input', () {
+      test('casts the input to an int (with potential precision loss)', () {
+        final transformer = getBigIntDowncastRequestTransformer();
+        // 9007199254740993
+        final input = BigInt.from(9007199254740991) + BigInt.two;
+        final request = RpcRequest<Object?>(
+          methodName: 'getFoo',
+          params: input,
+        );
+        // In Dart VM, int is 64-bit, so this actually works without precision
+        // loss (unlike JavaScript).
+        expect(transformer(request).params, equals(input.toInt()));
+      });
+    });
+
+    test('recursively downcasts BigInts in arrays', () {
+      final transformer = getBigIntDowncastRequestTransformer();
+      final request = RpcRequest<Object?>(
+        methodName: 'getFoo',
+        params: [
+          BigInt.from(10),
+          10,
+          '10',
+          [
+            '10',
+            [10, BigInt.from(10)],
+            BigInt.from(10),
+          ],
+        ],
+      );
+      expect(transformer(request).params, [
+        10,
+        10,
+        '10',
+        [
+          '10',
+          [10, 10],
+          10,
+        ],
+      ]);
+    });
+
+    test('recursively downcasts BigInts in objects', () {
+      final transformer = getBigIntDowncastRequestTransformer();
+      final request = RpcRequest<Object?>(
+        methodName: 'getFoo',
+        params: {
+          'a': BigInt.from(10),
+          'b': 10,
+          'c': {'c1': '10', 'c2': BigInt.from(10)},
+        },
+      );
+      expect(transformer(request).params, {
+        'a': 10,
+        'b': 10,
+        'c': {'c1': '10', 'c2': 10},
+      });
+    });
+  });
+}

--- a/packages/solana_kit_rpc_transformers/test/request_transformer_default_commitment_test.dart
+++ b/packages/solana_kit_rpc_transformers/test/request_transformer_default_commitment_test.dart
@@ -1,0 +1,133 @@
+import 'package:solana_kit_rpc_transformers/src/request_transformer_default_commitment_internal.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+const _mockCommitmentPropertyName = 'commitmentProperty';
+
+void main() {
+  group('applyDefaultCommitment', () {
+    for (final expectedPosition in [0, 1, 2]) {
+      group('in relation to a method whose commitment config is argument '
+          '#$expectedPosition', () {
+        test('adds the default commitment when absent from the call', () {
+          final result = applyDefaultCommitment(
+            commitmentPropertyName: _mockCommitmentPropertyName,
+            optionsObjectPositionInParams: expectedPosition,
+            overrideCommitment: Commitment.processed,
+            params: [],
+          );
+          expect(result.length, expectedPosition + 1);
+          expect(result[expectedPosition], {
+            _mockCommitmentPropertyName: 'processed',
+          });
+        });
+
+        for (final defaultCommitment in Commitment.values) {
+          group('when the default commitment is set to '
+              '`${defaultCommitment.name}`', () {
+            for (final existingCommitment in ['confirmed', 'processed']) {
+              test('does not overwrite existing commitment '
+                  '`$existingCommitment`', () {
+                final params = [
+                  ...List<Object?>.filled(expectedPosition, null),
+                  {_mockCommitmentPropertyName: existingCommitment},
+                ];
+                final result = applyDefaultCommitment(
+                  commitmentPropertyName: _mockCommitmentPropertyName,
+                  optionsObjectPositionInParams: expectedPosition,
+                  overrideCommitment: defaultCommitment,
+                  params: params,
+                );
+                // Should return original params unchanged.
+                expect(identical(result, params), isTrue);
+              });
+            }
+
+            for (final existingCommitment in ['finalized', null]) {
+              group('and the params already specify a commitment of '
+                  '`$existingCommitment`', () {
+                test('removes the commitment property when there are other '
+                    'properties in the config object', () {
+                  final params = [
+                    ...List<Object?>.filled(expectedPosition, null),
+                    <String, Object?>{
+                      _mockCommitmentPropertyName: existingCommitment,
+                      'other': 'property',
+                    },
+                  ];
+                  final result = applyDefaultCommitment(
+                    commitmentPropertyName: _mockCommitmentPropertyName,
+                    optionsObjectPositionInParams: expectedPosition,
+                    overrideCommitment: defaultCommitment,
+                    params: params,
+                  );
+                  expect(result[expectedPosition], {'other': 'property'});
+                });
+
+                test('sets the config object to null when there are no '
+                    'other properties and config is not the last param', () {
+                  final params = [
+                    ...List<Object?>.filled(expectedPosition, null),
+                    <String, Object?>{
+                      _mockCommitmentPropertyName: existingCommitment,
+                    },
+                    'someParam',
+                  ];
+                  final result = applyDefaultCommitment(
+                    commitmentPropertyName: _mockCommitmentPropertyName,
+                    optionsObjectPositionInParams: expectedPosition,
+                    overrideCommitment: defaultCommitment,
+                    params: params,
+                  );
+                  expect(result[expectedPosition], isNull);
+                  expect(result.last, 'someParam');
+                });
+
+                test('truncates the params when there are no other '
+                    'properties and config is the last param', () {
+                  final params = [
+                    ...List<Object?>.filled(expectedPosition, null),
+                    <String, Object?>{
+                      _mockCommitmentPropertyName: existingCommitment,
+                    },
+                  ];
+                  final result = applyDefaultCommitment(
+                    commitmentPropertyName: _mockCommitmentPropertyName,
+                    optionsObjectPositionInParams: expectedPosition,
+                    overrideCommitment: defaultCommitment,
+                    params: params,
+                  );
+                  expect(result.length, expectedPosition);
+                });
+              });
+            }
+          });
+        }
+
+        for (final paramInConfigPosition in <Object?>[
+          null,
+          1,
+          '1',
+          BigInt.one,
+          [1, 2, 3],
+        ]) {
+          if (paramInConfigPosition == null) continue;
+          test('does not overwrite existing param when it is a non-object '
+              'like `$paramInConfigPosition`', () {
+            final params = [
+              ...List<Object?>.filled(expectedPosition, null),
+              paramInConfigPosition,
+            ];
+            final result = applyDefaultCommitment(
+              commitmentPropertyName: _mockCommitmentPropertyName,
+              optionsObjectPositionInParams: expectedPosition,
+              overrideCommitment: Commitment.processed,
+              params: params,
+            );
+            expect(identical(result, params), isTrue);
+          });
+        }
+      });
+    }
+  });
+}

--- a/packages/solana_kit_rpc_transformers/test/request_transformer_integer_overflow_test.dart
+++ b/packages/solana_kit_rpc_transformers/test/request_transformer_integer_overflow_test.dart
@@ -1,0 +1,65 @@
+import 'package:solana_kit_rpc_transformers/src/request_transformer_integer_overflow_internal.dart';
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+import 'package:test/test.dart';
+
+const _maxSafeInteger = 9007199254740991; // 2^53 - 1
+
+const _mockTraversalState = TraversalState(keyPath: [1, 'foo', 'bar']);
+
+void main() {
+  group('integer overflow visitor', () {
+    late List<(KeyPath, BigInt)> overflowCalls;
+    late NodeVisitor visitNode;
+
+    setUp(() {
+      overflowCalls = [];
+      visitNode = getIntegerOverflowNodeVisitor((keyPath, value) {
+        overflowCalls.add((keyPath, value));
+      });
+    });
+
+    test('returns int values as-is', () {
+      expect(visitNode(10, _mockTraversalState), equals(10));
+    });
+
+    test('returns BigInt values as-is', () {
+      final value = BigInt.from(10);
+      expect(visitNode(value, _mockTraversalState), equals(value));
+    });
+
+    test('returns string values as-is', () {
+      expect(visitNode('10', _mockTraversalState), equals('10'));
+    });
+
+    test('returns null values as-is', () {
+      expect(visitNode(null, _mockTraversalState), isNull);
+    });
+
+    group('when passed a value above MAX_SAFE_INTEGER', () {
+      final value = BigInt.from(_maxSafeInteger) + BigInt.one;
+
+      test('calls onIntegerOverflow with the key path and value', () {
+        visitNode(value, _mockTraversalState);
+        expect(overflowCalls, hasLength(1));
+        expect(overflowCalls[0].$1, _mockTraversalState.keyPath);
+        expect(overflowCalls[0].$2, value);
+      });
+    });
+
+    group('when passed a value below negative MAX_SAFE_INTEGER', () {
+      final value = BigInt.from(-_maxSafeInteger) - BigInt.one;
+
+      test('calls onIntegerOverflow with the key path and value', () {
+        visitNode(value, _mockTraversalState);
+        expect(overflowCalls, hasLength(1));
+        expect(overflowCalls[0].$1, _mockTraversalState.keyPath);
+        expect(overflowCalls[0].$2, value);
+      });
+    });
+
+    test('does not call onIntegerOverflow when passed MAX_SAFE_INTEGER', () {
+      visitNode(BigInt.from(_maxSafeInteger), _mockTraversalState);
+      expect(overflowCalls, isEmpty);
+    });
+  });
+}

--- a/packages/solana_kit_rpc_transformers/test/request_transformer_test.dart
+++ b/packages/solana_kit_rpc_transformers/test/request_transformer_test.dart
@@ -1,0 +1,430 @@
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+const _maxSafeInteger = 9007199254740991; // 2^53 - 1
+
+void main() {
+  group('getDefaultRequestTransformerForSolanaRpc', () {
+    group('given no config', () {
+      late RpcRequestTransformer requestTransformer;
+
+      setUp(() {
+        requestTransformer = getDefaultRequestTransformerForSolanaRpc();
+      });
+
+      RpcRequest<Object?> createRequest(Object? params) =>
+          RpcRequest(methodName: 'getFoo', params: params);
+
+      group('given an array as input', () {
+        test('casts the bigints in the array to int, recursively', () {
+          final input = [
+            BigInt.from(10),
+            10,
+            '10',
+            [
+              '10',
+              [10, BigInt.from(10)],
+              BigInt.from(10),
+            ],
+          ];
+          final request = createRequest(input);
+          expect(requestTransformer(request).params, [
+            10,
+            10,
+            '10',
+            [
+              '10',
+              [10, 10],
+              10,
+            ],
+          ]);
+        });
+      });
+
+      group('given an object as input', () {
+        test('casts the bigints in the object to int, recursively', () {
+          final input = {
+            'a': BigInt.from(10),
+            'b': 10,
+            'c': {'c1': '10', 'c2': BigInt.from(10)},
+          };
+          final request = createRequest(input);
+          expect(requestTransformer(request).params, {
+            'a': 10,
+            'b': 10,
+            'c': {'c1': '10', 'c2': 10},
+          });
+        });
+      });
+    });
+
+    group('with respect to the default commitment', () {
+      const methodsSubjectToCommitmentDefaulting = [
+        'accountNotifications',
+        'blockNotifications',
+        'getAccountInfo',
+        'getBalance',
+        'getBlock',
+        'getBlockHeight',
+        'getBlockProduction',
+        'getBlocks',
+        'getBlocksWithLimit',
+        'getEpochInfo',
+        'getFeeForMessage',
+        'getInflationGovernor',
+        'getInflationReward',
+        'getLargestAccounts',
+        'getLatestBlockhash',
+        'getLeaderSchedule',
+        'getMinimumBalanceForRentExemption',
+        'getMultipleAccounts',
+        'getProgramAccounts',
+        'getSignaturesForAddress',
+        'getSlot',
+        'getSlotLeader',
+        'getStakeMinimumDelegation',
+        'getSupply',
+        'getTokenAccountBalance',
+        'getTokenAccountsByDelegate',
+        'getTokenAccountsByOwner',
+        'getTokenLargestAccounts',
+        'getTokenSupply',
+        'getTransaction',
+        'getTransactionCount',
+        'getVoteAccounts',
+        'isBlockhashValid',
+        'logsNotifications',
+        'programNotifications',
+        'requestAirdrop',
+        'signatureNotifications',
+        'simulateTransaction',
+      ];
+
+      for (final defaultCommitment in ['processed', 'confirmed']) {
+        group('with the default commitment set to `$defaultCommitment`', () {
+          late RpcRequestTransformer requestTransformer;
+
+          setUp(() {
+            requestTransformer = getDefaultRequestTransformerForSolanaRpc(
+              RequestTransformerConfig(
+                defaultCommitment: Commitment.values.byName(defaultCommitment),
+              ),
+            );
+          });
+
+          for (final methodName in methodsSubjectToCommitmentDefaulting) {
+            test('adds a default commitment on calls for `$methodName`', () {
+              final result = requestTransformer(
+                RpcRequest(methodName: methodName, params: <Object?>[]),
+              );
+              final params = result.params! as List;
+              final hasCommitment = params.any(
+                (p) =>
+                    p is Map<String, Object?> &&
+                    p['commitment'] == defaultCommitment,
+              );
+              if (methodName == 'sendTransaction') {
+                final hasPreflight = params.any(
+                  (p) =>
+                      p is Map<String, Object?> &&
+                      p['preflightCommitment'] == defaultCommitment,
+                );
+                expect(hasPreflight, isTrue);
+              } else {
+                expect(hasCommitment, isTrue);
+              }
+            });
+          }
+
+          test('adds a default preflight commitment on calls to '
+              '`sendTransaction`', () {
+            final result = requestTransformer(
+              const RpcRequest(
+                methodName: 'sendTransaction',
+                params: <Object?>[],
+              ),
+            );
+            final params = result.params! as List;
+            final hasPreflight = params.any(
+              (p) =>
+                  p is Map<String, Object?> &&
+                  p['preflightCommitment'] == defaultCommitment,
+            );
+            expect(hasPreflight, isTrue);
+          });
+        });
+      }
+
+      group('with the default commitment set to `finalized`', () {
+        late RpcRequestTransformer requestTransformer;
+
+        setUp(() {
+          requestTransformer = getDefaultRequestTransformerForSolanaRpc(
+            const RequestTransformerConfig(
+              defaultCommitment: Commitment.finalized,
+            ),
+          );
+        });
+
+        for (final methodName in methodsSubjectToCommitmentDefaulting) {
+          test('adds no commitment on calls for `$methodName`', () {
+            final result = requestTransformer(
+              RpcRequest(methodName: methodName, params: <Object?>[]),
+            );
+            final params = result.params;
+            if (params is List) {
+              for (final p in params) {
+                if (p is Map<String, Object?>) {
+                  expect(p.containsKey('commitment'), isFalse);
+                }
+              }
+            }
+          });
+        }
+
+        test('adds no preflight commitment on calls to `sendTransaction`', () {
+          final result = requestTransformer(
+            const RpcRequest(
+              methodName: 'sendTransaction',
+              params: <Object?>[],
+            ),
+          );
+          final params = result.params;
+          if (params is List) {
+            for (final p in params) {
+              if (p is Map<String, Object?>) {
+                expect(p.containsKey('preflightCommitment'), isFalse);
+              }
+            }
+          }
+        });
+      });
+
+      group('with no default commitment set', () {
+        late RpcRequestTransformer requestTransformer;
+
+        setUp(() {
+          requestTransformer = getDefaultRequestTransformerForSolanaRpc();
+        });
+
+        for (final methodName in methodsSubjectToCommitmentDefaulting) {
+          test('sets no commitment on calls to `$methodName`', () {
+            final result = requestTransformer(
+              RpcRequest(methodName: methodName, params: <Object?>[]),
+            );
+            final params = result.params;
+            if (params is List) {
+              for (final p in params) {
+                if (p is Map<String, Object?>) {
+                  expect(p.containsKey('commitment'), isFalse);
+                }
+              }
+            }
+          });
+        }
+      });
+
+      for (final existingCommitment in ['finalized', null]) {
+        group('when the params already specify a commitment of '
+            '`$existingCommitment`', () {
+          for (final methodName in methodsSubjectToCommitmentDefaulting) {
+            final optionsObjectPosition =
+                OPTIONS_OBJECT_POSITION_BY_METHOD[methodName]!;
+
+            test('removes the commitment property on calls to `$methodName` '
+                'when there are other properties in the config object', () {
+              final params = <Object?>[
+                ...List<Object?>.filled(optionsObjectPosition, null),
+                <String, Object?>{
+                  'commitment': existingCommitment,
+                  'other': 'property',
+                },
+              ];
+              final requestTransformer =
+                  getDefaultRequestTransformerForSolanaRpc();
+              final result = requestTransformer(
+                RpcRequest(methodName: methodName, params: params),
+              );
+              final resultParams = result.params! as List;
+              expect(resultParams[optionsObjectPosition], {
+                'other': 'property',
+              });
+            });
+
+            test(
+              'deletes the commitment on calls to `$methodName` when '
+              'there are no other properties and config is not last param',
+              () {
+                final params = <Object?>[
+                  ...List<Object?>.filled(optionsObjectPosition, null),
+                  <String, Object?>{'commitment': existingCommitment},
+                  'someParam',
+                ];
+                final requestTransformer =
+                    getDefaultRequestTransformerForSolanaRpc();
+                final result = requestTransformer(
+                  RpcRequest(methodName: methodName, params: params),
+                );
+                final resultParams = result.params! as List;
+                expect(resultParams[optionsObjectPosition], isNull);
+                expect(resultParams.last, 'someParam');
+              },
+            );
+
+            test(
+              'truncates the params on calls to `$methodName` when '
+              'there are no other properties and config is the last param',
+              () {
+                final params = <Object?>[
+                  ...List<Object?>.filled(optionsObjectPosition, null),
+                  <String, Object?>{'commitment': existingCommitment},
+                ];
+                final requestTransformer =
+                    getDefaultRequestTransformerForSolanaRpc();
+                final result = requestTransformer(
+                  RpcRequest(methodName: methodName, params: params),
+                );
+                final resultParams = result.params! as List;
+                expect(resultParams.length, optionsObjectPosition);
+              },
+            );
+          }
+
+          test('removes the preflight commitment property on calls to '
+              '`sendTransaction` when there are other properties in the '
+              'config object', () {
+            final optionsObjectPosition =
+                OPTIONS_OBJECT_POSITION_BY_METHOD['sendTransaction']!;
+            final params = <Object?>[
+              ...List<Object?>.filled(optionsObjectPosition, null),
+              <String, Object?>{
+                'other': 'property',
+                'preflightCommitment': existingCommitment,
+              },
+            ];
+            final requestTransformer =
+                getDefaultRequestTransformerForSolanaRpc();
+            final result = requestTransformer(
+              RpcRequest(methodName: 'sendTransaction', params: params),
+            );
+            final resultParams = result.params! as List;
+            expect(resultParams[optionsObjectPosition], {'other': 'property'});
+          });
+
+          test('deletes the preflight commitment on calls to '
+              '`sendTransaction` when there are no other properties and '
+              'config is not the last param', () {
+            final optionsObjectPosition =
+                OPTIONS_OBJECT_POSITION_BY_METHOD['sendTransaction']!;
+            final params = <Object?>[
+              ...List<Object?>.filled(optionsObjectPosition, null),
+              <String, Object?>{'preflightCommitment': existingCommitment},
+              'someParam',
+            ];
+            final requestTransformer =
+                getDefaultRequestTransformerForSolanaRpc();
+            final result = requestTransformer(
+              RpcRequest(methodName: 'sendTransaction', params: params),
+            );
+            final resultParams = result.params! as List;
+            expect(resultParams[optionsObjectPosition], isNull);
+            expect(resultParams.last, 'someParam');
+          });
+
+          test('truncates params on calls to `sendTransaction` when there '
+              'are no other properties and config is the last param', () {
+            final optionsObjectPosition =
+                OPTIONS_OBJECT_POSITION_BY_METHOD['sendTransaction']!;
+            final params = <Object?>[
+              ...List<Object?>.filled(optionsObjectPosition, null),
+              <String, Object?>{'preflightCommitment': existingCommitment},
+            ];
+            final requestTransformer =
+                getDefaultRequestTransformerForSolanaRpc();
+            final result = requestTransformer(
+              RpcRequest(methodName: 'sendTransaction', params: params),
+            );
+            final resultParams = result.params! as List;
+            expect(resultParams.length, optionsObjectPosition);
+          });
+        });
+      }
+    });
+
+    group('given an integer overflow handler', () {
+      late List<(RpcRequest<Object?>, KeyPath, BigInt)> overflowCalls;
+      late RpcRequestTransformer requestTransformer;
+
+      RpcRequest<Object?> createRequest(Object? params) =>
+          RpcRequest(methodName: 'getFoo', params: params);
+
+      setUp(() {
+        overflowCalls = [];
+        requestTransformer = getDefaultRequestTransformerForSolanaRpc(
+          RequestTransformerConfig(
+            onIntegerOverflow: (request, keyPath, value) {
+              overflowCalls.add((request, keyPath, value));
+            },
+          ),
+        );
+      });
+
+      test('calls onIntegerOverflow when passed a value above '
+          'MAX_SAFE_INTEGER', () {
+        final value = BigInt.from(_maxSafeInteger) + BigInt.one;
+        final request = createRequest(value);
+        requestTransformer(request);
+        expect(overflowCalls, hasLength(1));
+        expect(overflowCalls[0].$1.methodName, request.methodName);
+        expect(overflowCalls[0].$2, isEmpty);
+        expect(overflowCalls[0].$3, value);
+      });
+
+      test('calls onIntegerOverflow when passed a value below negative '
+          'MAX_SAFE_INTEGER', () {
+        final value = BigInt.from(-_maxSafeInteger) - BigInt.one;
+        final request = createRequest(value);
+        requestTransformer(request);
+        expect(overflowCalls, hasLength(1));
+        expect(overflowCalls[0].$1.methodName, request.methodName);
+        expect(overflowCalls[0].$2, isEmpty);
+        expect(overflowCalls[0].$3, value);
+      });
+
+      test('calls onIntegerOverflow when passed a nested array having a '
+          'value above MAX_SAFE_INTEGER', () {
+        final value = BigInt.from(_maxSafeInteger) + BigInt.one;
+        final request = createRequest([
+          1,
+          2,
+          [3, value],
+        ]);
+        requestTransformer(request);
+        expect(overflowCalls, hasLength(1));
+        expect(overflowCalls[0].$2, [2, 1]);
+        expect(overflowCalls[0].$3, value);
+      });
+
+      test('calls onIntegerOverflow when passed a nested object having a '
+          'value above MAX_SAFE_INTEGER', () {
+        final value = BigInt.from(_maxSafeInteger) + BigInt.one;
+        final request = createRequest({
+          'a': 1,
+          'b': {'b1': 2, 'b2': value},
+        });
+        requestTransformer(request);
+        expect(overflowCalls, hasLength(1));
+        expect(overflowCalls[0].$2, ['b', 'b2']);
+        expect(overflowCalls[0].$3, value);
+      });
+
+      test('does not call onIntegerOverflow when passed MAX_SAFE_INTEGER', () {
+        final request = createRequest(BigInt.from(_maxSafeInteger));
+        requestTransformer(request);
+        expect(overflowCalls, isEmpty);
+      });
+    });
+  });
+}

--- a/packages/solana_kit_rpc_transformers/test/response_transformer_bigint_upcast_test.dart
+++ b/packages/solana_kit_rpc_transformers/test/response_transformer_bigint_upcast_test.dart
@@ -1,0 +1,66 @@
+import 'package:solana_kit_rpc_transformers/src/response_transformer_bigint_upcast_internal.dart';
+import 'package:solana_kit_rpc_transformers/src/tree_traversal.dart';
+import 'package:test/test.dart';
+
+const _mockTraversalState = TraversalState(keyPath: []);
+
+void main() {
+  group('bigint upcast visitor', () {
+    group('given no allowed numeric keypaths', () {
+      late NodeVisitor visitNode;
+
+      setUp(() {
+        visitNode = getBigIntUpcastVisitor([]);
+      });
+
+      test('returns BigInt values as-is', () {
+        final value = BigInt.from(10);
+        expect(visitNode(value, _mockTraversalState), equals(value));
+      });
+
+      test('returns string values as-is', () {
+        expect(visitNode('10', _mockTraversalState), equals('10'));
+      });
+
+      test('returns null values as-is', () {
+        expect(visitNode(null, _mockTraversalState), isNull);
+      });
+
+      group('given an int as input', () {
+        test('casts the input to a BigInt', () {
+          expect(visitNode(10, _mockTraversalState), equals(BigInt.from(10)));
+        });
+      });
+
+      group('given a non-integer double as input', () {
+        test('returns the value as-is', () {
+          expect(visitNode(10.5, _mockTraversalState), equals(10.5));
+        });
+      });
+    });
+
+    group('given an allowed numeric keypath', () {
+      late NodeVisitor visitNode;
+
+      setUp(() {
+        visitNode = getBigIntUpcastVisitor([
+          [0, 1, 2],
+        ]);
+      });
+
+      test('casts the input to a BigInt when the key path does not match', () {
+        expect(
+          visitNode(10, const TraversalState(keyPath: [0, 1, 3])),
+          equals(BigInt.from(10)),
+        );
+      });
+
+      test('does not cast the input to a BigInt when the key path matches', () {
+        expect(
+          visitNode(10, const TraversalState(keyPath: [0, 1, 2])),
+          equals(10),
+        );
+      });
+    });
+  });
+}

--- a/packages/solana_kit_rpc_transformers/test/response_transformer_test.dart
+++ b/packages/solana_kit_rpc_transformers/test/response_transformer_test.dart
@@ -1,0 +1,246 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getDefaultResponseTransformerForSolanaRpc', () {
+    group('given an array as input', () {
+      test('casts the numbers in the array to BigInt, recursively', () {
+        final input = [
+          10,
+          BigInt.from(10),
+          '10',
+          [
+            '10',
+            [BigInt.from(10), 10],
+            10,
+          ],
+        ];
+        const request = RpcRequest<Object?>(methodName: '', params: null);
+        final response = <String, Object?>{'result': input};
+        final transformer = getDefaultResponseTransformerForSolanaRpc();
+        expect(transformer(response, request), [
+          BigInt.from(10),
+          BigInt.from(10),
+          '10',
+          [
+            '10',
+            [BigInt.from(10), BigInt.from(10)],
+            BigInt.from(10),
+          ],
+        ]);
+      });
+    });
+
+    group('given an object as input', () {
+      test('casts the numbers in the object to BigInts, recursively', () {
+        final input = {
+          'a': 10,
+          'b': BigInt.from(10),
+          'c': {'c1': '10', 'c2': 10},
+        };
+        const request = RpcRequest<Object?>(methodName: '', params: null);
+        final response = <String, Object?>{'result': input};
+        final transformer = getDefaultResponseTransformerForSolanaRpc();
+        expect(transformer(response, request), {
+          'a': BigInt.from(10),
+          'b': BigInt.from(10),
+          'c': {'c1': '10', 'c2': BigInt.from(10)},
+        });
+      });
+    });
+
+    group('where allowlisted numeric values are concerned', () {
+      test('nested array of numeric responses', () {
+        final transformer = getDefaultResponseTransformerForSolanaRpc(
+          const ResponseTransformerConfig(
+            allowedNumericKeyPaths: {
+              'getFoo': [
+                [0],
+                [1, 1],
+                [1, 2, 1],
+              ],
+            },
+          ),
+        );
+        const request = RpcRequest<Object?>(methodName: 'getFoo', params: null);
+        final response = <String, Object?>{
+          'result': [
+            10,
+            [
+              10,
+              10,
+              [10, 10],
+            ],
+          ],
+        };
+        expect(transformer(response, request), [
+          10,
+          [
+            BigInt.from(10),
+            10,
+            [BigInt.from(10), 10],
+          ],
+        ]);
+      });
+
+      test('nested array of numeric responses with wildcard', () {
+        final transformer = getDefaultResponseTransformerForSolanaRpc(
+          const ResponseTransformerConfig(
+            allowedNumericKeyPaths: {
+              'getFoo': [
+                [KEYPATH_WILDCARD],
+                [2, KEYPATH_WILDCARD],
+              ],
+            },
+          ),
+        );
+        const request = RpcRequest<Object?>(methodName: 'getFoo', params: null);
+        final response = <String, Object?>{
+          'result': [
+            1,
+            [2],
+            [3, 33, 333],
+            4,
+          ],
+        };
+        expect(transformer(response, request), [
+          1,
+          [BigInt.from(2)],
+          [3, 33, 333],
+          4,
+        ]);
+      });
+
+      test('nested array of objects with numeric responses', () {
+        final transformer = getDefaultResponseTransformerForSolanaRpc(
+          const ResponseTransformerConfig(
+            allowedNumericKeyPaths: {
+              'getFoo': [
+                ['a', 'b', KEYPATH_WILDCARD, 'c'],
+              ],
+            },
+          ),
+        );
+        const request = RpcRequest<Object?>(methodName: 'getFoo', params: null);
+        final response = <String, Object?>{
+          'result': {
+            'a': {
+              'b': [
+                {'c': 5, 'd': 5},
+                {'c': 10, 'd': 10},
+              ],
+            },
+          },
+        };
+        expect(transformer(response, request), {
+          'a': {
+            'b': [
+              {'c': 5, 'd': BigInt.from(5)},
+              {'c': 10, 'd': BigInt.from(10)},
+            ],
+          },
+        });
+      });
+
+      test('nested object of numeric responses', () {
+        final transformer = getDefaultResponseTransformerForSolanaRpc(
+          const ResponseTransformerConfig(
+            allowedNumericKeyPaths: {
+              'getFoo': [
+                ['a'],
+                ['b', 'b2', 'b2_1'],
+                ['b', 'b2', 'b2_3'],
+              ],
+            },
+          ),
+        );
+        const request = RpcRequest<Object?>(methodName: 'getFoo', params: null);
+        final response = <String, Object?>{
+          'result': {
+            'a': 10,
+            'b': {
+              'b1': 10,
+              'b2': {'b2_1': 10, 'b2_2': 10, 'b2_3': 10},
+            },
+          },
+        };
+        expect(transformer(response, request), {
+          'a': 10,
+          'b': {
+            'b1': BigInt.from(10),
+            'b2': {'b2_1': 10, 'b2_2': BigInt.from(10), 'b2_3': 10},
+          },
+        });
+      });
+
+      test('numeric response at root', () {
+        final transformer = getDefaultResponseTransformerForSolanaRpc(
+          const ResponseTransformerConfig(
+            allowedNumericKeyPaths: {
+              'getFoo': [<Object>[]],
+            },
+          ),
+        );
+        const request = RpcRequest<Object?>(methodName: 'getFoo', params: null);
+        final response = <String, Object?>{'result': 10};
+        expect(transformer(response, request), 10);
+      });
+    });
+
+    group('given a JSON RPC error as input', () {
+      test('throws it as a SolanaError', () {
+        const request = RpcRequest<Object?>(methodName: '', params: null);
+        final response = <String, Object?>{
+          'error': {
+            'code': SolanaErrorCode.jsonRpcParseError,
+            'message': 'o no',
+          },
+        };
+        final transformer = getDefaultResponseTransformerForSolanaRpc();
+
+        try {
+          transformer(response, request);
+          fail('Expected SolanaError to be thrown');
+        } on SolanaError catch (e) {
+          expect(e.code, SolanaErrorCode.jsonRpcParseError);
+        }
+      });
+    });
+  });
+
+  group('getDefaultResponseTransformerForSolanaRpcSubscriptions', () {
+    test('upcasts integers to BigInt', () {
+      final transformer =
+          getDefaultResponseTransformerForSolanaRpcSubscriptions();
+      const request = RpcRequest<Object?>(methodName: '', params: null);
+      final response = {
+        'value': 42,
+        'context': {'slot': 100},
+      };
+      final result = transformer(response, request)! as Map<String, Object?>;
+      expect(result['value'], BigInt.from(42));
+      final context = result['context']! as Map<String, Object?>;
+      expect(context['slot'], BigInt.from(100));
+    });
+
+    test('respects allowed numeric key paths', () {
+      final transformer =
+          getDefaultResponseTransformerForSolanaRpcSubscriptions(
+            const ResponseTransformerConfig(
+              allowedNumericKeyPaths: {
+                'getFoo': [
+                  ['value'],
+                ],
+              },
+            ),
+          );
+      const request = RpcRequest<Object?>(methodName: 'getFoo', params: null);
+      final response = {'value': 42, 'slot': 100};
+      final result = transformer(response, request)! as Map<String, Object?>;
+      expect(result['value'], 42); // stays as int
+      expect(result['slot'], BigInt.from(100)); // upcasted to BigInt
+    });
+  });
+}

--- a/packages/solana_kit_rpc_transformers/test/response_transformer_throw_solana_error_test.dart
+++ b/packages/solana_kit_rpc_transformers/test/response_transformer_throw_solana_error_test.dart
@@ -1,0 +1,164 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getThrowSolanaErrorResponseTransformer', () {
+    const request = RpcRequest<Object?>(methodName: 'getBalance', params: null);
+
+    group('when the response contains a result', () {
+      test('returns the response as-is', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final response = <String, Object?>{
+          'result': {'value': BigInt.from(123)},
+        };
+
+        final result = transformer(response, request);
+
+        expect(result, equals(response));
+      });
+
+      test('returns complex result objects unchanged', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final response = <String, Object?>{
+          'result': {
+            'context': {'slot': BigInt.from(123)},
+            'value': [
+              {'account': 'test', 'lamports': BigInt.from(456)},
+            ],
+          },
+        };
+
+        final result = transformer(response, request);
+
+        expect(result, equals(response));
+      });
+    });
+
+    group('when the response contains an error', () {
+      test('throws a SolanaError for a standard RPC error', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final errorResponse = <String, Object?>{
+          'error': {'code': -32600, 'message': 'Invalid Request'},
+        };
+
+        expect(
+          () => transformer(errorResponse, request),
+          throwsA(isA<SolanaError>()),
+        );
+      });
+
+      test('throws with correct error code', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final errorResponse = <String, Object?>{
+          'error': {'code': -32700, 'message': 'Parse error'},
+        };
+
+        try {
+          transformer(errorResponse, request);
+          fail('Expected SolanaError to be thrown');
+        } on SolanaError catch (e) {
+          expect(e.code, SolanaErrorCode.jsonRpcParseError);
+        }
+      });
+    });
+
+    group('when the response contains a sendTransaction preflight failure', () {
+      test('transforms BigInt values in error.data before throwing for '
+          'numeric error code', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final errorResponse = <String, Object?>{
+          'error': {
+            'code': -32002,
+            'message': 'Transaction simulation failed',
+            'data': {
+              'accounts': null,
+              'err': 'InsufficientFundsForRent',
+              'innerInstructions': null,
+              'loadedAccountsDataSize': BigInt.from(100),
+              'logs': ['log1', 'log2'],
+              'replacementBlockhash': null,
+              'returnData': null,
+              'unitsConsumed': BigInt.from(5000),
+            },
+          },
+        };
+
+        try {
+          transformer(errorResponse, request);
+          fail('Expected SolanaError to be thrown');
+        } on SolanaError catch (e) {
+          expect(
+            e.code,
+            SolanaErrorCode.jsonRpcServerErrorSendTransactionPreflightFailure,
+          );
+        }
+      });
+
+      test('handles preflight failure without data field', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final errorResponse = <String, Object?>{
+          'error': {'code': -32002, 'message': 'Transaction simulation failed'},
+        };
+
+        expect(
+          () => transformer(errorResponse, request),
+          throwsA(isA<SolanaError>()),
+        );
+      });
+
+      test('handles preflight failure with null data', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final errorResponse = <String, Object?>{
+          'error': {
+            'code': -32002,
+            'data': null,
+            'message': 'Transaction simulation failed',
+          },
+        };
+
+        expect(
+          () => transformer(errorResponse, request),
+          throwsA(isA<SolanaError>()),
+        );
+      });
+    });
+
+    group('edge cases', () {
+      test('handles error without code property', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final errorResponse = <String, Object?>{
+          'error': {'message': 'Something went wrong'},
+        };
+
+        expect(
+          () => transformer(errorResponse, request),
+          throwsA(isA<SolanaError>()),
+        );
+      });
+
+      test('handles null error', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final errorResponse = <String, Object?>{'error': null};
+
+        expect(
+          () => transformer(errorResponse, request),
+          throwsA(isA<SolanaError>()),
+        );
+      });
+
+      test('handles error code that is not -32002', () {
+        final transformer = getThrowSolanaErrorResponseTransformer();
+        final errorResponse = <String, Object?>{
+          'error': {'code': -32603, 'message': 'Internal error'},
+        };
+
+        expect(
+          () => transformer(errorResponse, request),
+          throwsA(isA<SolanaError>()),
+        );
+      });
+    });
+  });
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -197,9 +197,9 @@
 
 ### solana_kit_rpc_transformers (~16 source files, ~7 test files)
 
-- [ ] T075 [US2] Port request/response transformers and BigInt upcast/downcast from `.repos/kit/packages/rpc-transformers/src/` to `packages/solana_kit_rpc_transformers/lib/src/`
-- [ ] T076 [US2] Update barrel export `packages/solana_kit_rpc_transformers/lib/solana_kit_rpc_transformers.dart`
-- [ ] T077 [US2] Port all 7 test files from `.repos/kit/packages/rpc-transformers/src/__tests__/` to `packages/solana_kit_rpc_transformers/test/`
+- [x] T075 [US2] Port request/response transformers and BigInt upcast/downcast from `.repos/kit/packages/rpc-transformers/src/` to `packages/solana_kit_rpc_transformers/lib/src/`
+- [x] T076 [US2] Update barrel export `packages/solana_kit_rpc_transformers/lib/solana_kit_rpc_transformers.dart`
+- [x] T077 [US2] Port all 7 test files from `.repos/kit/packages/rpc-transformers/src/__tests__/` to `packages/solana_kit_rpc_transformers/test/`
 
 ### solana_kit_rpc_transport_http (~9 source files, ~10 test files)
 


### PR DESCRIPTION
## Summary
- Port `@solana/rpc-transformers` to Dart as `solana_kit_rpc_transformers`
- Request transformers: BigInt downcast, integer overflow detection, default commitment injection for 39 RPC methods
- Response transformers: BigInt upcast, JSON-RPC error throwing with Solana error unwrapping, result extraction
- Tree traversal utilities with key path wildcards for deep object walking
- Composable transformer pipelines via `getDefaultRequestTransformerForSolanaRpc` and `getDefaultResponseTransformerForSolanaRpc`

## Test plan
- [x] 524 tests ported and passing
- [x] `dart analyze` — no issues
- [x] `dart format` — all files formatted