### PR TITLE
✨ feat(solana_kit_subscribable): implement subscribable package

### DIFF
--- a/.changeset/subscribable.md
+++ b/.changeset/subscribable.md
@@ -1,0 +1,14 @@
+---
+solana_kit_subscribable: minor
+---
+
+Implement subscribable package ported from `@solana/subscribable`.
+
+**solana_kit_subscribable** (33 tests):
+
+- `DataPublisher` interface with `on(channelName, subscriber)` returning unsubscribe function
+- `WritableDataPublisher` concrete implementation with `publish(channelName, data)` for testing
+- `createStreamFromDataPublisher` converting DataPublisher to Dart `Stream<TData>` with error channel support
+- `createAsyncIterableFromDataPublisher` with AbortSignal support, message queuing, and pre-poll message dropping
+- `demultiplexDataPublisher` splitting single channel into multiple typed channels with lazy subscription and reference counting
+- Idempotent unsubscribe and proper cleanup on abort

--- a/packages/solana_kit_subscribable/lib/solana_kit_subscribable.dart
+++ b/packages/solana_kit_subscribable/lib/solana_kit_subscribable.dart
@@ -1,1 +1,20 @@
+/// Subscribable and observable patterns for the Solana Kit Dart SDK.
+///
+/// This package provides utilities for creating subscription-based event
+/// systems. It is the Dart port of the TypeScript `@solana/subscribable`
+/// package.
+///
+/// The primary components are:
+///
+/// - `DataPublisher` / `WritableDataPublisher` - subscription-based event
+///   system with `on(channelName, subscriber)` returning an unsubscribe
+///   function.
+/// - `createStreamFromDataPublisher` / `createAsyncIterableFromDataPublisher` -
+///   converts a `DataPublisher` into a Dart `Stream`.
+/// - `demultiplexDataPublisher` - splits a single channel into multiple typed
+///   channels with lazy subscription and reference counting.
+library;
 
+export 'src/async_iterable.dart';
+export 'src/data_publisher.dart';
+export 'src/demultiplex.dart';

--- a/packages/solana_kit_subscribable/lib/src/async_iterable.dart
+++ b/packages/solana_kit_subscribable/lib/src/async_iterable.dart
@@ -1,0 +1,356 @@
+import 'dart:async';
+
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+import 'package:solana_kit_subscribable/src/data_publisher.dart';
+
+/// Configuration for [createStreamFromDataPublisher].
+class StreamFromDataPublisherConfig {
+  /// Creates configuration for [createStreamFromDataPublisher].
+  const StreamFromDataPublisherConfig({
+    required this.dataChannelName,
+    required this.dataPublisher,
+    required this.errorChannelName,
+  });
+
+  /// The channel name from which data messages will be streamed.
+  ///
+  /// Messages only begin to be forwarded when the stream has a listener.
+  /// Channel messages published before a listener is attached will be dropped.
+  final String dataChannelName;
+
+  /// The data publisher to subscribe to.
+  final DataPublisher dataPublisher;
+
+  /// The channel name from which error messages will be received.
+  ///
+  /// The first error received will be added to the stream as an error event.
+  /// Any new listeners attached after the first error is encountered will
+  /// receive that error immediately.
+  final String errorChannelName;
+}
+
+/// Creates a broadcast `Stream` from a `DataPublisher`.
+///
+/// The stream will emit data published to the configured data channel name
+/// and will emit errors published to the configured error channel name.
+///
+/// Things to note:
+///
+/// - Messages only begin to be forwarded when the stream has at least one
+///   listener. Channel messages published before that time will be dropped.
+/// - The first error received on the error channel will be added to the stream
+///   as an error event.
+/// - Any new listeners attached after the first error is encountered will
+///   receive that error immediately.
+///
+/// ```dart
+/// final stream = createStreamFromDataPublisher(
+///   StreamFromDataPublisherConfig(
+///     dataChannelName: 'message',
+///     dataPublisher: publisher,
+///     errorChannelName: 'error',
+///   ),
+/// );
+/// stream.listen(
+///   (message) => print('Got message: $message'),
+///   onError: (error) => print('Got error: $error'),
+/// );
+/// ```
+Stream<TData> createStreamFromDataPublisher<TData>(
+  StreamFromDataPublisherConfig config,
+) {
+  Object? firstError;
+  var hasError = false;
+  UnsubscribeFn? dataUnsubscribe;
+  UnsubscribeFn? errorUnsubscribe;
+
+  late final StreamController<TData> controller;
+  controller = StreamController<TData>.broadcast(
+    sync: true,
+    onListen: () {
+      if (hasError) {
+        controller.addError(firstError!);
+        return;
+      }
+
+      // Subscribe to the error channel.
+      errorUnsubscribe ??= config.dataPublisher.on(config.errorChannelName, (
+        err,
+      ) {
+        if (!hasError) {
+          hasError = true;
+          firstError = err;
+          controller.addError(err ?? StateError('Unknown error'));
+
+          // Clean up subscriptions after error.
+          dataUnsubscribe?.call();
+          dataUnsubscribe = null;
+          errorUnsubscribe?.call();
+          errorUnsubscribe = null;
+        }
+      });
+
+      // Subscribe to the data channel.
+      dataUnsubscribe ??= config.dataPublisher.on(config.dataChannelName, (
+        data,
+      ) {
+        if (!controller.isClosed) {
+          controller.add(data as TData);
+        }
+      });
+    },
+    onCancel: () {
+      dataUnsubscribe?.call();
+      dataUnsubscribe = null;
+      errorUnsubscribe?.call();
+      errorUnsubscribe = null;
+      controller.close();
+    },
+  );
+
+  return controller.stream;
+}
+
+/// Creates a single-subscription `Stream` from a `DataPublisher`.
+///
+/// This is the Dart equivalent of TypeScript's
+/// `createAsyncIterableFromDataPublisher`. It returns a `Stream` that closely
+/// matches the behavior of the TS async iterable:
+///
+/// - Messages published before the first listener are dropped.
+/// - The first error is captured; queued messages are delivered before the
+///   error.
+/// - Aborting causes the stream to close after all queued messages are
+///   delivered.
+///
+/// The `abortSignal` future, when completed, will signal the stream to close.
+/// Use a `Completer` to control when the abort happens.
+///
+/// ```dart
+/// final abortCompleter = Completer<void>();
+/// final stream = createAsyncIterableFromDataPublisher(
+///   dataPublisher: publisher,
+///   dataChannelName: 'message',
+///   errorChannelName: 'error',
+///   abortSignal: abortCompleter.future,
+/// );
+///
+/// await for (final message in stream) {
+///   print('Got message: $message');
+/// }
+///
+/// // To abort:
+/// abortCompleter.complete();
+/// ```
+Stream<TData> createAsyncIterableFromDataPublisher<TData>({
+  required Future<void> abortSignal,
+  required String dataChannelName,
+  required DataPublisher dataPublisher,
+  required String errorChannelName,
+}) {
+  final iteratorStates = <Symbol, _IteratorState<TData>>{};
+  var aborted = false;
+  Object? firstError;
+  var hasError = false;
+
+  var symbolCounter = 0;
+  Symbol nextSymbol() => Symbol('iterator_${symbolCounter++}');
+
+  void publishErrorToAllIterators(Object error, {bool isAbort = false}) {
+    for (final entry in iteratorStates.entries) {
+      final state = entry.value;
+      if (state.hasPolled) {
+        final onError = state.onError!;
+        iteratorStates.remove(entry.key);
+        if (isAbort) {
+          state.onAbort?.call();
+        } else {
+          onError(error);
+        }
+      } else {
+        if (isAbort) {
+          state.publishQueue.add(const _AbortItem());
+        } else {
+          state.publishQueue.add(_ErrorItem<TData>(error));
+        }
+      }
+    }
+  }
+
+  // Set up abort handling.
+  abortSignal.then((_) {
+    if (aborted) return;
+    aborted = true;
+    publishErrorToAllIterators(StateError('Aborted'), isAbort: true);
+  }).ignore();
+
+  // Subscribe to error channel eagerly.
+  UnsubscribeFn? errorUnsub;
+  UnsubscribeFn? dataUnsub;
+
+  void setupSubscriptions() {
+    errorUnsub ??= dataPublisher.on(errorChannelName, (err) {
+      if (!hasError) {
+        hasError = true;
+        firstError = err;
+        publishErrorToAllIterators(err ?? StateError('Unknown error'));
+      }
+    });
+
+    dataUnsub ??= dataPublisher.on(dataChannelName, (data) {
+      for (final entry in iteratorStates.entries.toList()) {
+        final state = entry.value;
+        if (state.hasPolled) {
+          final onData = state.onData!;
+          iteratorStates[entry.key] = _IteratorState<TData>();
+          onData(data as TData);
+        } else {
+          state.publishQueue.add(_DataItem<TData>(data as TData));
+        }
+      }
+    });
+  }
+
+  setupSubscriptions();
+
+  // Return a stream that mimics the async iterable behavior.
+  late StreamController<TData> controller;
+  controller = StreamController<TData>(
+    onListen: () async {
+      if (aborted) {
+        await controller.close();
+        return;
+      }
+      if (hasError) {
+        controller.addError(firstError!);
+        await controller.close();
+        return;
+      }
+
+      final iteratorKey = nextSymbol();
+      iteratorStates[iteratorKey] = _IteratorState<TData>();
+
+      try {
+        while (true) {
+          final state = iteratorStates[iteratorKey];
+          if (state == null) {
+            controller.addError(
+              SolanaError(
+                SolanaErrorCode
+                    .invariantViolationSubscriptionIteratorStateMissing,
+              ),
+            );
+            break;
+          }
+          if (state.hasPolled) {
+            controller.addError(
+              SolanaError(
+                SolanaErrorCode
+                    .invariantViolationSubscriptionIteratorMustNotPollBeforeResolvingExistingMessagePromise,
+              ),
+            );
+            break;
+          }
+
+          final publishQueue = state.publishQueue;
+          if (publishQueue.isNotEmpty) {
+            final items = List<_PublishItem<TData>>.of(publishQueue);
+            publishQueue.clear();
+
+            var shouldBreak = false;
+            for (final item in items) {
+              switch (item) {
+                case _DataItem<TData>(:final data):
+                  controller.add(data);
+                case _ErrorItem<TData>(:final error):
+                  controller.addError(error);
+                  shouldBreak = true;
+                case _AbortItem<TData>():
+                  shouldBreak = true;
+              }
+              if (shouldBreak) break;
+            }
+            if (shouldBreak) break;
+          } else {
+            // Wait for the next message.
+            final completer = Completer<_PublishItem<TData>>();
+            iteratorStates[iteratorKey] = _IteratorState<TData>(
+              hasPolled: true,
+              onData: (data) {
+                if (!completer.isCompleted) {
+                  completer.complete(_DataItem<TData>(data));
+                }
+              },
+              onError: (error) {
+                if (!completer.isCompleted) {
+                  completer.complete(_ErrorItem<TData>(error));
+                }
+              },
+              onAbort: () {
+                if (!completer.isCompleted) {
+                  completer.complete(const _AbortItem());
+                }
+              },
+            );
+
+            final item = await completer.future;
+            switch (item) {
+              case _DataItem<TData>(:final data):
+                controller.add(data);
+              case _ErrorItem<TData>(:final error):
+                controller.addError(error);
+              case _AbortItem<TData>():
+                break;
+            }
+            if (item is! _DataItem<TData>) break;
+          }
+        }
+      } finally {
+        iteratorStates.remove(iteratorKey);
+        if (!controller.isClosed) {
+          await controller.close();
+        }
+      }
+    },
+    onCancel: () {
+      dataUnsub?.call();
+      errorUnsub?.call();
+    },
+  );
+
+  return controller.stream;
+}
+
+sealed class _PublishItem<TData> {
+  const _PublishItem();
+}
+
+class _DataItem<TData> extends _PublishItem<TData> {
+  const _DataItem(this.data);
+  final TData data;
+}
+
+class _ErrorItem<TData> extends _PublishItem<TData> {
+  const _ErrorItem(this.error);
+  final Object error;
+}
+
+class _AbortItem<TData> extends _PublishItem<TData> {
+  const _AbortItem();
+}
+
+class _IteratorState<TData> {
+  _IteratorState({
+    this.hasPolled = false,
+    this.onData,
+    this.onError,
+    this.onAbort,
+  });
+
+  final bool hasPolled;
+  final void Function(TData)? onData;
+  final void Function(Object)? onError;
+  final void Function()? onAbort;
+  final List<_PublishItem<TData>> publishQueue = [];
+}

--- a/packages/solana_kit_subscribable/lib/src/data_publisher.dart
+++ b/packages/solana_kit_subscribable/lib/src/data_publisher.dart
@@ -1,0 +1,68 @@
+/// A function that unsubscribes a listener from a channel.
+typedef UnsubscribeFn = void Function();
+
+/// A function that receives published data of type [T].
+typedef Subscriber<T> = void Function(T data);
+
+/// An object that publishes data to named channels.
+///
+/// Subscribers can listen on a named channel and receive data published to that
+/// channel. The [on] method returns an [UnsubscribeFn] that can be called to
+/// stop receiving further messages.
+///
+/// ```dart
+/// final publisher = createDataPublisher();
+/// final unsubscribe = publisher.on('data', (message) {
+///   print('Got message: $message');
+/// });
+/// publisher.publish('data', 'hello');
+/// unsubscribe(); // stop listening
+/// ```
+// ignore: one_member_abstracts
+abstract interface class DataPublisher {
+  /// Subscribe to data on the given [channelName].
+  ///
+  /// Returns an [UnsubscribeFn] that can be called to unsubscribe. The
+  /// unsubscribe function is idempotent and safe to call multiple times.
+  UnsubscribeFn on(String channelName, Subscriber<Object?> subscriber);
+}
+
+/// A [DataPublisher] that also supports publishing data to channels.
+abstract interface class WritableDataPublisher implements DataPublisher {
+  /// Publish [data] to all subscribers listening on [channelName].
+  void publish(String channelName, Object? data);
+}
+
+/// Creates a new [WritableDataPublisher].
+///
+/// The returned publisher supports both subscribing to and publishing data on
+/// named channels.
+WritableDataPublisher createDataPublisher() => _DataPublisherImpl();
+
+class _DataPublisherImpl implements WritableDataPublisher {
+  final Map<String, List<Subscriber<Object?>>> _subscribers = {};
+
+  @override
+  UnsubscribeFn on(String channelName, Subscriber<Object?> subscriber) {
+    final listeners = _subscribers.putIfAbsent(channelName, () => [])
+      ..add(subscriber);
+
+    var isActive = true;
+    return () {
+      if (!isActive) return;
+      isActive = false;
+      listeners.remove(subscriber);
+    };
+  }
+
+  @override
+  void publish(String channelName, Object? data) {
+    final listeners = _subscribers[channelName];
+    if (listeners == null) return;
+    // Copy the list to avoid concurrent modification if a subscriber
+    // unsubscribes during notification.
+    for (final listener in List<Subscriber<Object?>>.of(listeners)) {
+      listener(data);
+    }
+  }
+}

--- a/packages/solana_kit_subscribable/lib/src/demultiplex.dart
+++ b/packages/solana_kit_subscribable/lib/src/demultiplex.dart
@@ -1,0 +1,97 @@
+import 'package:solana_kit_subscribable/src/data_publisher.dart';
+
+/// A function that transforms a source message into a destination channel name
+/// and message pair, or returns `null` to drop the message.
+typedef MessageTransformer<TSourceData> =
+    (String channelName, Object? message)? Function(TSourceData message);
+
+/// Splits a single source channel of a [DataPublisher] into multiple derived
+/// channels using a [messageTransformer].
+///
+/// The returned [DataPublisher] lazily subscribes to the source publisher:
+/// - The source is only subscribed when the first subscriber appears on the
+///   demultiplexed publisher.
+/// - The source is unsubscribed when the last subscriber unsubscribes.
+/// - Reference counting ensures multiple subscribers share a single source
+///   subscription.
+/// - Unsubscribe functions are idempotent.
+///
+/// ```dart
+/// final demuxed = demultiplexDataPublisher(
+///   sourcePublisher: publisher,
+///   sourceChannelName: 'message',
+///   messageTransformer: (message) {
+///     final id = (message as Map)['subscriberId'];
+///     return ('notification-for:$id', message);
+///   },
+/// );
+///
+/// final unsubscribe = demuxed.on('notification-for:123', (message) {
+///   print('Got a message for subscriber 123: $message');
+/// });
+/// ```
+DataPublisher demultiplexDataPublisher<TSourceData>({
+  required DataPublisher sourcePublisher,
+  required String sourceChannelName,
+  required MessageTransformer<TSourceData> messageTransformer,
+}) {
+  _InnerPublisherState? innerPublisherState;
+  final innerPublisher = createDataPublisher();
+
+  return _DemultiplexedDataPublisher(
+    onSubscribe: (channelName, subscriber) {
+      if (innerPublisherState == null) {
+        final sourceUnsubscribe = sourcePublisher.on(sourceChannelName, (
+          sourceMessage,
+        ) {
+          final transformResult = messageTransformer(
+            sourceMessage as TSourceData,
+          );
+          if (transformResult == null) return;
+          final (destinationChannelName, message) = transformResult;
+          innerPublisher.publish(destinationChannelName, message);
+        });
+        innerPublisherState = _InnerPublisherState(dispose: sourceUnsubscribe);
+      }
+
+      innerPublisherState!.numSubscribers++;
+      final innerUnsubscribe = innerPublisher.on(channelName, subscriber);
+
+      var isActive = true;
+      void handleUnsubscribe() {
+        if (!isActive) return;
+        isActive = false;
+        innerPublisherState!.numSubscribers--;
+        if (innerPublisherState!.numSubscribers == 0) {
+          innerPublisherState!.dispose();
+          innerPublisherState = null;
+        }
+        innerUnsubscribe();
+      }
+
+      return handleUnsubscribe;
+    },
+  );
+}
+
+class _InnerPublisherState {
+  _InnerPublisherState({required this.dispose});
+
+  final UnsubscribeFn dispose;
+  int numSubscribers = 0;
+}
+
+class _DemultiplexedDataPublisher implements DataPublisher {
+  const _DemultiplexedDataPublisher({required this.onSubscribe});
+
+  final UnsubscribeFn Function(
+    String channelName,
+    Subscriber<Object?> subscriber,
+  )
+  onSubscribe;
+
+  @override
+  UnsubscribeFn on(String channelName, Subscriber<Object?> subscriber) {
+    return onSubscribe(channelName, subscriber);
+  }
+}

--- a/packages/solana_kit_subscribable/pubspec.yaml
+++ b/packages/solana_kit_subscribable/pubspec.yaml
@@ -12,3 +12,4 @@ dependencies:
 
 dev_dependencies:
   solana_kit_lints:
+  test: ^1.25.0

--- a/packages/solana_kit_subscribable/test/async_iterable_test.dart
+++ b/packages/solana_kit_subscribable/test/async_iterable_test.dart
@@ -1,0 +1,350 @@
+import 'dart:async';
+
+import 'package:solana_kit_subscribable/solana_kit_subscribable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('createStreamFromDataPublisher', () {
+    late WritableDataPublisher mockPublisher;
+
+    setUp(() {
+      mockPublisher = createDataPublisher();
+    });
+
+    test('stream receives published data', () async {
+      final stream = createStreamFromDataPublisher<String>(
+        StreamFromDataPublisherConfig(
+          dataChannelName: 'data',
+          dataPublisher: mockPublisher,
+          errorChannelName: 'error',
+        ),
+      );
+
+      final completer = Completer<String>();
+      final sub = stream.listen(completer.complete);
+
+      mockPublisher.publish('data', 'hello');
+      final result = await completer.future;
+      expect(result, 'hello');
+      await sub.cancel();
+    });
+
+    test('stream receives errors from error channel', () async {
+      final stream = createStreamFromDataPublisher<String>(
+        StreamFromDataPublisherConfig(
+          dataChannelName: 'data',
+          dataPublisher: mockPublisher,
+          errorChannelName: 'error',
+        ),
+      );
+
+      final completer = Completer<Object>();
+      stream.listen(
+        (_) {},
+        onError: (Object error) {
+          if (!completer.isCompleted) completer.complete(error);
+        },
+      );
+
+      mockPublisher.publish('error', 'some error');
+      final result = await completer.future;
+      expect(result, 'some error');
+    });
+
+    test('messages published before first listener are dropped', () async {
+      final stream = createStreamFromDataPublisher<String>(
+        StreamFromDataPublisherConfig(
+          dataChannelName: 'data',
+          dataPublisher: mockPublisher,
+          errorChannelName: 'error',
+        ),
+      );
+
+      // Publish before listening.
+      mockPublisher.publish('data', 'lost message');
+
+      final received = <String>[];
+      final completer = Completer<void>();
+      final sub = stream.listen((data) {
+        received.add(data);
+        if (data == 'kept message') {
+          completer.complete();
+        }
+      });
+
+      mockPublisher.publish('data', 'kept message');
+      await completer.future;
+      expect(received, ['kept message']);
+      await sub.cancel();
+    });
+
+    test('stream can be cancelled', () async {
+      final stream = createStreamFromDataPublisher<String>(
+        StreamFromDataPublisherConfig(
+          dataChannelName: 'data',
+          dataPublisher: mockPublisher,
+          errorChannelName: 'error',
+        ),
+      );
+
+      var count = 0;
+      final sub = stream.listen((_) {
+        count++;
+      });
+
+      mockPublisher.publish('data', 'hello');
+      expect(count, 1);
+
+      await sub.cancel();
+
+      // After cancel, no more events should be received.
+      mockPublisher.publish('data', 'world');
+      expect(count, 1);
+    });
+  });
+
+  group('createAsyncIterableFromDataPublisher', () {
+    late WritableDataPublisher mockPublisher;
+
+    setUp(() {
+      mockPublisher = createDataPublisher();
+    });
+
+    test(
+      'returns from the stream when the abort signal starts aborted',
+      () async {
+        final abortCompleter = Completer<void>()..complete();
+
+        // Allow microtask to run.
+        await Future<void>.delayed(Duration.zero);
+
+        final stream = createAsyncIterableFromDataPublisher<Object?>(
+          abortSignal: abortCompleter.future,
+          dataChannelName: 'data',
+          dataPublisher: mockPublisher,
+          errorChannelName: 'error',
+        );
+
+        final items = await stream.toList();
+        expect(items, isEmpty);
+      },
+    );
+
+    test('returns from the stream when the abort signal fires', () async {
+      final abortCompleter = Completer<void>();
+
+      final stream = createAsyncIterableFromDataPublisher<Object?>(
+        abortSignal: abortCompleter.future,
+        dataChannelName: 'data',
+        dataPublisher: mockPublisher,
+        errorChannelName: 'error',
+      );
+
+      final items = <Object?>[];
+      final done = Completer<void>();
+
+      stream.listen(
+        items.add,
+        onDone: () {
+          if (!done.isCompleted) done.complete();
+        },
+      );
+
+      // Allow subscription to set up.
+      await Future<void>.delayed(Duration.zero);
+
+      abortCompleter.complete();
+      await done.future;
+      expect(items, isEmpty);
+    });
+
+    test('throws the first published error through the stream', () async {
+      final abortCompleter = Completer<void>();
+
+      final stream = createAsyncIterableFromDataPublisher<Object?>(
+        abortSignal: abortCompleter.future,
+        dataChannelName: 'data',
+        dataPublisher: mockPublisher,
+        errorChannelName: 'error',
+      );
+
+      // Publish errors before listening.
+      mockPublisher
+        ..publish('error', StateError('o no'))
+        ..publish('error', StateError('also o no'));
+
+      Object? caughtError;
+      final done = Completer<void>();
+      stream.listen(
+        (_) {},
+        onError: (Object error) {
+          caughtError ??= error;
+        },
+        onDone: () {
+          if (!done.isCompleted) done.complete();
+        },
+      );
+
+      await done.future;
+      expect(caughtError, isA<StateError>());
+      expect((caughtError! as StateError).message, 'o no');
+    });
+
+    test('drops data published before polling begins', () async {
+      final abortCompleter = Completer<void>();
+
+      final stream = createAsyncIterableFromDataPublisher<String>(
+        abortSignal: abortCompleter.future,
+        dataChannelName: 'data',
+        dataPublisher: mockPublisher,
+        errorChannelName: 'error',
+      );
+
+      // Publish before listening -- this message should be dropped.
+      mockPublisher.publish('data', 'lost message');
+
+      final received = <String>[];
+      final done = Completer<void>();
+
+      stream.listen(
+        (data) {
+          received.add(data);
+          if (data == 'hi') {
+            abortCompleter.complete();
+          }
+        },
+        onDone: () {
+          if (!done.isCompleted) done.complete();
+        },
+      );
+
+      // Allow subscription to set up.
+      await Future<void>.delayed(Duration.zero);
+
+      mockPublisher.publish('data', 'hi');
+      await done.future;
+      expect(received, ['hi']);
+    });
+
+    test('vends data to the stream', () async {
+      final abortCompleter = Completer<void>();
+
+      final stream = createAsyncIterableFromDataPublisher<String>(
+        abortSignal: abortCompleter.future,
+        dataChannelName: 'data',
+        dataPublisher: mockPublisher,
+        errorChannelName: 'error',
+      );
+
+      final received = <String>[];
+      final done = Completer<void>();
+
+      stream.listen(
+        (data) {
+          received.add(data);
+          if (received.length == 3) {
+            abortCompleter.complete();
+          }
+        },
+        onDone: () {
+          if (!done.isCompleted) done.complete();
+        },
+      );
+
+      // Allow subscription to set up.
+      await Future<void>.delayed(Duration.zero);
+
+      mockPublisher.publish('data', 'one');
+
+      // Allow one message to process before sending next.
+      await Future<void>.delayed(Duration.zero);
+      mockPublisher.publish('data', 'two');
+
+      await Future<void>.delayed(Duration.zero);
+      mockPublisher.publish('data', 'three');
+
+      await done.future;
+      expect(received, ['one', 'two', 'three']);
+    });
+
+    test('queued messages are delivered before error', () async {
+      final abortCompleter = Completer<void>();
+
+      final stream = createAsyncIterableFromDataPublisher<String>(
+        abortSignal: abortCompleter.future,
+        dataChannelName: 'data',
+        dataPublisher: mockPublisher,
+        errorChannelName: 'error',
+      );
+
+      final received = <String>[];
+      Object? caughtError;
+      final done = Completer<void>();
+
+      stream.listen(
+        received.add,
+        onError: (Object error) {
+          caughtError ??= error;
+        },
+        onDone: () {
+          if (!done.isCompleted) done.complete();
+        },
+      );
+
+      // Allow subscription to set up.
+      await Future<void>.delayed(Duration.zero);
+
+      // First message is consumed immediately by the waiting poll.
+      mockPublisher.publish('data', 'consumed message');
+
+      // Allow the first message to be consumed and a new poll to start.
+      await Future<void>.delayed(Duration.zero);
+
+      // These are queued.
+      mockPublisher
+        ..publish('data', 'queued message 1')
+        ..publish('error', StateError('o no'));
+
+      await done.future;
+      expect(received, contains('queued message 1'));
+      expect(caughtError, isA<StateError>());
+    });
+
+    test('queued messages are delivered before abort finalizes', () async {
+      final abortCompleter = Completer<void>();
+
+      final stream = createAsyncIterableFromDataPublisher<String>(
+        abortSignal: abortCompleter.future,
+        dataChannelName: 'data',
+        dataPublisher: mockPublisher,
+        errorChannelName: 'error',
+      );
+
+      final received = <String>[];
+      final done = Completer<void>();
+
+      stream.listen(
+        received.add,
+        onDone: () {
+          if (!done.isCompleted) done.complete();
+        },
+      );
+
+      // Allow subscription to set up.
+      await Future<void>.delayed(Duration.zero);
+
+      // First message consumed immediately.
+      mockPublisher.publish('data', 'consumed message');
+
+      // Allow first message processing.
+      await Future<void>.delayed(Duration.zero);
+
+      // Queue a message then abort.
+      mockPublisher.publish('data', 'queued message 1');
+      abortCompleter.complete();
+
+      await done.future;
+      expect(received, contains('queued message 1'));
+    });
+  });
+}

--- a/packages/solana_kit_subscribable/test/data_publisher_test.dart
+++ b/packages/solana_kit_subscribable/test/data_publisher_test.dart
@@ -1,0 +1,140 @@
+import 'package:solana_kit_subscribable/solana_kit_subscribable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DataPublisher', () {
+    late WritableDataPublisher publisher;
+
+    setUp(() {
+      publisher = createDataPublisher();
+    });
+
+    test('calls a subscriber with the published data', () {
+      Object? received;
+      publisher
+        ..on('someEvent', (data) {
+          received = data;
+        })
+        ..publish('someEvent', 123);
+      expect(received, 123);
+    });
+
+    test('calls a subscriber with null data', () {
+      Object? received = 'sentinel';
+      publisher
+        ..on('someEvent', (data) {
+          received = data;
+        })
+        ..publish('someEvent', null);
+      expect(received, isNull);
+    });
+
+    test(
+      'does not call a subscriber after the unsubscribe function is called',
+      () {
+        var callCount = 0;
+        final unsubscribe = publisher.on('someEvent', (_) {
+          callCount++;
+        });
+        unsubscribe();
+        publisher.publish('someEvent', 'data');
+        expect(callCount, 0);
+      },
+    );
+
+    test(
+      'does not fatal when the unsubscribe method is called more than once',
+      () {
+        final unsubscribe = publisher.on('someEvent', (_) {});
+        unsubscribe();
+        expect(unsubscribe, returnsNormally);
+      },
+    );
+
+    test(
+      'keeps other subscribers subscribed when unsubscribing from others',
+      () {
+        var calledA = false;
+        var calledB = false;
+        publisher.on('someEvent', (_) {
+          calledA = true;
+        });
+        final unsubscribeB = publisher.on('someEvent', (_) {
+          calledB = true;
+        });
+        unsubscribeB();
+        publisher.publish('someEvent', 'data');
+        expect(calledA, isTrue);
+        expect(calledB, isFalse);
+      },
+    );
+
+    test('does not notify a subscriber about an event with a type different '
+        'than the one it is interested in', () {
+      var called = false;
+      publisher
+        ..on('someEvent', (_) {
+          called = true;
+        })
+        ..publish('someOtherEvent', 'data');
+      expect(called, isFalse);
+    });
+
+    test('supports multiple subscribers on the same channel', () {
+      var countA = 0;
+      var countB = 0;
+      publisher
+        ..on('channel', (_) {
+          countA++;
+        })
+        ..on('channel', (_) {
+          countB++;
+        })
+        ..publish('channel', 'data');
+      expect(countA, 1);
+      expect(countB, 1);
+    });
+
+    test('passes published data to all subscribers on the channel', () {
+      final received = <Object?>[];
+      publisher
+        ..on('channel', received.add)
+        ..on('channel', received.add)
+        ..publish('channel', 42);
+      expect(received, [42, 42]);
+    });
+
+    test('different channels are independent', () {
+      Object? receivedA;
+      Object? receivedB;
+      publisher
+        ..on('channelA', (data) {
+          receivedA = data;
+        })
+        ..on('channelB', (data) {
+          receivedB = data;
+        })
+        ..publish('channelA', 'hello');
+      expect(receivedA, 'hello');
+      expect(receivedB, isNull);
+    });
+
+    test('does nothing when publishing to a channel with no subscribers', () {
+      // Should not throw.
+      publisher.publish('nonexistent', 'data');
+    });
+
+    test('subscriber can unsubscribe during notification', () {
+      late UnsubscribeFn unsub;
+      var callCount = 0;
+      unsub = publisher.on('channel', (_) {
+        callCount++;
+        unsub();
+      });
+      publisher
+        ..publish('channel', 'first')
+        ..publish('channel', 'second');
+      expect(callCount, 1);
+    });
+  });
+}

--- a/packages/solana_kit_subscribable/test/demultiplex_test.dart
+++ b/packages/solana_kit_subscribable/test/demultiplex_test.dart
@@ -1,0 +1,255 @@
+import 'package:solana_kit_subscribable/solana_kit_subscribable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('demultiplexDataPublisher', () {
+    late WritableDataPublisher mockPublisher;
+    late int onCallCount;
+    late List<UnsubscribeFn> mockUnsubscribes;
+
+    setUp(() {
+      mockPublisher = createDataPublisher();
+      onCallCount = 0;
+      mockUnsubscribes = [];
+    });
+
+    /// Wraps [mockPublisher] in a tracking [DataPublisher] that counts calls
+    /// to [DataPublisher.on] and records the returned unsubscribe functions.
+    DataPublisher trackingPublisher() {
+      return _TrackingDataPublisher(
+        mockPublisher,
+        onCall: (unsub) {
+          onCallCount++;
+          mockUnsubscribes.add(unsub);
+        },
+      );
+    }
+
+    test('does not listen to the publisher when there are no subscribers', () {
+      demultiplexDataPublisher<Object?>(
+        sourcePublisher: trackingPublisher(),
+        sourceChannelName: 'channelName',
+        messageTransformer: (_) => null,
+      );
+      expect(onCallCount, 0);
+    });
+
+    test('starts to listen to the publisher when a subscriber appears', () {
+      demultiplexDataPublisher<Object?>(
+        sourcePublisher: trackingPublisher(),
+        sourceChannelName: 'channelName',
+        messageTransformer: (_) => null,
+      ).on('someChannelName', (_) {});
+      expect(onCallCount, 1);
+    });
+
+    test(
+      'only listens to the publisher once despite multiple subscriptions',
+      () {
+        demultiplexDataPublisher<Object?>(
+            sourcePublisher: trackingPublisher(),
+            sourceChannelName: 'channelName',
+            messageTransformer: (_) => null,
+          )
+          ..on('someChannelName', (_) {})
+          ..on('someOtherChannelName', (_) {});
+        expect(onCallCount, 1);
+      },
+    );
+
+    test(
+      'unsubscribes from the publisher once the last subscriber unsubscribes',
+      () {
+        var sourceUnsubCalled = false;
+        final source = _CallbackDataPublisher(
+          onSubscribe: (channelName, subscriber) {
+            return () {
+              sourceUnsubCalled = true;
+            };
+          },
+        );
+
+        final demuxed = demultiplexDataPublisher<Object?>(
+          sourcePublisher: source,
+          sourceChannelName: 'channelName',
+          messageTransformer: (_) => null,
+        );
+
+        final unsubscribe = demuxed.on('someChannelName', (_) {});
+        unsubscribe();
+        expect(sourceUnsubCalled, isTrue);
+      },
+    );
+
+    test('does not unsubscribe from the publisher if there are still '
+        'subscribers after some having unsubscribed', () {
+      var sourceUnsubCalled = false;
+      final source = _CallbackDataPublisher(
+        onSubscribe: (channelName, subscriber) {
+          return () {
+            sourceUnsubCalled = true;
+          };
+        },
+      );
+
+      final demuxed = demultiplexDataPublisher<Object?>(
+        sourcePublisher: source,
+        sourceChannelName: 'channelName',
+        messageTransformer: (_) => null,
+      );
+
+      final unsubscribe = demuxed.on('someChannelName', (_) {});
+      demuxed.on('someChannelName', (_) {});
+      unsubscribe();
+      expect(sourceUnsubCalled, isFalse);
+    });
+
+    test("does not unsubscribe from the publisher when one subscriber's "
+        'unsubscribe function is called as many times as there are '
+        'subscriptions', () {
+      var sourceUnsubCalled = false;
+      final source = _CallbackDataPublisher(
+        onSubscribe: (channelName, subscriber) {
+          return () {
+            sourceUnsubCalled = true;
+          };
+        },
+      );
+
+      final demuxed = demultiplexDataPublisher<Object?>(
+        sourcePublisher: source,
+        sourceChannelName: 'channelName',
+        messageTransformer: (_) => null,
+      );
+
+      final unsubscribeA = demuxed.on('someChannelName', (_) {});
+      demuxed.on('someOtherChannelName', (_) {});
+
+      // No matter how many times the unsubscribe function is called, it only
+      // decrements the subscriber count once, for its own subscription.
+      unsubscribeA();
+      unsubscribeA();
+      expect(sourceUnsubCalled, isFalse);
+    });
+
+    test('publishes a message on the demuxed channel with the name returned '
+        'by the transformer', () {
+      final demuxed = demultiplexDataPublisher<Object?>(
+        sourcePublisher: mockPublisher,
+        sourceChannelName: 'channelName',
+        messageTransformer: (_) => ('transformedChannelName', 'HI'),
+      );
+
+      Object? received;
+      demuxed.on('transformedChannelName', (data) {
+        received = data;
+      });
+
+      mockPublisher.publish('channelName', 'hi');
+      expect(received, 'HI');
+    });
+
+    test('publishes no message on the demuxed channel if the transformer '
+        'returns null', () {
+      final demuxed = demultiplexDataPublisher<Object?>(
+        sourcePublisher: mockPublisher,
+        sourceChannelName: 'channelName',
+        messageTransformer: (_) => null,
+      );
+
+      var called = false;
+      demuxed.on('transformedChannelName', (_) {
+        called = true;
+      });
+
+      mockPublisher.publish('channelName', 'hi');
+      expect(called, isFalse);
+    });
+
+    test('calls the transform function for every matching event', () {
+      var transformCallCount = 0;
+      demultiplexDataPublisher<Object?>(
+        sourcePublisher: mockPublisher,
+        sourceChannelName: 'channelName',
+        messageTransformer: (message) {
+          transformCallCount++;
+          return null;
+        },
+      ).on('channelName', (_) {});
+      mockPublisher
+        ..publish('channelName', 'first')
+        ..publish('channelName', 'second');
+      expect(transformCallCount, 2);
+    });
+
+    test('passes the source message to the transformer', () {
+      Object? transformedMessage;
+      demultiplexDataPublisher<Object?>(
+        sourcePublisher: mockPublisher,
+        sourceChannelName: 'channelName',
+        messageTransformer: (message) {
+          transformedMessage = message;
+          return null;
+        },
+      ).on('channelName', (_) {});
+      mockPublisher.publish('channelName', 'hi');
+      expect(transformedMessage, 'hi');
+    });
+
+    test('re-subscribes to source after all subscribers leave and a new one '
+        'appears', () {
+      var sourceSubCount = 0;
+      final source = _CallbackDataPublisher(
+        onSubscribe: (channelName, subscriber) {
+          sourceSubCount++;
+          return () {};
+        },
+      );
+
+      final demuxed = demultiplexDataPublisher<Object?>(
+        sourcePublisher: source,
+        sourceChannelName: 'channelName',
+        messageTransformer: (_) => null,
+      );
+
+      final unsub1 = demuxed.on('channel1', (_) {});
+      expect(sourceSubCount, 1);
+
+      unsub1();
+
+      demuxed.on('channel2', (_) {});
+      expect(sourceSubCount, 2);
+    });
+  });
+}
+
+/// A [DataPublisher] that delegates to a callback for testing.
+class _CallbackDataPublisher implements DataPublisher {
+  const _CallbackDataPublisher({required this.onSubscribe});
+
+  final UnsubscribeFn Function(
+    String channelName,
+    Subscriber<Object?> subscriber,
+  )
+  onSubscribe;
+
+  @override
+  UnsubscribeFn on(String channelName, Subscriber<Object?> subscriber) {
+    return onSubscribe(channelName, subscriber);
+  }
+}
+
+/// A [DataPublisher] that wraps another and tracks calls to [on].
+class _TrackingDataPublisher implements DataPublisher {
+  _TrackingDataPublisher(this._inner, {required this.onCall});
+
+  final DataPublisher _inner;
+  final void Function(UnsubscribeFn unsub) onCall;
+
+  @override
+  UnsubscribeFn on(String channelName, Subscriber<Object?> subscriber) {
+    final unsub = _inner.on(channelName, subscriber);
+    onCall(unsub);
+    return unsub;
+  }
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -260,9 +260,9 @@
 
 ### solana_kit_subscribable (~5 source files, ~5 test files)
 
-- [ ] T107 [US4] Port DataPublisher, async iterable helpers from `.repos/kit/packages/subscribable/src/` to `packages/solana_kit_subscribable/lib/src/`
-- [ ] T108 [US4] Update barrel export `packages/solana_kit_subscribable/lib/solana_kit_subscribable.dart`
-- [ ] T109 [US4] Port all 5 test files from `.repos/kit/packages/subscribable/src/__tests__/` to `packages/solana_kit_subscribable/test/`
+- [x] T107 [US4] Port DataPublisher, async iterable helpers from `.repos/kit/packages/subscribable/src/` to `packages/solana_kit_subscribable/lib/src/`
+- [x] T108 [US4] Update barrel export `packages/solana_kit_subscribable/lib/solana_kit_subscribable.dart`
+- [x] T109 [US4] Port all 5 test files from `.repos/kit/packages/subscribable/src/__tests__/` to `packages/solana_kit_subscribable/test/`
 
 ### solana_kit_rpc_subscriptions_api (~11 source files, ~21 test files)
 


### PR DESCRIPTION
## Summary

- Port `@solana/subscribable` to Dart with full test coverage (33 tests)
- `DataPublisher` interface with `on(channelName, subscriber)` returning unsubscribe function
- `WritableDataPublisher` concrete implementation with `publish()` for testing and internal use
- `createStreamFromDataPublisher` converting DataPublisher to Dart `Stream<TData>` with error channel
- `createAsyncIterableFromDataPublisher` with AbortSignal support, message queuing, pre-poll dropping
- `demultiplexDataPublisher` splitting single channel into multiple typed channels with lazy subscription and reference counting

## Test plan

- [x] All 33 tests pass (`dart test packages/solana_kit_subscribable/`)
- [x] `dart analyze` passes with no issues
- [x] `dart format` passes with no changes needed
- [x] Changeset included