### PR TITLE
✨ feat(solana_kit_sysvars): implement sysvars package

### DIFF
--- a/.changeset/sysvars.md
+++ b/.changeset/sysvars.md
@@ -1,0 +1,18 @@
+---
+solana_kit_sysvars: minor
+---
+
+Implement sysvars package ported from `@solana/sysvars`.
+
+**solana_kit_sysvars** (52 tests):
+
+- 10 sysvar address constants (Clock, EpochRewards, EpochSchedule, Instructions, LastRestartSlot, RecentBlockhashes, Rent, SlotHashes, SlotHistory, StakeHistory)
+- `SysvarClock` codec (40 bytes): slot, epochStartTimestamp, epoch, leaderScheduleEpoch, unixTimestamp
+- `SysvarEpochSchedule` codec (33 bytes): slotsPerEpoch, leaderScheduleSlotOffset, warmup, firstNormalEpoch, firstNormalSlot
+- `SysvarEpochRewards` codec (81 bytes): distributionStartingBlockHeight, numPartitions, parentBlockhash, totalPoints (u128), totalRewards, distributedRewards, active
+- `SysvarRent` codec (17 bytes): lamportsPerByteYear, exemptionThreshold (f64), burnPercent
+- `SysvarLastRestartSlot` codec (8 bytes), `SysvarSlotHashes` variable-size array codec
+- `SysvarSlotHistory` bitvector codec (131,097 bytes) with discriminator validation
+- `SysvarRecentBlockhashes` (deprecated) and `SysvarStakeHistory` variable-size array codecs
+- `fetchSysvar*` async RPC functions for each sysvar type
+- `fetchEncodedSysvarAccount` generic fetch function

--- a/packages/solana_kit_sysvars/lib/solana_kit_sysvars.dart
+++ b/packages/solana_kit_sysvars/lib/solana_kit_sysvars.dart
@@ -1,1 +1,10 @@
-
+export 'src/clock.dart';
+export 'src/epoch_rewards.dart';
+export 'src/epoch_schedule.dart';
+export 'src/last_restart_slot.dart';
+export 'src/recent_blockhashes.dart';
+export 'src/rent.dart';
+export 'src/slot_hashes.dart';
+export 'src/slot_history.dart';
+export 'src/stake_history.dart';
+export 'src/sysvar.dart';

--- a/packages/solana_kit_sysvars/lib/src/clock.dart
+++ b/packages/solana_kit_sysvars/lib/src/clock.dart
@@ -1,0 +1,156 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+import 'package:solana_kit_sysvars/src/sysvar.dart';
+
+/// The size in bytes of the Clock sysvar account data.
+const int sysvarClockSize = 40;
+
+/// Contains data on cluster time, including the current slot, epoch, and
+/// estimated wall-clock Unix timestamp. It is updated every slot.
+@immutable
+class SysvarClock {
+  /// Creates a new [SysvarClock].
+  const SysvarClock({
+    required this.slot,
+    required this.epochStartTimestamp,
+    required this.epoch,
+    required this.leaderScheduleEpoch,
+    required this.unixTimestamp,
+  });
+
+  /// The current slot.
+  final BigInt slot;
+
+  /// The Unix timestamp of the first slot in this epoch.
+  ///
+  /// In the first slot of an epoch, this timestamp is identical to the
+  /// [unixTimestamp].
+  final BigInt epochStartTimestamp;
+
+  /// The current epoch.
+  final BigInt epoch;
+
+  /// The most recent epoch for which the leader schedule has already been
+  /// generated.
+  final BigInt leaderScheduleEpoch;
+
+  /// The Unix timestamp of this slot.
+  final BigInt unixTimestamp;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SysvarClock &&
+          runtimeType == other.runtimeType &&
+          slot == other.slot &&
+          epochStartTimestamp == other.epochStartTimestamp &&
+          epoch == other.epoch &&
+          leaderScheduleEpoch == other.leaderScheduleEpoch &&
+          unixTimestamp == other.unixTimestamp;
+
+  @override
+  int get hashCode => Object.hash(
+    slot,
+    epochStartTimestamp,
+    epoch,
+    leaderScheduleEpoch,
+    unixTimestamp,
+  );
+
+  @override
+  String toString() =>
+      'SysvarClock(slot: $slot, epochStartTimestamp: $epochStartTimestamp, '
+      'epoch: $epoch, leaderScheduleEpoch: $leaderScheduleEpoch, '
+      'unixTimestamp: $unixTimestamp)';
+}
+
+/// Returns a fixed-size encoder for the [SysvarClock] sysvar.
+FixedSizeEncoder<SysvarClock> getSysvarClockEncoder() {
+  final structEncoder =
+      getStructEncoder([
+            ('slot', getU64Encoder()),
+            ('epochStartTimestamp', getI64Encoder()),
+            ('epoch', getU64Encoder()),
+            ('leaderScheduleEpoch', getU64Encoder()),
+            ('unixTimestamp', getI64Encoder()),
+          ])
+          as FixedSizeEncoder<Map<String, Object?>>;
+
+  return FixedSizeEncoder<SysvarClock>(
+    fixedSize: sysvarClockSize,
+    write: (SysvarClock value, Uint8List bytes, int offset) {
+      return structEncoder.write(
+        {
+          'slot': value.slot,
+          'epochStartTimestamp': value.epochStartTimestamp,
+          'epoch': value.epoch,
+          'leaderScheduleEpoch': value.leaderScheduleEpoch,
+          'unixTimestamp': value.unixTimestamp,
+        },
+        bytes,
+        offset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size decoder for the [SysvarClock] sysvar.
+FixedSizeDecoder<SysvarClock> getSysvarClockDecoder() {
+  final structDecoder =
+      getStructDecoder([
+            ('slot', getU64Decoder()),
+            ('epochStartTimestamp', getI64Decoder()),
+            ('epoch', getU64Decoder()),
+            ('leaderScheduleEpoch', getU64Decoder()),
+            ('unixTimestamp', getI64Decoder()),
+          ])
+          as FixedSizeDecoder<Map<String, Object?>>;
+
+  return FixedSizeDecoder<SysvarClock>(
+    fixedSize: sysvarClockSize,
+    read: (Uint8List bytes, int offset) {
+      final (map, newOffset) = structDecoder.read(bytes, offset);
+      return (
+        SysvarClock(
+          slot: map['slot']! as BigInt,
+          epochStartTimestamp: map['epochStartTimestamp']! as BigInt,
+          epoch: map['epoch']! as BigInt,
+          leaderScheduleEpoch: map['leaderScheduleEpoch']! as BigInt,
+          unixTimestamp: map['unixTimestamp']! as BigInt,
+        ),
+        newOffset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size codec for the [SysvarClock] sysvar.
+FixedSizeCodec<SysvarClock, SysvarClock> getSysvarClockCodec() {
+  return combineCodec(getSysvarClockEncoder(), getSysvarClockDecoder())
+      as FixedSizeCodec<SysvarClock, SysvarClock>;
+}
+
+/// Fetches the `Clock` sysvar account using the provided RPC client.
+Future<SysvarClock> fetchSysvarClock(
+  Rpc rpc, {
+  FetchAccountConfig? config,
+}) async {
+  final account = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarClockAddress,
+    config: config,
+  );
+  assertAccountExists(account);
+  final decoded = decodeAccount(
+    (account as ExistingAccount<Uint8List>).account,
+    getSysvarClockDecoder(),
+  );
+  return decoded.data;
+}

--- a/packages/solana_kit_sysvars/lib/src/epoch_rewards.dart
+++ b/packages/solana_kit_sysvars/lib/src/epoch_rewards.dart
@@ -1,0 +1,193 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+import 'package:solana_kit_sysvars/src/sysvar.dart';
+
+/// The size in bytes of the EpochRewards sysvar account data.
+const int sysvarEpochRewardsSize = 81;
+
+/// Tracks whether the rewards period (including calculation and distribution)
+/// is in progress, as well as the details needed to resume distribution when
+/// starting from a snapshot during the rewards period.
+///
+/// The sysvar is repopulated at the start of the first block of each epoch.
+/// Therefore, the sysvar contains data about the current epoch until a new
+/// epoch begins.
+@immutable
+class SysvarEpochRewards {
+  /// Creates a new [SysvarEpochRewards].
+  const SysvarEpochRewards({
+    required this.distributionStartingBlockHeight,
+    required this.numPartitions,
+    required this.parentBlockhash,
+    required this.totalPoints,
+    required this.totalRewards,
+    required this.distributedRewards,
+    required this.active,
+  });
+
+  /// The starting block height of the rewards distribution in the current
+  /// epoch.
+  final BigInt distributionStartingBlockHeight;
+
+  /// Number of partitions in the rewards distribution in the current epoch,
+  /// used to generate an `EpochRewardsHasher`.
+  final BigInt numPartitions;
+
+  /// The [Blockhash] of the parent block of the first block in the epoch,
+  /// used to seed an `EpochRewardsHasher`.
+  final Blockhash parentBlockhash;
+
+  /// The total rewards points calculated for the current epoch, where points
+  /// equals the sum of (delegated stake * credits observed) for all
+  /// delegations.
+  final BigInt totalPoints;
+
+  /// The total rewards for the current epoch, in [Lamports].
+  final Lamports totalRewards;
+
+  /// The rewards currently distributed for the current epoch, in [Lamports].
+  final Lamports distributedRewards;
+
+  /// Whether the rewards period (including calculation and distribution) is
+  /// active.
+  final bool active;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SysvarEpochRewards &&
+          runtimeType == other.runtimeType &&
+          distributionStartingBlockHeight ==
+              other.distributionStartingBlockHeight &&
+          numPartitions == other.numPartitions &&
+          parentBlockhash == other.parentBlockhash &&
+          totalPoints == other.totalPoints &&
+          totalRewards == other.totalRewards &&
+          distributedRewards == other.distributedRewards &&
+          active == other.active;
+
+  @override
+  int get hashCode => Object.hash(
+    distributionStartingBlockHeight,
+    numPartitions,
+    parentBlockhash,
+    totalPoints,
+    totalRewards,
+    distributedRewards,
+    active,
+  );
+
+  @override
+  String toString() =>
+      'SysvarEpochRewards(distributionStartingBlockHeight: '
+      '$distributionStartingBlockHeight, numPartitions: $numPartitions, '
+      'parentBlockhash: ${parentBlockhash.value}, '
+      'totalPoints: $totalPoints, totalRewards: ${totalRewards.value}, '
+      'distributedRewards: ${distributedRewards.value}, active: $active)';
+}
+
+/// Returns a fixed-size encoder for the [SysvarEpochRewards] sysvar.
+FixedSizeEncoder<SysvarEpochRewards> getSysvarEpochRewardsEncoder() {
+  final structEncoder =
+      getStructEncoder([
+            ('distributionStartingBlockHeight', getU64Encoder()),
+            ('numPartitions', getU64Encoder()),
+            ('parentBlockhash', getBlockhashEncoder()),
+            ('totalPoints', getU128Encoder()),
+            ('totalRewards', getDefaultLamportsEncoder()),
+            ('distributedRewards', getDefaultLamportsEncoder()),
+            ('active', getBooleanEncoder()),
+          ])
+          as FixedSizeEncoder<Map<String, Object?>>;
+
+  return FixedSizeEncoder<SysvarEpochRewards>(
+    fixedSize: sysvarEpochRewardsSize,
+    write: (SysvarEpochRewards value, Uint8List bytes, int offset) {
+      return structEncoder.write(
+        {
+          'distributionStartingBlockHeight':
+              value.distributionStartingBlockHeight,
+          'numPartitions': value.numPartitions,
+          'parentBlockhash': value.parentBlockhash,
+          'totalPoints': value.totalPoints,
+          'totalRewards': value.totalRewards,
+          'distributedRewards': value.distributedRewards,
+          'active': value.active,
+        },
+        bytes,
+        offset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size decoder for the [SysvarEpochRewards] sysvar.
+FixedSizeDecoder<SysvarEpochRewards> getSysvarEpochRewardsDecoder() {
+  final structDecoder =
+      getStructDecoder([
+            ('distributionStartingBlockHeight', getU64Decoder()),
+            ('numPartitions', getU64Decoder()),
+            ('parentBlockhash', getBlockhashDecoder()),
+            ('totalPoints', getU128Decoder()),
+            ('totalRewards', getDefaultLamportsDecoder()),
+            ('distributedRewards', getDefaultLamportsDecoder()),
+            ('active', getBooleanDecoder()),
+          ])
+          as FixedSizeDecoder<Map<String, Object?>>;
+
+  return FixedSizeDecoder<SysvarEpochRewards>(
+    fixedSize: sysvarEpochRewardsSize,
+    read: (Uint8List bytes, int offset) {
+      final (map, newOffset) = structDecoder.read(bytes, offset);
+      return (
+        SysvarEpochRewards(
+          distributionStartingBlockHeight:
+              map['distributionStartingBlockHeight']! as BigInt,
+          numPartitions: map['numPartitions']! as BigInt,
+          parentBlockhash: map['parentBlockhash']! as Blockhash,
+          totalPoints: map['totalPoints']! as BigInt,
+          totalRewards: map['totalRewards']! as Lamports,
+          distributedRewards: map['distributedRewards']! as Lamports,
+          active: map['active']! as bool,
+        ),
+        newOffset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size codec for the [SysvarEpochRewards] sysvar.
+FixedSizeCodec<SysvarEpochRewards, SysvarEpochRewards>
+getSysvarEpochRewardsCodec() {
+  return combineCodec(
+        getSysvarEpochRewardsEncoder(),
+        getSysvarEpochRewardsDecoder(),
+      )
+      as FixedSizeCodec<SysvarEpochRewards, SysvarEpochRewards>;
+}
+
+/// Fetches the `EpochRewards` sysvar account using the provided RPC client.
+Future<SysvarEpochRewards> fetchSysvarEpochRewards(
+  Rpc rpc, {
+  FetchAccountConfig? config,
+}) async {
+  final account = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarEpochRewardsAddress,
+    config: config,
+  );
+  assertAccountExists(account);
+  final decoded = decodeAccount(
+    (account as ExistingAccount<Uint8List>).account,
+    getSysvarEpochRewardsDecoder(),
+  );
+  return decoded.data;
+}

--- a/packages/solana_kit_sysvars/lib/src/epoch_schedule.dart
+++ b/packages/solana_kit_sysvars/lib/src/epoch_schedule.dart
@@ -1,0 +1,158 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+import 'package:solana_kit_sysvars/src/sysvar.dart';
+
+/// The size in bytes of the EpochSchedule sysvar account data.
+const int sysvarEpochScheduleSize = 33;
+
+/// Includes the number of slots per epoch, timing of leader schedule
+/// selection, and information about epoch warm-up time.
+@immutable
+class SysvarEpochSchedule {
+  /// Creates a new [SysvarEpochSchedule].
+  const SysvarEpochSchedule({
+    required this.slotsPerEpoch,
+    required this.leaderScheduleSlotOffset,
+    required this.warmup,
+    required this.firstNormalEpoch,
+    required this.firstNormalSlot,
+  });
+
+  /// The maximum number of slots in each epoch.
+  final BigInt slotsPerEpoch;
+
+  /// A number of slots before beginning of an epoch to calculate a leader
+  /// schedule for that epoch.
+  final BigInt leaderScheduleSlotOffset;
+
+  /// Whether epochs start short and grow.
+  final bool warmup;
+
+  /// First normal-length epoch after the warmup period.
+  final BigInt firstNormalEpoch;
+
+  /// The first slot after the warmup period.
+  final BigInt firstNormalSlot;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SysvarEpochSchedule &&
+          runtimeType == other.runtimeType &&
+          slotsPerEpoch == other.slotsPerEpoch &&
+          leaderScheduleSlotOffset == other.leaderScheduleSlotOffset &&
+          warmup == other.warmup &&
+          firstNormalEpoch == other.firstNormalEpoch &&
+          firstNormalSlot == other.firstNormalSlot;
+
+  @override
+  int get hashCode => Object.hash(
+    slotsPerEpoch,
+    leaderScheduleSlotOffset,
+    warmup,
+    firstNormalEpoch,
+    firstNormalSlot,
+  );
+
+  @override
+  String toString() =>
+      'SysvarEpochSchedule(slotsPerEpoch: $slotsPerEpoch, '
+      'leaderScheduleSlotOffset: $leaderScheduleSlotOffset, '
+      'warmup: $warmup, firstNormalEpoch: $firstNormalEpoch, '
+      'firstNormalSlot: $firstNormalSlot)';
+}
+
+/// Returns a fixed-size encoder for the [SysvarEpochSchedule] sysvar.
+FixedSizeEncoder<SysvarEpochSchedule> getSysvarEpochScheduleEncoder() {
+  final structEncoder =
+      getStructEncoder([
+            ('slotsPerEpoch', getU64Encoder()),
+            ('leaderScheduleSlotOffset', getU64Encoder()),
+            ('warmup', getBooleanEncoder()),
+            ('firstNormalEpoch', getU64Encoder()),
+            ('firstNormalSlot', getU64Encoder()),
+          ])
+          as FixedSizeEncoder<Map<String, Object?>>;
+
+  return FixedSizeEncoder<SysvarEpochSchedule>(
+    fixedSize: sysvarEpochScheduleSize,
+    write: (SysvarEpochSchedule value, Uint8List bytes, int offset) {
+      return structEncoder.write(
+        {
+          'slotsPerEpoch': value.slotsPerEpoch,
+          'leaderScheduleSlotOffset': value.leaderScheduleSlotOffset,
+          'warmup': value.warmup,
+          'firstNormalEpoch': value.firstNormalEpoch,
+          'firstNormalSlot': value.firstNormalSlot,
+        },
+        bytes,
+        offset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size decoder for the [SysvarEpochSchedule] sysvar.
+FixedSizeDecoder<SysvarEpochSchedule> getSysvarEpochScheduleDecoder() {
+  final structDecoder =
+      getStructDecoder([
+            ('slotsPerEpoch', getU64Decoder()),
+            ('leaderScheduleSlotOffset', getU64Decoder()),
+            ('warmup', getBooleanDecoder()),
+            ('firstNormalEpoch', getU64Decoder()),
+            ('firstNormalSlot', getU64Decoder()),
+          ])
+          as FixedSizeDecoder<Map<String, Object?>>;
+
+  return FixedSizeDecoder<SysvarEpochSchedule>(
+    fixedSize: sysvarEpochScheduleSize,
+    read: (Uint8List bytes, int offset) {
+      final (map, newOffset) = structDecoder.read(bytes, offset);
+      return (
+        SysvarEpochSchedule(
+          slotsPerEpoch: map['slotsPerEpoch']! as BigInt,
+          leaderScheduleSlotOffset: map['leaderScheduleSlotOffset']! as BigInt,
+          warmup: map['warmup']! as bool,
+          firstNormalEpoch: map['firstNormalEpoch']! as BigInt,
+          firstNormalSlot: map['firstNormalSlot']! as BigInt,
+        ),
+        newOffset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size codec for the [SysvarEpochSchedule] sysvar.
+FixedSizeCodec<SysvarEpochSchedule, SysvarEpochSchedule>
+getSysvarEpochScheduleCodec() {
+  return combineCodec(
+        getSysvarEpochScheduleEncoder(),
+        getSysvarEpochScheduleDecoder(),
+      )
+      as FixedSizeCodec<SysvarEpochSchedule, SysvarEpochSchedule>;
+}
+
+/// Fetches the `EpochSchedule` sysvar account using the provided RPC client.
+Future<SysvarEpochSchedule> fetchSysvarEpochSchedule(
+  Rpc rpc, {
+  FetchAccountConfig? config,
+}) async {
+  final account = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarEpochScheduleAddress,
+    config: config,
+  );
+  assertAccountExists(account);
+  final decoded = decodeAccount(
+    (account as ExistingAccount<Uint8List>).account,
+    getSysvarEpochScheduleDecoder(),
+  );
+  return decoded.data;
+}

--- a/packages/solana_kit_sysvars/lib/src/last_restart_slot.dart
+++ b/packages/solana_kit_sysvars/lib/src/last_restart_slot.dart
@@ -1,0 +1,108 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+import 'package:solana_kit_sysvars/src/sysvar.dart';
+
+/// The size in bytes of the LastRestartSlot sysvar account data.
+const int sysvarLastRestartSlotSize = 8;
+
+/// Information about the last restart slot (hard fork).
+///
+/// The `LastRestartSlot` sysvar provides access to the last restart slot kept
+/// in the bank fork for the slot on the fork that executes the current
+/// transaction. In case there was no fork it returns `0`.
+@immutable
+class SysvarLastRestartSlot {
+  /// Creates a new [SysvarLastRestartSlot].
+  const SysvarLastRestartSlot({required this.lastRestartSlot});
+
+  /// The last restart slot.
+  final BigInt lastRestartSlot;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SysvarLastRestartSlot &&
+          runtimeType == other.runtimeType &&
+          lastRestartSlot == other.lastRestartSlot;
+
+  @override
+  int get hashCode => lastRestartSlot.hashCode;
+
+  @override
+  String toString() =>
+      'SysvarLastRestartSlot(lastRestartSlot: $lastRestartSlot)';
+}
+
+/// Returns a fixed-size encoder for the [SysvarLastRestartSlot] sysvar.
+FixedSizeEncoder<SysvarLastRestartSlot> getSysvarLastRestartSlotEncoder() {
+  final structEncoder =
+      getStructEncoder([('lastRestartSlot', getU64Encoder())])
+          as FixedSizeEncoder<Map<String, Object?>>;
+
+  return FixedSizeEncoder<SysvarLastRestartSlot>(
+    fixedSize: sysvarLastRestartSlotSize,
+    write: (SysvarLastRestartSlot value, Uint8List bytes, int offset) {
+      return structEncoder.write(
+        {'lastRestartSlot': value.lastRestartSlot},
+        bytes,
+        offset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size decoder for the [SysvarLastRestartSlot] sysvar.
+FixedSizeDecoder<SysvarLastRestartSlot> getSysvarLastRestartSlotDecoder() {
+  final structDecoder =
+      getStructDecoder([('lastRestartSlot', getU64Decoder())])
+          as FixedSizeDecoder<Map<String, Object?>>;
+
+  return FixedSizeDecoder<SysvarLastRestartSlot>(
+    fixedSize: sysvarLastRestartSlotSize,
+    read: (Uint8List bytes, int offset) {
+      final (map, newOffset) = structDecoder.read(bytes, offset);
+      return (
+        SysvarLastRestartSlot(
+          lastRestartSlot: map['lastRestartSlot']! as BigInt,
+        ),
+        newOffset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size codec for the [SysvarLastRestartSlot] sysvar.
+FixedSizeCodec<SysvarLastRestartSlot, SysvarLastRestartSlot>
+getSysvarLastRestartSlotCodec() {
+  return combineCodec(
+        getSysvarLastRestartSlotEncoder(),
+        getSysvarLastRestartSlotDecoder(),
+      )
+      as FixedSizeCodec<SysvarLastRestartSlot, SysvarLastRestartSlot>;
+}
+
+/// Fetches the `LastRestartSlot` sysvar account using the provided RPC
+/// client.
+Future<SysvarLastRestartSlot> fetchSysvarLastRestartSlot(
+  Rpc rpc, {
+  FetchAccountConfig? config,
+}) async {
+  final account = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarLastRestartSlotAddress,
+    config: config,
+  );
+  assertAccountExists(account);
+  final decoded = decodeAccount(
+    (account as ExistingAccount<Uint8List>).account,
+    getSysvarLastRestartSlotDecoder(),
+  );
+  return decoded.data;
+}

--- a/packages/solana_kit_sysvars/lib/src/recent_blockhashes.dart
+++ b/packages/solana_kit_sysvars/lib/src/recent_blockhashes.dart
@@ -1,0 +1,182 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+import 'package:solana_kit_sysvars/src/sysvar.dart';
+
+/// A fee calculator containing the lamports per signature cost.
+@immutable
+class FeeCalculator {
+  /// Creates a new [FeeCalculator].
+  const FeeCalculator({required this.lamportsPerSignature});
+
+  /// The current cost of a signature.
+  ///
+  /// This amount may increase/decrease over time based on cluster processing
+  /// load.
+  final Lamports lamportsPerSignature;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FeeCalculator &&
+          runtimeType == other.runtimeType &&
+          lamportsPerSignature == other.lamportsPerSignature;
+
+  @override
+  int get hashCode => lamportsPerSignature.hashCode;
+
+  @override
+  String toString() =>
+      'FeeCalculator(lamportsPerSignature: ${lamportsPerSignature.value})';
+}
+
+/// An entry in the recent blockhashes sysvar.
+@immutable
+class RecentBlockhashEntry {
+  /// Creates a new [RecentBlockhashEntry].
+  const RecentBlockhashEntry({
+    required this.blockhash,
+    required this.feeCalculator,
+  });
+
+  /// The blockhash.
+  final Blockhash blockhash;
+
+  /// The fee calculator for this blockhash.
+  final FeeCalculator feeCalculator;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RecentBlockhashEntry &&
+          runtimeType == other.runtimeType &&
+          blockhash == other.blockhash &&
+          feeCalculator == other.feeCalculator;
+
+  @override
+  int get hashCode => Object.hash(blockhash, feeCalculator);
+
+  @override
+  String toString() =>
+      'RecentBlockhashEntry(blockhash: ${blockhash.value}, '
+      'feeCalculator: $feeCalculator)';
+}
+
+/// Information about recent blocks and their fee calculators.
+///
+/// @deprecated Transaction fees should be determined with the
+/// `getFeeForMessage` RPC method.
+typedef SysvarRecentBlockhashes = List<RecentBlockhashEntry>;
+
+/// Returns a variable-size encoder for the [SysvarRecentBlockhashes] sysvar.
+///
+/// @deprecated Transaction fees should be determined with the
+/// `getFeeForMessage` RPC method.
+VariableSizeEncoder<SysvarRecentBlockhashes>
+getSysvarRecentBlockhashesEncoder() {
+  final entryEncoder = getStructEncoder([
+    ('blockhash', getBlockhashEncoder()),
+    (
+      'feeCalculator',
+      getStructEncoder([('lamportsPerSignature', getDefaultLamportsEncoder())]),
+    ),
+  ]);
+  final arrayEncoder = getArrayEncoder<Map<String, Object?>>(entryEncoder);
+
+  return VariableSizeEncoder<SysvarRecentBlockhashes>(
+    getSizeFromValue: (SysvarRecentBlockhashes value) {
+      final maps = _entriesToMaps(value);
+      return getEncodedSize(maps, arrayEncoder);
+    },
+    write: (SysvarRecentBlockhashes value, Uint8List bytes, int offset) {
+      final maps = _entriesToMaps(value);
+      return arrayEncoder.write(maps, bytes, offset);
+    },
+  );
+}
+
+/// Returns a variable-size decoder for the [SysvarRecentBlockhashes] sysvar.
+///
+/// @deprecated Transaction fees should be determined with the
+/// `getFeeForMessage` RPC method.
+VariableSizeDecoder<SysvarRecentBlockhashes>
+getSysvarRecentBlockhashesDecoder() {
+  final entryDecoder = getStructDecoder([
+    ('blockhash', getBlockhashDecoder()),
+    (
+      'feeCalculator',
+      getStructDecoder([('lamportsPerSignature', getDefaultLamportsDecoder())]),
+    ),
+  ]);
+  final arrayDecoder = getArrayDecoder<Map<String, Object?>>(entryDecoder);
+
+  return VariableSizeDecoder<SysvarRecentBlockhashes>(
+    read: (Uint8List bytes, int offset) {
+      final (maps, newOffset) = arrayDecoder.read(bytes, offset);
+      final entries = maps.map(_mapToEntry).toList();
+      return (entries, newOffset);
+    },
+  );
+}
+
+/// Returns a variable-size codec for the [SysvarRecentBlockhashes] sysvar.
+///
+/// @deprecated Transaction fees should be determined with the
+/// `getFeeForMessage` RPC method.
+VariableSizeCodec<SysvarRecentBlockhashes, SysvarRecentBlockhashes>
+getSysvarRecentBlockhashesCodec() {
+  return combineCodec(
+        getSysvarRecentBlockhashesEncoder(),
+        getSysvarRecentBlockhashesDecoder(),
+      )
+      as VariableSizeCodec<SysvarRecentBlockhashes, SysvarRecentBlockhashes>;
+}
+
+/// Fetches the `RecentBlockhashes` sysvar account using the provided RPC
+/// client.
+///
+/// @deprecated Transaction fees should be determined with the
+/// `getFeeForMessage` RPC method.
+Future<SysvarRecentBlockhashes> fetchSysvarRecentBlockhashes(
+  Rpc rpc, {
+  FetchAccountConfig? config,
+}) async {
+  final account = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarRecentBlockhashesAddress,
+    config: config,
+  );
+  assertAccountExists(account);
+  final decoded = decodeAccount(
+    (account as ExistingAccount<Uint8List>).account,
+    getSysvarRecentBlockhashesDecoder(),
+  );
+  return decoded.data;
+}
+
+List<Map<String, Object?>> _entriesToMaps(SysvarRecentBlockhashes entries) {
+  return entries.map((entry) {
+    return <String, Object?>{
+      'blockhash': entry.blockhash,
+      'feeCalculator': <String, Object?>{
+        'lamportsPerSignature': entry.feeCalculator.lamportsPerSignature,
+      },
+    };
+  }).toList();
+}
+
+RecentBlockhashEntry _mapToEntry(Map<String, Object?> map) {
+  final feeCalcMap = map['feeCalculator']! as Map<String, Object?>;
+  return RecentBlockhashEntry(
+    blockhash: map['blockhash']! as Blockhash,
+    feeCalculator: FeeCalculator(
+      lamportsPerSignature: feeCalcMap['lamportsPerSignature']! as Lamports,
+    ),
+  );
+}

--- a/packages/solana_kit_sysvars/lib/src/rent.dart
+++ b/packages/solana_kit_sysvars/lib/src/rent.dart
@@ -1,0 +1,133 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+import 'package:solana_kit_sysvars/src/sysvar.dart';
+
+/// The size in bytes of the Rent sysvar account data.
+const int sysvarRentSize = 17;
+
+/// Configuration for network rent.
+@immutable
+class SysvarRent {
+  /// Creates a new [SysvarRent].
+  const SysvarRent({
+    required this.lamportsPerByteYear,
+    required this.exemptionThreshold,
+    required this.burnPercent,
+  });
+
+  /// Rental rate in [Lamports]/byte-year.
+  final Lamports lamportsPerByteYear;
+
+  /// Amount of time (in years) a balance must include rent for the account
+  /// to be rent exempt.
+  final double exemptionThreshold;
+
+  /// The percentage of collected rent that is burned.
+  ///
+  /// Valid values are in the range [0, 100]. The remaining percentage is
+  /// distributed to validators.
+  final int burnPercent;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SysvarRent &&
+          runtimeType == other.runtimeType &&
+          lamportsPerByteYear == other.lamportsPerByteYear &&
+          exemptionThreshold == other.exemptionThreshold &&
+          burnPercent == other.burnPercent;
+
+  @override
+  int get hashCode =>
+      Object.hash(lamportsPerByteYear, exemptionThreshold, burnPercent);
+
+  @override
+  String toString() =>
+      'SysvarRent(lamportsPerByteYear: ${lamportsPerByteYear.value}, '
+      'exemptionThreshold: $exemptionThreshold, '
+      'burnPercent: $burnPercent)';
+}
+
+/// Returns a fixed-size encoder for the [SysvarRent] sysvar.
+FixedSizeEncoder<SysvarRent> getSysvarRentEncoder() {
+  final structEncoder =
+      getStructEncoder([
+            ('lamportsPerByteYear', getDefaultLamportsEncoder()),
+            ('exemptionThreshold', getF64Encoder()),
+            ('burnPercent', getU8Encoder()),
+          ])
+          as FixedSizeEncoder<Map<String, Object?>>;
+
+  return FixedSizeEncoder<SysvarRent>(
+    fixedSize: sysvarRentSize,
+    write: (SysvarRent value, Uint8List bytes, int offset) {
+      return structEncoder.write(
+        {
+          'lamportsPerByteYear': value.lamportsPerByteYear,
+          'exemptionThreshold': value.exemptionThreshold,
+          'burnPercent': value.burnPercent,
+        },
+        bytes,
+        offset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size decoder for the [SysvarRent] sysvar.
+FixedSizeDecoder<SysvarRent> getSysvarRentDecoder() {
+  final structDecoder =
+      getStructDecoder([
+            ('lamportsPerByteYear', getDefaultLamportsDecoder()),
+            ('exemptionThreshold', getF64Decoder()),
+            ('burnPercent', getU8Decoder()),
+          ])
+          as FixedSizeDecoder<Map<String, Object?>>;
+
+  return FixedSizeDecoder<SysvarRent>(
+    fixedSize: sysvarRentSize,
+    read: (Uint8List bytes, int offset) {
+      final (map, newOffset) = structDecoder.read(bytes, offset);
+      return (
+        SysvarRent(
+          lamportsPerByteYear: map['lamportsPerByteYear']! as Lamports,
+          exemptionThreshold: map['exemptionThreshold']! as double,
+          burnPercent: map['burnPercent']! as int,
+        ),
+        newOffset,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size codec for the [SysvarRent] sysvar.
+FixedSizeCodec<SysvarRent, SysvarRent> getSysvarRentCodec() {
+  return combineCodec(getSysvarRentEncoder(), getSysvarRentDecoder())
+      as FixedSizeCodec<SysvarRent, SysvarRent>;
+}
+
+/// Fetches the `Rent` sysvar account using the provided RPC client.
+Future<SysvarRent> fetchSysvarRent(
+  Rpc rpc, {
+  FetchAccountConfig? config,
+}) async {
+  final account = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarRentAddress,
+    config: config,
+  );
+  assertAccountExists(account);
+  final decoded = decodeAccount(
+    (account as ExistingAccount<Uint8List>).account,
+    getSysvarRentDecoder(),
+  );
+  return decoded.data;
+}

--- a/packages/solana_kit_sysvars/lib/src/slot_hashes.dart
+++ b/packages/solana_kit_sysvars/lib/src/slot_hashes.dart
@@ -1,0 +1,119 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+import 'package:solana_kit_sysvars/src/sysvar.dart';
+
+/// An entry in the slot hashes sysvar.
+@immutable
+class SlotHashEntry {
+  /// Creates a new [SlotHashEntry].
+  const SlotHashEntry({required this.slot, required this.hash});
+
+  /// The slot number.
+  final BigInt slot;
+
+  /// The hash of the slot's parent bank.
+  final Blockhash hash;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SlotHashEntry &&
+          runtimeType == other.runtimeType &&
+          slot == other.slot &&
+          hash == other.hash;
+
+  @override
+  int get hashCode => Object.hash(slot, hash);
+
+  @override
+  String toString() => 'SlotHashEntry(slot: $slot, hash: ${hash.value})';
+}
+
+/// The most recent hashes of a slot's parent banks.
+typedef SysvarSlotHashes = List<SlotHashEntry>;
+
+/// Returns a variable-size encoder for the [SysvarSlotHashes] sysvar.
+VariableSizeEncoder<SysvarSlotHashes> getSysvarSlotHashesEncoder() {
+  final entryEncoder = getStructEncoder([
+    ('slot', getU64Encoder()),
+    ('hash', getBlockhashEncoder()),
+  ]);
+  final arrayEncoder = getArrayEncoder<Map<String, Object?>>(entryEncoder);
+
+  return VariableSizeEncoder<SysvarSlotHashes>(
+    getSizeFromValue: (SysvarSlotHashes value) {
+      final maps = _entriesToMaps(value);
+      return getEncodedSize(maps, arrayEncoder);
+    },
+    write: (SysvarSlotHashes value, Uint8List bytes, int offset) {
+      final maps = _entriesToMaps(value);
+      return arrayEncoder.write(maps, bytes, offset);
+    },
+  );
+}
+
+/// Returns a variable-size decoder for the [SysvarSlotHashes] sysvar.
+VariableSizeDecoder<SysvarSlotHashes> getSysvarSlotHashesDecoder() {
+  final entryDecoder = getStructDecoder([
+    ('slot', getU64Decoder()),
+    ('hash', getBlockhashDecoder()),
+  ]);
+  final arrayDecoder = getArrayDecoder<Map<String, Object?>>(entryDecoder);
+
+  return VariableSizeDecoder<SysvarSlotHashes>(
+    read: (Uint8List bytes, int offset) {
+      final (maps, newOffset) = arrayDecoder.read(bytes, offset);
+      final entries = maps.map(_mapToEntry).toList();
+      return (entries, newOffset);
+    },
+  );
+}
+
+/// Returns a variable-size codec for the [SysvarSlotHashes] sysvar.
+VariableSizeCodec<SysvarSlotHashes, SysvarSlotHashes>
+getSysvarSlotHashesCodec() {
+  return combineCodec(
+        getSysvarSlotHashesEncoder(),
+        getSysvarSlotHashesDecoder(),
+      )
+      as VariableSizeCodec<SysvarSlotHashes, SysvarSlotHashes>;
+}
+
+/// Fetches the `SlotHashes` sysvar account using the provided RPC client.
+Future<SysvarSlotHashes> fetchSysvarSlotHashes(
+  Rpc rpc, {
+  FetchAccountConfig? config,
+}) async {
+  final account = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarSlotHashesAddress,
+    config: config,
+  );
+  assertAccountExists(account);
+  final decoded = decodeAccount(
+    (account as ExistingAccount<Uint8List>).account,
+    getSysvarSlotHashesDecoder(),
+  );
+  return decoded.data;
+}
+
+List<Map<String, Object?>> _entriesToMaps(SysvarSlotHashes entries) {
+  return entries.map((entry) {
+    return <String, Object?>{'slot': entry.slot, 'hash': entry.hash};
+  }).toList();
+}
+
+SlotHashEntry _mapToEntry(Map<String, Object?> map) {
+  return SlotHashEntry(
+    slot: map['slot']! as BigInt,
+    hash: map['hash']! as Blockhash,
+  );
+}

--- a/packages/solana_kit_sysvars/lib/src/slot_history.dart
+++ b/packages/solana_kit_sysvars/lib/src/slot_history.dart
@@ -1,0 +1,234 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+import 'package:solana_kit_sysvars/src/sysvar.dart';
+
+/// The bitvector discriminator value.
+const int bitvecDiscriminator = 1;
+
+/// Max number of bits in the bitvector.
+///
+/// The Solana SDK defines a constant `MAX_ENTRIES` representing the maximum
+/// number of bits that can be represented by the bitvector in the
+/// `SlotHistory` sysvar. This value is 1024 * 1024 = 1,048,576.
+const int bitvecNumBits = 1024 * 1024;
+
+/// The length of the bitvector in 64-bit blocks.
+///
+/// At 64 bits per block, this is 1024 * 1024 / 64 = 16,384.
+const int bitvecLength = bitvecNumBits ~/ 64;
+
+/// The size in bytes of the SlotHistory sysvar account data.
+///
+/// Computed as:
+/// - 1 byte for the discriminator
+/// - 8 bytes for the bitvector length (u64)
+/// - [bitvecLength] * 8 bytes for the bitvector data
+/// - 8 bytes for the number of bits (u64)
+/// - 8 bytes for the next slot (u64)
+const int sysvarSlotHistorySize = 1 + 8 + bitvecLength * 8 + 8 + 8; // 131,097
+
+/// A bitvector of slots present over the last epoch.
+@immutable
+class SysvarSlotHistory {
+  /// Creates a new [SysvarSlotHistory].
+  const SysvarSlotHistory({required this.bits, required this.nextSlot});
+
+  /// A vector of 64-bit numbers which, when their bits are strung together,
+  /// represent a record of non-skipped slots.
+  ///
+  /// The bit in position (slot % MAX_ENTRIES) is 0 if the slot was skipped
+  /// and 1 otherwise, valid only when the candidate slot is less than
+  /// [nextSlot] and greater than or equal to `MAX_ENTRIES - nextSlot`.
+  final List<BigInt> bits;
+
+  /// The number of the slot one newer than tracked by the bitvector.
+  final BigInt nextSlot;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SysvarSlotHistory &&
+          runtimeType == other.runtimeType &&
+          nextSlot == other.nextSlot &&
+          _listEquals(bits, other.bits);
+
+  @override
+  int get hashCode => Object.hash(Object.hashAll(bits), nextSlot);
+
+  @override
+  String toString() =>
+      'SysvarSlotHistory(bits: [${bits.length} elements], '
+      'nextSlot: $nextSlot)';
+}
+
+bool _listEquals(List<BigInt> a, List<BigInt> b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}
+
+/// Memoized codec instances.
+FixedSizeEncoder<BigInt>? _memoizedU64Encoder;
+FixedSizeDecoder<BigInt>? _memoizedU64Decoder;
+FixedSizeEncoder<List<BigInt>>? _memoizedU64ArrayEncoder;
+FixedSizeDecoder<List<BigInt>>? _memoizedU64ArrayDecoder;
+
+FixedSizeEncoder<BigInt> _getMemoizedU64Encoder() {
+  return _memoizedU64Encoder ??= getU64Encoder();
+}
+
+FixedSizeDecoder<BigInt> _getMemoizedU64Decoder() {
+  return _memoizedU64Decoder ??= getU64Decoder();
+}
+
+FixedSizeEncoder<List<BigInt>> _getMemoizedU64ArrayEncoder() {
+  if (_memoizedU64ArrayEncoder != null) return _memoizedU64ArrayEncoder!;
+  final codec = getArrayCodec<BigInt>(
+    getU64Codec(),
+    size: const FixedArraySize(bitvecLength),
+  );
+  _memoizedU64ArrayEncoder =
+      encoderFromCodec(codec) as FixedSizeEncoder<List<BigInt>>;
+  return _memoizedU64ArrayEncoder!;
+}
+
+FixedSizeDecoder<List<BigInt>> _getMemoizedU64ArrayDecoder() {
+  if (_memoizedU64ArrayDecoder != null) return _memoizedU64ArrayDecoder!;
+  final codec = getArrayCodec<BigInt>(
+    getU64Codec(),
+    size: const FixedArraySize(bitvecLength),
+  );
+  _memoizedU64ArrayDecoder =
+      decoderFromCodec(codec) as FixedSizeDecoder<List<BigInt>>;
+  return _memoizedU64ArrayDecoder!;
+}
+
+/// Returns a fixed-size encoder for the [SysvarSlotHistory] sysvar.
+FixedSizeEncoder<SysvarSlotHistory> getSysvarSlotHistoryEncoder() {
+  return FixedSizeEncoder<SysvarSlotHistory>(
+    fixedSize: sysvarSlotHistorySize,
+    write: (SysvarSlotHistory value, Uint8List bytes, int currentOffset) {
+      var o = currentOffset;
+      // First byte is the bitvector discriminator.
+      bytes[o] = bitvecDiscriminator;
+      o += 1;
+      // Next 8 bytes are the bitvector length.
+      _getMemoizedU64Encoder().write(BigInt.from(bitvecLength), bytes, o);
+      o += 8;
+      // Next `bitvecLength * 8` bytes are the bitvector.
+      _getMemoizedU64ArrayEncoder().write(value.bits, bytes, o);
+      o += bitvecLength * 8;
+      // Next 8 bytes are the number of bits.
+      _getMemoizedU64Encoder().write(BigInt.from(bitvecNumBits), bytes, o);
+      o += 8;
+      // Next 8 bytes are the next slot.
+      _getMemoizedU64Encoder().write(value.nextSlot, bytes, o);
+      return o + 8;
+    },
+  );
+}
+
+/// Returns a fixed-size decoder for the [SysvarSlotHistory] sysvar.
+FixedSizeDecoder<SysvarSlotHistory> getSysvarSlotHistoryDecoder() {
+  return FixedSizeDecoder<SysvarSlotHistory>(
+    fixedSize: sysvarSlotHistorySize,
+    read: (Uint8List bytes, int currentOffset) {
+      var o = currentOffset;
+      // Byte length should be exact.
+      if (bytes.length != sysvarSlotHistorySize) {
+        throw SolanaError(SolanaErrorCode.codecsInvalidByteLength, {
+          'actual': bytes.length,
+          'expected': sysvarSlotHistorySize,
+        });
+      }
+      // First byte is the bitvector discriminator.
+      final discriminator = bytes[o];
+      o += 1;
+      if (discriminator != bitvecDiscriminator) {
+        throw SolanaError(SolanaErrorCode.codecsEnumDiscriminatorOutOfRange, {
+          'actual': discriminator,
+          'expected': bitvecDiscriminator,
+        });
+      }
+      // Next 8 bytes are the bitvector length.
+      final (bitVecLength, offsetAfterLen) = _getMemoizedU64Decoder().read(
+        bytes,
+        o,
+      );
+      o = offsetAfterLen;
+      if (bitVecLength != BigInt.from(bitvecLength)) {
+        throw SolanaError(SolanaErrorCode.codecsInvalidNumberOfItems, {
+          'actual': bitVecLength,
+          'codecDescription': 'SysvarSlotHistoryCodec',
+          'expected': bitvecLength,
+        });
+      }
+      // Next `bitvecLength * 8` bytes are the bitvector.
+      final (bits, offsetAfterBits) = _getMemoizedU64ArrayDecoder().read(
+        bytes,
+        o,
+      );
+      o = offsetAfterBits;
+      // Next 8 bytes are the number of bits.
+      final (numBits, offsetAfterNumBits) = _getMemoizedU64Decoder().read(
+        bytes,
+        o,
+      );
+      o = offsetAfterNumBits;
+      if (numBits != BigInt.from(bitvecNumBits)) {
+        throw SolanaError(SolanaErrorCode.codecsInvalidNumberOfItems, {
+          'actual': numBits,
+          'codecDescription': 'SysvarSlotHistoryCodec',
+          'expected': bitvecNumBits,
+        });
+      }
+      // Next 8 bytes are the next slot.
+      final (nextSlot, offsetAfterNextSlot) = _getMemoizedU64Decoder().read(
+        bytes,
+        o,
+      );
+      return (
+        SysvarSlotHistory(bits: bits, nextSlot: nextSlot),
+        offsetAfterNextSlot,
+      );
+    },
+  );
+}
+
+/// Returns a fixed-size codec for the [SysvarSlotHistory] sysvar.
+FixedSizeCodec<SysvarSlotHistory, SysvarSlotHistory>
+getSysvarSlotHistoryCodec() {
+  return combineCodec(
+        getSysvarSlotHistoryEncoder(),
+        getSysvarSlotHistoryDecoder(),
+      )
+      as FixedSizeCodec<SysvarSlotHistory, SysvarSlotHistory>;
+}
+
+/// Fetches the `SlotHistory` sysvar account using the provided RPC client.
+Future<SysvarSlotHistory> fetchSysvarSlotHistory(
+  Rpc rpc, {
+  FetchAccountConfig? config,
+}) async {
+  final account = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarSlotHistoryAddress,
+    config: config,
+  );
+  assertAccountExists(account);
+  final decoded = decodeAccount(
+    (account as ExistingAccount<Uint8List>).account,
+    getSysvarSlotHistoryDecoder(),
+  );
+  return decoded.data;
+}

--- a/packages/solana_kit_sysvars/lib/src/stake_history.dart
+++ b/packages/solana_kit_sysvars/lib/src/stake_history.dart
@@ -1,0 +1,203 @@
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+import 'package:solana_kit_sysvars/src/sysvar.dart';
+
+/// Stake activation/deactivation data for a single epoch.
+@immutable
+class StakeHistoryData {
+  /// Creates a new [StakeHistoryData].
+  const StakeHistoryData({
+    required this.effective,
+    required this.activating,
+    required this.deactivating,
+  });
+
+  /// Effective stake at this epoch, in [Lamports].
+  final Lamports effective;
+
+  /// Sum of portion of stakes requested to be warmed up, but not fully
+  /// activated yet, in [Lamports].
+  final Lamports activating;
+
+  /// Sum of portion of stakes requested to be cooled down, but not fully
+  /// deactivated yet, in [Lamports].
+  final Lamports deactivating;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is StakeHistoryData &&
+          runtimeType == other.runtimeType &&
+          effective == other.effective &&
+          activating == other.activating &&
+          deactivating == other.deactivating;
+
+  @override
+  int get hashCode => Object.hash(effective, activating, deactivating);
+
+  @override
+  String toString() =>
+      'StakeHistoryData(effective: ${effective.value}, '
+      'activating: ${activating.value}, '
+      'deactivating: ${deactivating.value})';
+}
+
+/// An entry in the stake history sysvar.
+@immutable
+class StakeHistoryEntry {
+  /// Creates a new [StakeHistoryEntry].
+  const StakeHistoryEntry({required this.epoch, required this.stakeHistory});
+
+  /// The epoch to which this stake history entry pertains.
+  final BigInt epoch;
+
+  /// The stake activation/deactivation data.
+  final StakeHistoryData stakeHistory;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is StakeHistoryEntry &&
+          runtimeType == other.runtimeType &&
+          epoch == other.epoch &&
+          stakeHistory == other.stakeHistory;
+
+  @override
+  int get hashCode => Object.hash(epoch, stakeHistory);
+
+  @override
+  String toString() =>
+      'StakeHistoryEntry(epoch: $epoch, stakeHistory: $stakeHistory)';
+}
+
+/// History of stake activations and de-activations.
+typedef SysvarStakeHistory = List<StakeHistoryEntry>;
+
+/// Size of each entry struct: u64 epoch + u64 effective + u64 activating +
+/// u64 deactivating = 32 bytes.
+const int _entrySize = 32;
+
+/// Returns a variable-size encoder for the [SysvarStakeHistory] sysvar.
+VariableSizeEncoder<SysvarStakeHistory> getSysvarStakeHistoryEncoder() {
+  final u64Encoder = getU64Encoder();
+  final entryEncoder = getStructEncoder([
+    ('epoch', getU64Encoder()),
+    (
+      'stakeHistory',
+      getStructEncoder([
+        ('effective', getDefaultLamportsEncoder()),
+        ('activating', getDefaultLamportsEncoder()),
+        ('deactivating', getDefaultLamportsEncoder()),
+      ]),
+    ),
+  ]);
+
+  return VariableSizeEncoder<SysvarStakeHistory>(
+    getSizeFromValue: (SysvarStakeHistory value) {
+      // 8 bytes for the u64 length prefix + entry size * count.
+      return 8 + _entrySize * value.length;
+    },
+    write: (SysvarStakeHistory value, Uint8List bytes, int offset) {
+      var o = offset;
+      // Write the u64 length prefix.
+      o = u64Encoder.write(BigInt.from(value.length), bytes, o);
+      // Write each entry.
+      for (final entry in value) {
+        o = entryEncoder.write(_entryToMap(entry), bytes, o);
+      }
+      return o;
+    },
+  );
+}
+
+/// Returns a variable-size decoder for the [SysvarStakeHistory] sysvar.
+VariableSizeDecoder<SysvarStakeHistory> getSysvarStakeHistoryDecoder() {
+  final u64Decoder = getU64Decoder();
+  final entryDecoder = getStructDecoder([
+    ('epoch', getU64Decoder()),
+    (
+      'stakeHistory',
+      getStructDecoder([
+        ('effective', getDefaultLamportsDecoder()),
+        ('activating', getDefaultLamportsDecoder()),
+        ('deactivating', getDefaultLamportsDecoder()),
+      ]),
+    ),
+  ]);
+
+  return VariableSizeDecoder<SysvarStakeHistory>(
+    read: (Uint8List bytes, int offset) {
+      var o = offset;
+      // Read the u64 length prefix.
+      final (length, offsetAfterLen) = u64Decoder.read(bytes, o);
+      o = offsetAfterLen;
+      final count = length.toInt();
+      final entries = <StakeHistoryEntry>[];
+      for (var i = 0; i < count; i++) {
+        final (map, newOffset) = entryDecoder.read(bytes, o);
+        o = newOffset;
+        entries.add(_mapToEntry(map));
+      }
+      return (entries, o);
+    },
+  );
+}
+
+/// Returns a variable-size codec for the [SysvarStakeHistory] sysvar.
+VariableSizeCodec<SysvarStakeHistory, SysvarStakeHistory>
+getSysvarStakeHistoryCodec() {
+  return combineCodec(
+        getSysvarStakeHistoryEncoder(),
+        getSysvarStakeHistoryDecoder(),
+      )
+      as VariableSizeCodec<SysvarStakeHistory, SysvarStakeHistory>;
+}
+
+/// Fetches the `StakeHistory` sysvar account using the provided RPC client.
+Future<SysvarStakeHistory> fetchSysvarStakeHistory(
+  Rpc rpc, {
+  FetchAccountConfig? config,
+}) async {
+  final account = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarStakeHistoryAddress,
+    config: config,
+  );
+  assertAccountExists(account);
+  final decoded = decodeAccount(
+    (account as ExistingAccount<Uint8List>).account,
+    getSysvarStakeHistoryDecoder(),
+  );
+  return decoded.data;
+}
+
+Map<String, Object?> _entryToMap(StakeHistoryEntry entry) {
+  return <String, Object?>{
+    'epoch': entry.epoch,
+    'stakeHistory': <String, Object?>{
+      'effective': entry.stakeHistory.effective,
+      'activating': entry.stakeHistory.activating,
+      'deactivating': entry.stakeHistory.deactivating,
+    },
+  };
+}
+
+StakeHistoryEntry _mapToEntry(Map<String, Object?> map) {
+  final stakeHistoryMap = map['stakeHistory']! as Map<String, Object?>;
+  return StakeHistoryEntry(
+    epoch: map['epoch']! as BigInt,
+    stakeHistory: StakeHistoryData(
+      effective: stakeHistoryMap['effective']! as Lamports,
+      activating: stakeHistoryMap['activating']! as Lamports,
+      deactivating: stakeHistoryMap['deactivating']! as Lamports,
+    ),
+  );
+}

--- a/packages/solana_kit_sysvars/lib/src/sysvar.dart
+++ b/packages/solana_kit_sysvars/lib/src/sysvar.dart
@@ -1,0 +1,65 @@
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+/// The address of the Clock sysvar.
+const Address sysvarClockAddress = Address(
+  'SysvarC1ock11111111111111111111111111111111',
+);
+
+/// The address of the EpochRewards sysvar.
+const Address sysvarEpochRewardsAddress = Address(
+  'SysvarEpochRewards1111111111111111111111111',
+);
+
+/// The address of the EpochSchedule sysvar.
+const Address sysvarEpochScheduleAddress = Address(
+  'SysvarEpochSchedu1e111111111111111111111111',
+);
+
+/// The address of the Instructions sysvar.
+const Address sysvarInstructionsAddress = Address(
+  'Sysvar1nstructions1111111111111111111111111',
+);
+
+/// The address of the LastRestartSlot sysvar.
+const Address sysvarLastRestartSlotAddress = Address(
+  'SysvarLastRestartS1ot1111111111111111111111',
+);
+
+/// The address of the RecentBlockhashes sysvar.
+const Address sysvarRecentBlockhashesAddress = Address(
+  'SysvarRecentB1ockHashes11111111111111111111',
+);
+
+/// The address of the Rent sysvar.
+const Address sysvarRentAddress = Address(
+  'SysvarRent111111111111111111111111111111111',
+);
+
+/// The address of the SlotHashes sysvar.
+const Address sysvarSlotHashesAddress = Address(
+  'SysvarS1otHashes111111111111111111111111111',
+);
+
+/// The address of the SlotHistory sysvar.
+const Address sysvarSlotHistoryAddress = Address(
+  'SysvarS1otHistory11111111111111111111111111',
+);
+
+/// The address of the StakeHistory sysvar.
+const Address sysvarStakeHistoryAddress = Address(
+  'SysvarStakeHistory1111111111111111111111111',
+);
+
+/// Fetches an encoded sysvar account.
+///
+/// Sysvars are special accounts that contain dynamically-updated data about
+/// the network cluster, the blockchain history, and the executing transaction.
+Future<MaybeEncodedAccount> fetchEncodedSysvarAccount(
+  Rpc rpc,
+  Address address, {
+  FetchAccountConfig? config,
+}) {
+  return fetchEncodedAccount(rpc, address, config: config);
+}

--- a/packages/solana_kit_sysvars/pubspec.yaml
+++ b/packages/solana_kit_sysvars/pubspec.yaml
@@ -8,7 +8,16 @@ environment:
 resolution: workspace
 
 dependencies:
+  meta:
+  solana_kit_accounts:
+  solana_kit_addresses:
+  solana_kit_codecs_core:
+  solana_kit_codecs_data_structures:
+  solana_kit_codecs_numbers:
   solana_kit_errors:
+  solana_kit_rpc_spec:
+  solana_kit_rpc_types:
 
 dev_dependencies:
   solana_kit_lints:
+  test: ^1.25.0

--- a/packages/solana_kit_sysvars/test/clock_test.dart
+++ b/packages/solana_kit_sysvars/test/clock_test.dart
@@ -1,0 +1,90 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('clock', () {
+    test('decode', () {
+      // From TS test: clock-test.ts
+      final clockState = Uint8List.fromList([
+        // slot
+        119, 233, 246, 16, 0, 0, 0, 0,
+        // epochStartTimestamp
+        246, 255, 255, 255, 255, 255, 255, 255,
+        // epoch
+        4, 0, 0, 0, 0, 0, 0, 0,
+        // leaderScheduleEpoch
+        0, 0, 0, 0, 0, 0, 0, 0,
+        // unixTimestamp
+        224, 177, 255, 255, 255, 255, 255, 255,
+      ]);
+
+      final result = getSysvarClockCodec().decode(clockState);
+      expect(result.slot, equals(BigInt.from(284617079)));
+      expect(result.epochStartTimestamp, equals(BigInt.from(-10)));
+      expect(result.epoch, equals(BigInt.from(4)));
+      expect(result.leaderScheduleEpoch, equals(BigInt.zero));
+      expect(result.unixTimestamp, equals(BigInt.from(-20000)));
+    });
+
+    test('encode roundtrip', () {
+      final clock = SysvarClock(
+        slot: BigInt.from(284617079),
+        epochStartTimestamp: BigInt.from(-10),
+        epoch: BigInt.from(4),
+        leaderScheduleEpoch: BigInt.zero,
+        unixTimestamp: BigInt.from(-20000),
+      );
+
+      final codec = getSysvarClockCodec();
+      final encoded = codec.encode(clock);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded.slot, equals(clock.slot));
+      expect(decoded.epochStartTimestamp, equals(clock.epochStartTimestamp));
+      expect(decoded.epoch, equals(clock.epoch));
+      expect(decoded.leaderScheduleEpoch, equals(clock.leaderScheduleEpoch));
+      expect(decoded.unixTimestamp, equals(clock.unixTimestamp));
+    });
+
+    test('encoder has correct fixed size', () {
+      final encoder = getSysvarClockEncoder();
+      expect(encoder.fixedSize, equals(sysvarClockSize));
+      expect(encoder.fixedSize, equals(40));
+      expect(isFixedSize(encoder), isTrue);
+    });
+
+    test('decoder has correct fixed size', () {
+      final decoder = getSysvarClockDecoder();
+      expect(decoder.fixedSize, equals(sysvarClockSize));
+      expect(isFixedSize(decoder), isTrue);
+    });
+
+    test('codec has correct fixed size', () {
+      final codec = getSysvarClockCodec();
+      expect(codec.fixedSize, equals(sysvarClockSize));
+      expect(isFixedSize(codec), isTrue);
+    });
+
+    test('SysvarClock equality', () {
+      final a = SysvarClock(
+        slot: BigInt.from(100),
+        epochStartTimestamp: BigInt.from(200),
+        epoch: BigInt.from(3),
+        leaderScheduleEpoch: BigInt.from(4),
+        unixTimestamp: BigInt.from(500),
+      );
+      final b = SysvarClock(
+        slot: BigInt.from(100),
+        epochStartTimestamp: BigInt.from(200),
+        epoch: BigInt.from(3),
+        leaderScheduleEpoch: BigInt.from(4),
+        unixTimestamp: BigInt.from(500),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_sysvars/test/epoch_rewards_test.dart
+++ b/packages/solana_kit_sysvars/test/epoch_rewards_test.dart
@@ -1,0 +1,124 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('epoch rewards', () {
+    test('decode', () {
+      // From TS test: epoch-rewards-test.ts
+      final epochRewardsState = Uint8List.fromList([
+        // distributionStartingBlockHeight
+        0xab, 0xa8, 0x87, 0x12, 0x00, 0x00, 0x00, 0x00,
+        // numPartitions
+        0x3a, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // parentBlockhash
+        0x67, 0x8b, 0xd4, 0xe4, 0xc8, 0x5c, 0x10, 0x87,
+        0xa8, 0x0a, 0xfb, 0x2f, 0x0d, 0xbb, 0x13, 0x27,
+        0x16, 0x11, 0x3a, 0xc7, 0xc7, 0xb0, 0xc7, 0xe4,
+        0x99, 0x51, 0x4d, 0x42, 0xdb, 0x43, 0xd7, 0x1c,
+        // totalPoints
+        0x10, 0xbe, 0x90, 0x99, 0x7a, 0x16, 0x9e, 0xa5,
+        0xc2, 0x2d, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // totalRewards
+        0x00, 0xb3, 0x04, 0x4e, 0xd0, 0x20, 0x89, 0x00,
+        // distributedRewards
+        0x00, 0xb8, 0xea, 0x37, 0xd0, 0x20, 0x89, 0x00,
+        // active
+        0x00,
+      ]);
+
+      final result = getSysvarEpochRewardsCodec().decode(epochRewardsState);
+      expect(
+        result.distributionStartingBlockHeight,
+        equals(BigInt.from(310880427)),
+      );
+      expect(result.numPartitions, equals(BigInt.from(314)));
+      expect(
+        result.parentBlockhash.value,
+        equals('7yCfKTaamnrmkAfefSgsonQ6rtwCfVaxQJircWb9K4Qj'),
+      );
+      expect(
+        result.totalPoints,
+        equals(BigInt.parse('2633948733309470433656336')),
+      );
+      expect(
+        result.totalRewards,
+        equals(Lamports(BigInt.parse('38598150843577088'))),
+      );
+      expect(
+        result.distributedRewards,
+        equals(Lamports(BigInt.parse('38598150472775680'))),
+      );
+      expect(result.active, isFalse);
+    });
+
+    test('encode roundtrip', () {
+      final rewards = SysvarEpochRewards(
+        distributionStartingBlockHeight: BigInt.from(310880427),
+        numPartitions: BigInt.from(314),
+        parentBlockhash: const Blockhash(
+          '7yCfKTaamnrmkAfefSgsonQ6rtwCfVaxQJircWb9K4Qj',
+        ),
+        totalPoints: BigInt.parse('2633948733309470433656336'),
+        totalRewards: Lamports(BigInt.parse('38598150843577088')),
+        distributedRewards: Lamports(BigInt.parse('38598150472775680')),
+        active: false,
+      );
+
+      final codec = getSysvarEpochRewardsCodec();
+      final encoded = codec.encode(rewards);
+      final decoded = codec.decode(encoded);
+
+      expect(
+        decoded.distributionStartingBlockHeight,
+        equals(rewards.distributionStartingBlockHeight),
+      );
+      expect(decoded.numPartitions, equals(rewards.numPartitions));
+      expect(
+        decoded.parentBlockhash.value,
+        equals(rewards.parentBlockhash.value),
+      );
+      expect(decoded.totalPoints, equals(rewards.totalPoints));
+      expect(decoded.totalRewards, equals(rewards.totalRewards));
+      expect(decoded.distributedRewards, equals(rewards.distributedRewards));
+      expect(decoded.active, equals(rewards.active));
+    });
+
+    test('encoder has correct fixed size', () {
+      final encoder = getSysvarEpochRewardsEncoder();
+      expect(encoder.fixedSize, equals(sysvarEpochRewardsSize));
+      expect(encoder.fixedSize, equals(81));
+      expect(isFixedSize(encoder), isTrue);
+    });
+
+    test('SysvarEpochRewards equality', () {
+      final a = SysvarEpochRewards(
+        distributionStartingBlockHeight: BigInt.from(100),
+        numPartitions: BigInt.from(10),
+        parentBlockhash: const Blockhash(
+          '7yCfKTaamnrmkAfefSgsonQ6rtwCfVaxQJircWb9K4Qj',
+        ),
+        totalPoints: BigInt.from(1000),
+        totalRewards: Lamports(BigInt.from(500)),
+        distributedRewards: Lamports(BigInt.from(200)),
+        active: true,
+      );
+      final b = SysvarEpochRewards(
+        distributionStartingBlockHeight: BigInt.from(100),
+        numPartitions: BigInt.from(10),
+        parentBlockhash: const Blockhash(
+          '7yCfKTaamnrmkAfefSgsonQ6rtwCfVaxQJircWb9K4Qj',
+        ),
+        totalPoints: BigInt.from(1000),
+        totalRewards: Lamports(BigInt.from(500)),
+        distributedRewards: Lamports(BigInt.from(200)),
+        active: true,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_sysvars/test/epoch_schedule_test.dart
+++ b/packages/solana_kit_sysvars/test/epoch_schedule_test.dart
@@ -1,0 +1,97 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('epoch schedule', () {
+    test('decode', () {
+      // From TS test: epoch-schedule-test.ts
+      final epochScheduleState = Uint8List.fromList([
+        // slotsPerEpoch
+        16, 39, 0, 0, 0, 0, 0, 0,
+        // leaderScheduleSlotOffset
+        134, 74, 2, 0, 0, 0, 0, 0,
+        // warmup
+        1,
+        // firstNormalEpoch
+        38, 2, 0, 0, 0, 0, 0, 0,
+        // firstNormalSlot
+        128, 147, 220, 20, 0, 0, 0, 0,
+      ]);
+
+      final result = getSysvarEpochScheduleCodec().decode(epochScheduleState);
+      expect(result.slotsPerEpoch, equals(BigInt.from(10000)));
+      expect(result.leaderScheduleSlotOffset, equals(BigInt.from(150150)));
+      expect(result.warmup, isTrue);
+      expect(result.firstNormalEpoch, equals(BigInt.from(550)));
+      expect(result.firstNormalSlot, equals(BigInt.from(350000000)));
+    });
+
+    test('encode roundtrip', () {
+      final schedule = SysvarEpochSchedule(
+        slotsPerEpoch: BigInt.from(10000),
+        leaderScheduleSlotOffset: BigInt.from(150150),
+        warmup: true,
+        firstNormalEpoch: BigInt.from(550),
+        firstNormalSlot: BigInt.from(350000000),
+      );
+
+      final codec = getSysvarEpochScheduleCodec();
+      final encoded = codec.encode(schedule);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded.slotsPerEpoch, equals(schedule.slotsPerEpoch));
+      expect(
+        decoded.leaderScheduleSlotOffset,
+        equals(schedule.leaderScheduleSlotOffset),
+      );
+      expect(decoded.warmup, equals(schedule.warmup));
+      expect(decoded.firstNormalEpoch, equals(schedule.firstNormalEpoch));
+      expect(decoded.firstNormalSlot, equals(schedule.firstNormalSlot));
+    });
+
+    test('encoder has correct fixed size', () {
+      final encoder = getSysvarEpochScheduleEncoder();
+      expect(encoder.fixedSize, equals(sysvarEpochScheduleSize));
+      expect(encoder.fixedSize, equals(33));
+      expect(isFixedSize(encoder), isTrue);
+    });
+
+    test('decode with warmup false', () {
+      final schedule = SysvarEpochSchedule(
+        slotsPerEpoch: BigInt.from(432000),
+        leaderScheduleSlotOffset: BigInt.from(432000),
+        warmup: false,
+        firstNormalEpoch: BigInt.zero,
+        firstNormalSlot: BigInt.zero,
+      );
+
+      final codec = getSysvarEpochScheduleCodec();
+      final encoded = codec.encode(schedule);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded.warmup, isFalse);
+    });
+
+    test('SysvarEpochSchedule equality', () {
+      final a = SysvarEpochSchedule(
+        slotsPerEpoch: BigInt.from(10000),
+        leaderScheduleSlotOffset: BigInt.from(150150),
+        warmup: true,
+        firstNormalEpoch: BigInt.from(550),
+        firstNormalSlot: BigInt.from(350000000),
+      );
+      final b = SysvarEpochSchedule(
+        slotsPerEpoch: BigInt.from(10000),
+        leaderScheduleSlotOffset: BigInt.from(150150),
+        warmup: true,
+        firstNormalEpoch: BigInt.from(550),
+        firstNormalSlot: BigInt.from(350000000),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_sysvars/test/last_restart_slot_test.dart
+++ b/packages/solana_kit_sysvars/test/last_restart_slot_test.dart
@@ -1,0 +1,54 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('last restart slot', () {
+    test('decode', () {
+      // From TS test: last-restart-slot-test.ts
+      final lastRestartSlotState = Uint8List.fromList([
+        119,
+        233,
+        246,
+        16,
+        0,
+        0,
+        0,
+        0,
+      ]);
+
+      final result = getSysvarLastRestartSlotCodec().decode(
+        lastRestartSlotState,
+      );
+      expect(result.lastRestartSlot, equals(BigInt.from(284617079)));
+    });
+
+    test('encode roundtrip', () {
+      final lastRestartSlot = SysvarLastRestartSlot(
+        lastRestartSlot: BigInt.from(284617079),
+      );
+
+      final codec = getSysvarLastRestartSlotCodec();
+      final encoded = codec.encode(lastRestartSlot);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded.lastRestartSlot, equals(lastRestartSlot.lastRestartSlot));
+    });
+
+    test('encoder has correct fixed size', () {
+      final encoder = getSysvarLastRestartSlotEncoder();
+      expect(encoder.fixedSize, equals(sysvarLastRestartSlotSize));
+      expect(encoder.fixedSize, equals(8));
+      expect(isFixedSize(encoder), isTrue);
+    });
+
+    test('SysvarLastRestartSlot equality', () {
+      final a = SysvarLastRestartSlot(lastRestartSlot: BigInt.from(100));
+      final b = SysvarLastRestartSlot(lastRestartSlot: BigInt.from(100));
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_sysvars/test/recent_blockhashes_test.dart
+++ b/packages/solana_kit_sysvars/test/recent_blockhashes_test.dart
@@ -1,0 +1,112 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('recent blockhashes', () {
+    test('decode', () {
+      // From TS test: recent-blockhashes-test.ts
+      final recentBlockhashesState = Uint8List.fromList([
+        // array length (u32)
+        2, 0, 0, 0,
+        // entry 1: blockhash (32 bytes of 0x01)
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        // entry 1: lamportsPerSignature
+        134, 74, 2, 0, 0, 0, 0, 0,
+        // entry 2: blockhash (32 bytes of 0x02)
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        // entry 2: lamportsPerSignature
+        134, 74, 2, 0, 0, 0, 0, 0,
+      ]);
+
+      final result = getSysvarRecentBlockhashesCodec().decode(
+        recentBlockhashesState,
+      );
+      expect(result, hasLength(2));
+      expect(
+        result[0].blockhash.value,
+        equals('4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi'),
+      );
+      expect(
+        result[0].feeCalculator.lamportsPerSignature,
+        equals(Lamports(BigInt.from(150150))),
+      );
+      expect(
+        result[1].blockhash.value,
+        equals('8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR'),
+      );
+      expect(
+        result[1].feeCalculator.lamportsPerSignature,
+        equals(Lamports(BigInt.from(150150))),
+      );
+    });
+
+    test('encode roundtrip', () {
+      final entries = [
+        RecentBlockhashEntry(
+          blockhash: const Blockhash(
+            '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
+          ),
+          feeCalculator: FeeCalculator(
+            lamportsPerSignature: Lamports(BigInt.from(150150)),
+          ),
+        ),
+        RecentBlockhashEntry(
+          blockhash: const Blockhash(
+            '8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR',
+          ),
+          feeCalculator: FeeCalculator(
+            lamportsPerSignature: Lamports(BigInt.from(150150)),
+          ),
+        ),
+      ];
+
+      final codec = getSysvarRecentBlockhashesCodec();
+      final encoded = codec.encode(entries);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded, hasLength(2));
+      expect(decoded[0].blockhash.value, equals(entries[0].blockhash.value));
+      expect(
+        decoded[0].feeCalculator.lamportsPerSignature,
+        equals(entries[0].feeCalculator.lamportsPerSignature),
+      );
+      expect(decoded[1].blockhash.value, equals(entries[1].blockhash.value));
+      expect(
+        decoded[1].feeCalculator.lamportsPerSignature,
+        equals(entries[1].feeCalculator.lamportsPerSignature),
+      );
+    });
+
+    test('codec is variable-size', () {
+      final codec = getSysvarRecentBlockhashesCodec();
+      expect(isFixedSize(codec), isFalse);
+    });
+
+    test('RecentBlockhashEntry equality', () {
+      final a = RecentBlockhashEntry(
+        blockhash: const Blockhash(
+          '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
+        ),
+        feeCalculator: FeeCalculator(
+          lamportsPerSignature: Lamports(BigInt.from(100)),
+        ),
+      );
+      final b = RecentBlockhashEntry(
+        blockhash: const Blockhash(
+          '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
+        ),
+        feeCalculator: FeeCalculator(
+          lamportsPerSignature: Lamports(BigInt.from(100)),
+        ),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_sysvars/test/rent_test.dart
+++ b/packages/solana_kit_sysvars/test/rent_test.dart
@@ -1,0 +1,70 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('rent', () {
+    test('decode', () {
+      // From TS test: rent-test.ts
+      final rentState = Uint8List.fromList([
+        // lamportsPerByteYear
+        0, 225, 245, 5, 0, 0, 0, 0,
+        // exemptionThreshold (f64: same bytes as lamportsPerByteYear)
+        0, 225, 245, 5, 0, 0, 0, 0,
+        // burnPercent
+        8,
+      ]);
+
+      final result = getSysvarRentCodec().decode(rentState);
+      expect(
+        result.lamportsPerByteYear,
+        equals(Lamports(BigInt.from(100000000))),
+      );
+      // The TS test expects 4.94065646e-316 which is a very small f64 value
+      // produced by interpreting the bytes 0x00e1f50500000000 as a float64.
+      expect(result.exemptionThreshold, closeTo(4.94065646e-316, 1e-322));
+      expect(result.burnPercent, equals(8));
+    });
+
+    test('encode roundtrip', () {
+      final rent = SysvarRent(
+        lamportsPerByteYear: Lamports(BigInt.from(3480)),
+        exemptionThreshold: 2,
+        burnPercent: 50,
+      );
+
+      final codec = getSysvarRentCodec();
+      final encoded = codec.encode(rent);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded.lamportsPerByteYear, equals(rent.lamportsPerByteYear));
+      expect(decoded.exemptionThreshold, equals(rent.exemptionThreshold));
+      expect(decoded.burnPercent, equals(rent.burnPercent));
+    });
+
+    test('encoder has correct fixed size', () {
+      final encoder = getSysvarRentEncoder();
+      expect(encoder.fixedSize, equals(sysvarRentSize));
+      expect(encoder.fixedSize, equals(17));
+      expect(isFixedSize(encoder), isTrue);
+    });
+
+    test('SysvarRent equality', () {
+      final a = SysvarRent(
+        lamportsPerByteYear: Lamports(BigInt.from(3480)),
+        exemptionThreshold: 2,
+        burnPercent: 50,
+      );
+      final b = SysvarRent(
+        lamportsPerByteYear: Lamports(BigInt.from(3480)),
+        exemptionThreshold: 2,
+        burnPercent: 50,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_sysvars/test/slot_hashes_test.dart
+++ b/packages/solana_kit_sysvars/test/slot_hashes_test.dart
@@ -1,0 +1,82 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('slot hashes', () {
+    test('decode', () {
+      // From TS test: slot-hashes-test.ts
+      final slotHashesState = Uint8List.fromList([
+        // array length (u32)
+        2, 0, 0, 0,
+        // entry 1: slot
+        134, 74, 2, 0, 0, 0, 0, 0,
+        // entry 1: hash (32 bytes of 0x01)
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        // entry 2: slot
+        134, 74, 2, 0, 0, 0, 0, 0,
+        // entry 2: hash (32 bytes of 0x02)
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+      ]);
+
+      final result = getSysvarSlotHashesCodec().decode(slotHashesState);
+      expect(result, hasLength(2));
+      expect(result[0].slot, equals(BigInt.from(150150)));
+      expect(
+        result[0].hash.value,
+        equals('4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi'),
+      );
+      expect(result[1].slot, equals(BigInt.from(150150)));
+      expect(
+        result[1].hash.value,
+        equals('8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR'),
+      );
+    });
+
+    test('encode roundtrip', () {
+      final entries = [
+        SlotHashEntry(
+          slot: BigInt.from(150150),
+          hash: const Blockhash('4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi'),
+        ),
+        SlotHashEntry(
+          slot: BigInt.from(150150),
+          hash: const Blockhash('8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR'),
+        ),
+      ];
+
+      final codec = getSysvarSlotHashesCodec();
+      final encoded = codec.encode(entries);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded, hasLength(2));
+      expect(decoded[0].slot, equals(entries[0].slot));
+      expect(decoded[0].hash.value, equals(entries[0].hash.value));
+      expect(decoded[1].slot, equals(entries[1].slot));
+      expect(decoded[1].hash.value, equals(entries[1].hash.value));
+    });
+
+    test('codec is variable-size', () {
+      final codec = getSysvarSlotHashesCodec();
+      expect(isFixedSize(codec), isFalse);
+    });
+
+    test('SlotHashEntry equality', () {
+      final a = SlotHashEntry(
+        slot: BigInt.from(100),
+        hash: const Blockhash('4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi'),
+      );
+      final b = SlotHashEntry(
+        slot: BigInt.from(100),
+        hash: const Blockhash('4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi'),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_sysvars/test/slot_history_test.dart
+++ b/packages/solana_kit_sysvars/test/slot_history_test.dart
@@ -1,0 +1,83 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('slot history', () {
+    test('decode', () {
+      // From TS test: slot-history-test.ts
+      final codec = getSysvarSlotHistoryCodec();
+      final slotHistoryState = Uint8List(codec.fixedSize);
+      // Fill all with 1s (for the bitvector data section).
+      slotHistoryState.fillRange(0, slotHistoryState.length, 1);
+
+      var offset = 0;
+      // Discriminator
+      slotHistoryState[offset] = bitvecDiscriminator;
+      offset += 1;
+      // Bitvector length: 0x4000 = 16384
+      slotHistoryState.setAll(offset, [0, 64, 0, 0, 0, 0, 0, 0]);
+      offset += 8;
+      // Let the 1s represent the bits.
+      offset += bitvecLength * 8;
+      // Number of bits: 0x100000 = 1048576
+      slotHistoryState.setAll(offset, [0, 0, 16, 0, 0, 0, 0, 0]);
+      offset += 8;
+      // Next slot: 150150
+      slotHistoryState.setAll(offset, [134, 74, 2, 0, 0, 0, 0, 0]);
+
+      final result = codec.decode(slotHistoryState);
+
+      // Each u64 block is 0x0101010101010101 = 72340172838076673
+      expect(result.bits, contains(BigInt.parse('72340172838076673')));
+      expect(result.nextSlot, equals(BigInt.from(150150)));
+    });
+
+    test('encode roundtrip', () {
+      // Create a minimal slot history with all zeros in bits.
+      final bits = List<BigInt>.filled(bitvecLength, BigInt.zero);
+      bits[0] = BigInt.from(0xff); // First block has first 8 bits set.
+      final history = SysvarSlotHistory(bits: bits, nextSlot: BigInt.from(42));
+
+      final codec = getSysvarSlotHistoryCodec();
+      final encoded = codec.encode(history);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded.bits[0], equals(BigInt.from(0xff)));
+      expect(decoded.bits[1], equals(BigInt.zero));
+      expect(decoded.nextSlot, equals(BigInt.from(42)));
+      expect(decoded.bits.length, equals(bitvecLength));
+    });
+
+    test('encoder has correct fixed size', () {
+      final encoder = getSysvarSlotHistoryEncoder();
+      expect(encoder.fixedSize, equals(sysvarSlotHistorySize));
+      expect(encoder.fixedSize, equals(131097));
+      expect(isFixedSize(encoder), isTrue);
+    });
+
+    test('decoder has correct fixed size', () {
+      final decoder = getSysvarSlotHistoryDecoder();
+      expect(decoder.fixedSize, equals(sysvarSlotHistorySize));
+      expect(isFixedSize(decoder), isTrue);
+    });
+
+    test('constants are correct', () {
+      expect(bitvecDiscriminator, equals(1));
+      expect(bitvecNumBits, equals(1048576));
+      expect(bitvecLength, equals(16384));
+      expect(sysvarSlotHistorySize, equals(131097));
+    });
+
+    test('SysvarSlotHistory equality', () {
+      final bits1 = List<BigInt>.filled(bitvecLength, BigInt.zero);
+      final bits2 = List<BigInt>.filled(bitvecLength, BigInt.zero);
+      final a = SysvarSlotHistory(bits: bits1, nextSlot: BigInt.from(100));
+      final b = SysvarSlotHistory(bits: bits2, nextSlot: BigInt.from(100));
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_sysvars/test/stake_history_test.dart
+++ b/packages/solana_kit_sysvars/test/stake_history_test.dart
@@ -1,0 +1,151 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('stake history', () {
+    test('decode', () {
+      // From TS test: stake-history-test.ts
+      final stakeHistoryState = Uint8List.fromList([
+        // array length (u64)
+        2, 0, 0, 0, 0, 0, 0, 0,
+        // entry 1: epoch
+        1, 0, 0, 0, 0, 0, 0, 0,
+        // entry 1: effective
+        0, 208, 237, 144, 46, 0, 0, 0,
+        // entry 1: activating
+        0, 160, 219, 33, 93, 0, 0, 0,
+        // entry 1: deactivating
+        0, 112, 201, 178, 139, 0, 0, 0,
+        // entry 2: epoch
+        2, 0, 0, 0, 0, 0, 0, 0,
+        // entry 2: effective
+        0, 160, 219, 33, 93, 0, 0, 0,
+        // entry 2: activating
+        0, 112, 201, 178, 139, 0, 0, 0,
+        // entry 2: deactivating
+        0, 64, 183, 67, 186, 0, 0, 0,
+      ]);
+
+      final result = getSysvarStakeHistoryCodec().decode(stakeHistoryState);
+      expect(result, hasLength(2));
+
+      expect(result[0].epoch, equals(BigInt.from(1)));
+      expect(
+        result[0].stakeHistory.effective,
+        equals(Lamports(BigInt.from(200000000000))),
+      );
+      expect(
+        result[0].stakeHistory.activating,
+        equals(Lamports(BigInt.from(400000000000))),
+      );
+      expect(
+        result[0].stakeHistory.deactivating,
+        equals(Lamports(BigInt.from(600000000000))),
+      );
+
+      expect(result[1].epoch, equals(BigInt.from(2)));
+      expect(
+        result[1].stakeHistory.effective,
+        equals(Lamports(BigInt.from(400000000000))),
+      );
+      expect(
+        result[1].stakeHistory.activating,
+        equals(Lamports(BigInt.from(600000000000))),
+      );
+      expect(
+        result[1].stakeHistory.deactivating,
+        equals(Lamports(BigInt.from(800000000000))),
+      );
+    });
+
+    test('encode roundtrip', () {
+      final entries = [
+        StakeHistoryEntry(
+          epoch: BigInt.from(1),
+          stakeHistory: StakeHistoryData(
+            effective: Lamports(BigInt.from(200000000000)),
+            activating: Lamports(BigInt.from(400000000000)),
+            deactivating: Lamports(BigInt.from(600000000000)),
+          ),
+        ),
+        StakeHistoryEntry(
+          epoch: BigInt.from(2),
+          stakeHistory: StakeHistoryData(
+            effective: Lamports(BigInt.from(400000000000)),
+            activating: Lamports(BigInt.from(600000000000)),
+            deactivating: Lamports(BigInt.from(800000000000)),
+          ),
+        ),
+      ];
+
+      final codec = getSysvarStakeHistoryCodec();
+      final encoded = codec.encode(entries);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded, hasLength(2));
+      expect(decoded[0].epoch, equals(entries[0].epoch));
+      expect(
+        decoded[0].stakeHistory.effective,
+        equals(entries[0].stakeHistory.effective),
+      );
+      expect(
+        decoded[0].stakeHistory.activating,
+        equals(entries[0].stakeHistory.activating),
+      );
+      expect(
+        decoded[0].stakeHistory.deactivating,
+        equals(entries[0].stakeHistory.deactivating),
+      );
+      expect(decoded[1].epoch, equals(entries[1].epoch));
+      expect(
+        decoded[1].stakeHistory.effective,
+        equals(entries[1].stakeHistory.effective),
+      );
+    });
+
+    test('codec is variable-size', () {
+      final codec = getSysvarStakeHistoryCodec();
+      expect(isFixedSize(codec), isFalse);
+    });
+
+    test('StakeHistoryEntry equality', () {
+      final a = StakeHistoryEntry(
+        epoch: BigInt.from(1),
+        stakeHistory: StakeHistoryData(
+          effective: Lamports(BigInt.from(100)),
+          activating: Lamports(BigInt.from(200)),
+          deactivating: Lamports(BigInt.from(300)),
+        ),
+      );
+      final b = StakeHistoryEntry(
+        epoch: BigInt.from(1),
+        stakeHistory: StakeHistoryData(
+          effective: Lamports(BigInt.from(100)),
+          activating: Lamports(BigInt.from(200)),
+          deactivating: Lamports(BigInt.from(300)),
+        ),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('StakeHistoryData equality', () {
+      final a = StakeHistoryData(
+        effective: Lamports(BigInt.from(100)),
+        activating: Lamports(BigInt.from(200)),
+        deactivating: Lamports(BigInt.from(300)),
+      );
+      final b = StakeHistoryData(
+        effective: Lamports(BigInt.from(100)),
+        activating: Lamports(BigInt.from(200)),
+        deactivating: Lamports(BigInt.from(300)),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_sysvars/test/sysvar_test.dart
+++ b/packages/solana_kit_sysvars/test/sysvar_test.dart
@@ -1,0 +1,78 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('sysvar addresses', () {
+    test('sysvarClockAddress is correct', () {
+      expect(
+        sysvarClockAddress.value,
+        equals('SysvarC1ock11111111111111111111111111111111'),
+      );
+      expect(isAddress(sysvarClockAddress.value), isTrue);
+    });
+    test('sysvarEpochRewardsAddress is correct', () {
+      expect(
+        sysvarEpochRewardsAddress.value,
+        equals('SysvarEpochRewards1111111111111111111111111'),
+      );
+      expect(isAddress(sysvarEpochRewardsAddress.value), isTrue);
+    });
+    test('sysvarEpochScheduleAddress is correct', () {
+      expect(
+        sysvarEpochScheduleAddress.value,
+        equals('SysvarEpochSchedu1e111111111111111111111111'),
+      );
+      expect(isAddress(sysvarEpochScheduleAddress.value), isTrue);
+    });
+    test('sysvarInstructionsAddress is correct', () {
+      expect(
+        sysvarInstructionsAddress.value,
+        equals('Sysvar1nstructions1111111111111111111111111'),
+      );
+      expect(isAddress(sysvarInstructionsAddress.value), isTrue);
+    });
+    test('sysvarLastRestartSlotAddress is correct', () {
+      expect(
+        sysvarLastRestartSlotAddress.value,
+        equals('SysvarLastRestartS1ot1111111111111111111111'),
+      );
+      expect(isAddress(sysvarLastRestartSlotAddress.value), isTrue);
+    });
+    test('sysvarRecentBlockhashesAddress is correct', () {
+      expect(
+        sysvarRecentBlockhashesAddress.value,
+        equals('SysvarRecentB1ockHashes11111111111111111111'),
+      );
+      expect(isAddress(sysvarRecentBlockhashesAddress.value), isTrue);
+    });
+    test('sysvarRentAddress is correct', () {
+      expect(
+        sysvarRentAddress.value,
+        equals('SysvarRent111111111111111111111111111111111'),
+      );
+      expect(isAddress(sysvarRentAddress.value), isTrue);
+    });
+    test('sysvarSlotHashesAddress is correct', () {
+      expect(
+        sysvarSlotHashesAddress.value,
+        equals('SysvarS1otHashes111111111111111111111111111'),
+      );
+      expect(isAddress(sysvarSlotHashesAddress.value), isTrue);
+    });
+    test('sysvarSlotHistoryAddress is correct', () {
+      expect(
+        sysvarSlotHistoryAddress.value,
+        equals('SysvarS1otHistory11111111111111111111111111'),
+      );
+      expect(isAddress(sysvarSlotHistoryAddress.value), isTrue);
+    });
+    test('sysvarStakeHistoryAddress is correct', () {
+      expect(
+        sysvarStakeHistoryAddress.value,
+        equals('SysvarStakeHistory1111111111111111111111111'),
+      );
+      expect(isAddress(sysvarStakeHistoryAddress.value), isTrue);
+    });
+  });
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -238,9 +238,9 @@
 
 ### solana_kit_sysvars (~13 source files, ~12 test files)
 
-- [ ] T101 [P] [US2] Port Clock, EpochSchedule, Rent, and remaining sysvar types from `.repos/kit/packages/sysvars/src/` to `packages/solana_kit_sysvars/lib/src/`
-- [ ] T102 [US2] Update barrel export `packages/solana_kit_sysvars/lib/solana_kit_sysvars.dart`
-- [ ] T103 [US2] Port all 12 test files from `.repos/kit/packages/sysvars/src/__tests__/` to `packages/solana_kit_sysvars/test/`
+- [x] T101 [P] [US2] Port Clock, EpochSchedule, Rent, and remaining sysvar types from `.repos/kit/packages/sysvars/src/` to `packages/solana_kit_sysvars/lib/src/`
+- [x] T102 [US2] Update barrel export `packages/solana_kit_sysvars/lib/solana_kit_sysvars.dart`
+- [x] T103 [US2] Port all 12 test files from `.repos/kit/packages/sysvars/src/__tests__/` to `packages/solana_kit_sysvars/test/`
 
 ### solana_kit_program_client_core (~5 source files, ~7 test files)
 


### PR DESCRIPTION
## Summary

- Port `@solana/sysvars` to Dart with full test coverage (52 tests)
- 10 sysvar address constants (Clock, EpochRewards, EpochSchedule, Instructions, LastRestartSlot, RecentBlockhashes, Rent, SlotHashes, SlotHistory, StakeHistory)
- Fixed-size codecs: Clock (40B), EpochSchedule (33B), EpochRewards (81B), Rent (17B), LastRestartSlot (8B)
- Variable-size codecs: SlotHashes, RecentBlockhashes, StakeHistory (with manual u64 prefix)
- SlotHistory bitvector codec (131,097B) with discriminator validation and memoized internals
- `fetchSysvar*` async RPC functions for each sysvar type

## Test plan

- [x] All 52 tests pass (`dart test packages/solana_kit_sysvars/`)
- [x] `dart analyze` passes with no issues
- [x] `dart format` passes with no changes needed
- [x] Changeset included