### PR TITLE
✨ feat(solana_kit_transaction_confirmation): implement transaction confirmation package

### DIFF
--- a/.changeset/transaction-confirmation.md
+++ b/.changeset/transaction-confirmation.md
@@ -1,0 +1,17 @@
+---
+solana_kit_transaction_confirmation: minor
+---
+
+Implement transaction confirmation package ported from `@solana/transaction-confirmation`.
+
+**solana_kit_transaction_confirmation** (60 tests):
+
+- `createRecentSignatureConfirmationPromiseFactory` with dual-pronged subscription + one-shot query
+- `createBlockHeightExceedencePromiseFactory` monitoring slot notifications for block height tracking
+- `createNonceInvalidationPromiseFactory` detecting durable nonce advancement
+- `getTimeoutPromise` with commitment-based timeouts (30s processed, 60s confirmed/finalized)
+- `raceStrategies` core strategy racing with safe future handling
+- `waitForRecentTransactionConfirmation` high-level blockhash-based confirmation
+- `waitForDurableNonceTransactionConfirmation` high-level nonce-based confirmation
+- `waitForRecentTransactionConfirmationUntilTimeout` (deprecated) timeout-based fallback
+- Dependency injection pattern for RPC functions to keep dependencies minimal

--- a/packages/solana_kit_transaction_confirmation/lib/solana_kit_transaction_confirmation.dart
+++ b/packages/solana_kit_transaction_confirmation/lib/solana_kit_transaction_confirmation.dart
@@ -1,1 +1,26 @@
+/// Confirmation tracking for the Solana Kit Dart SDK.
+///
+/// This package provides utilities for confirming Solana transactions using
+/// multiple strategies:
+///
+/// - **Signature Confirmation** - Watch for a transaction signature to reach
+///   a target commitment level.
+/// - **Block Height Exceedence** - Detect when a blockhash-based transaction's
+///   lifetime has expired.
+/// - **Nonce Invalidation** - Detect when a durable nonce has been advanced
+///   (transaction expired).
+/// - **Timeout** - Simple timeout-based fallback.
+/// - **Strategy Racing** - Race multiple strategies to confirm or reject first.
+///
+/// This is the Dart port of the TypeScript `@solana/transaction-confirmation`
+/// package.
+library;
 
+export 'src/commitment_comparator.dart';
+export 'src/confirmation_strategy_blockheight.dart';
+export 'src/confirmation_strategy_nonce.dart';
+export 'src/confirmation_strategy_racer.dart';
+export 'src/confirmation_strategy_recent_signature.dart';
+export 'src/confirmation_strategy_timeout.dart';
+export 'src/signature_status.dart';
+export 'src/waiters.dart';

--- a/packages/solana_kit_transaction_confirmation/lib/src/commitment_comparator.dart
+++ b/packages/solana_kit_transaction_confirmation/lib/src/commitment_comparator.dart
@@ -1,0 +1,4 @@
+// Re-export commitmentComparator from solana_kit_rpc_types.
+// This package does not define its own version; it uses the canonical one.
+export 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart'
+    show commitmentComparator;

--- a/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_blockheight.dart
+++ b/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_blockheight.dart
@@ -1,0 +1,209 @@
+import 'dart:async';
+
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Information about the current epoch.
+class EpochInfo {
+  /// Creates an [EpochInfo].
+  const EpochInfo({required this.absoluteSlot, required this.blockHeight});
+
+  /// The current slot.
+  final BigInt absoluteSlot;
+
+  /// The current block height.
+  final BigInt blockHeight;
+}
+
+/// A slot notification from the RPC subscription.
+class SlotNotification {
+  /// Creates a [SlotNotification].
+  const SlotNotification({required this.slot});
+
+  /// The slot number.
+  final BigInt slot;
+}
+
+/// Configuration for the block height exceedence promise factory.
+class BlockHeightExceedenceConfig {
+  /// Creates a [BlockHeightExceedenceConfig].
+  const BlockHeightExceedenceConfig({
+    required this.getEpochInfo,
+    required this.onSlotNotification,
+  });
+
+  /// Function to get epoch info from the RPC.
+  final Future<EpochInfo> Function({
+    required AbortSignal abortSignal,
+    Commitment? commitment,
+  })
+  getEpochInfo;
+
+  /// Function to subscribe to slot notifications.
+  ///
+  /// Should call the `onNotification` callback for each slot notification,
+  /// and return a future that completes when the subscription ends.
+  final Future<void> Function({
+    required AbortSignal abortSignal,
+    required void Function(SlotNotification notification) onNotification,
+  })
+  onSlotNotification;
+}
+
+/// Creates a factory function that returns a promise that rejects when the
+/// network block height exceeds the transaction's last valid block height.
+///
+/// When a transaction's lifetime is tied to a blockhash, that transaction can
+/// be landed on the network until that blockhash expires. All blockhashes have
+/// a block height after which they are considered to have expired.
+///
+/// Throws [SolanaError] with [SolanaErrorCode.blockHeightExceeded] when the
+/// block height has been exceeded.
+Future<Never> Function({
+  required AbortSignal abortSignal,
+  required BigInt lastValidBlockHeight,
+  Commitment? commitment,
+})
+createBlockHeightExceedencePromiseFactory(BlockHeightExceedenceConfig config) {
+  return ({
+    required AbortSignal abortSignal,
+    required BigInt lastValidBlockHeight,
+    Commitment? commitment,
+  }) async {
+    if (abortSignal.isAborted) {
+      throw StateError('The operation was aborted: ${abortSignal.reason}');
+    }
+
+    final abortController = AbortController();
+
+    abortSignal.future.then((_) {
+      abortController.abort(abortSignal.reason);
+    }).ignore();
+
+    Future<
+      ({BigInt blockHeight, BigInt differenceBetweenSlotHeightAndBlockHeight})
+    >
+    getBlockHeightAndDifference() async {
+      final epochInfo = await config.getEpochInfo(
+        abortSignal: abortController.signal,
+        commitment: commitment,
+      );
+      return (
+        blockHeight: epochInfo.blockHeight,
+        differenceBetweenSlotHeightAndBlockHeight:
+            epochInfo.absoluteSlot - epochInfo.blockHeight,
+      );
+    }
+
+    try {
+      // Fetch initial block height and set up slot subscription in parallel.
+      final initialInfoCompleter =
+          Completer<
+            ({
+              BigInt blockHeight,
+              BigInt differenceBetweenSlotHeightAndBlockHeight,
+            })
+          >();
+      final slotNotifications = <SlotNotification>[];
+      var slotNotificationCallback = (SlotNotification _) {};
+
+      unawaited(
+        config
+            .onSlotNotification(
+              abortSignal: abortController.signal,
+              onNotification: (notification) {
+                slotNotificationCallback(notification);
+              },
+            )
+            .catchError((Object error) {
+              if (!initialInfoCompleter.isCompleted) {
+                initialInfoCompleter.completeError(error);
+              }
+            }),
+      );
+
+      unawaited(
+        getBlockHeightAndDifference()
+            .then((info) {
+              if (!initialInfoCompleter.isCompleted) {
+                initialInfoCompleter.complete(info);
+              }
+            })
+            .catchError((Object error) {
+              if (!initialInfoCompleter.isCompleted) {
+                initialInfoCompleter.completeError(error);
+              }
+            }),
+      );
+
+      final initialInfo = await initialInfoCompleter.future;
+
+      if (abortSignal.isAborted) {
+        throw StateError('The operation was aborted: ${abortSignal.reason}');
+      }
+
+      var currentBlockHeight = initialInfo.blockHeight;
+
+      if (currentBlockHeight <= lastValidBlockHeight) {
+        var lastKnownDifference =
+            initialInfo.differenceBetweenSlotHeightAndBlockHeight;
+
+        // Process slot notifications.
+        final exceedenceCompleter = Completer<Never>();
+
+        slotNotificationCallback = (SlotNotification notification) {
+          if (exceedenceCompleter.isCompleted) return;
+
+          final slot = notification.slot;
+          if (slot - lastKnownDifference > lastValidBlockHeight) {
+            // Before making a final decision, recheck the actual block height.
+            unawaited(
+              getBlockHeightAndDifference()
+                  .then((rechecked) {
+                    if (exceedenceCompleter.isCompleted) return;
+                    currentBlockHeight = rechecked.blockHeight;
+                    if (currentBlockHeight > lastValidBlockHeight) {
+                      exceedenceCompleter.completeError(
+                        SolanaError(SolanaErrorCode.blockHeightExceeded, {
+                          'currentBlockHeight': currentBlockHeight,
+                          'lastValidBlockHeight': lastValidBlockHeight,
+                        }),
+                      );
+                    } else {
+                      // Recalibrate the difference and keep waiting.
+                      lastKnownDifference =
+                          rechecked.differenceBetweenSlotHeightAndBlockHeight;
+                    }
+                  })
+                  .catchError((Object error) {
+                    if (!exceedenceCompleter.isCompleted) {
+                      exceedenceCompleter.completeError(error);
+                    }
+                  }),
+            );
+          }
+        };
+
+        // Also process any notifications that arrived before we set up
+        // the callback.
+        for (final notification in slotNotifications) {
+          slotNotificationCallback(notification);
+        }
+
+        return await exceedenceCompleter.future;
+      }
+
+      if (abortSignal.isAborted) {
+        throw StateError('The operation was aborted: ${abortSignal.reason}');
+      }
+
+      throw SolanaError(SolanaErrorCode.blockHeightExceeded, {
+        'currentBlockHeight': currentBlockHeight,
+        'lastValidBlockHeight': lastValidBlockHeight,
+      });
+    } finally {
+      abortController.abort();
+    }
+  };
+}

--- a/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_nonce.dart
+++ b/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_nonce.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// The result of fetching a nonce account's current nonce value.
+class NonceAccountInfo {
+  /// Creates a [NonceAccountInfo].
+  const NonceAccountInfo({required this.nonceValue});
+
+  /// The current nonce value stored in the account.
+  final String nonceValue;
+}
+
+/// Configuration for the nonce invalidation promise factory.
+class NonceInvalidationConfig {
+  /// Creates a [NonceInvalidationConfig].
+  const NonceInvalidationConfig({
+    required this.getNonceAccount,
+    required this.onAccountNotification,
+  });
+
+  /// Function to get the current nonce value from an account via RPC.
+  ///
+  /// Returns `null` if the account is not found.
+  final Future<NonceAccountInfo?> Function(
+    String nonceAccountAddress, {
+    required AbortSignal abortSignal,
+    required Commitment commitment,
+  })
+  getNonceAccount;
+
+  /// Function to subscribe to account notifications for the nonce account.
+  ///
+  /// Should call the `onNotification` callback for each notification, passing
+  /// the current nonce value. Returns a future that completes when the
+  /// subscription ends.
+  final Future<void> Function(
+    String nonceAccountAddress, {
+    required AbortSignal abortSignal,
+    required Commitment commitment,
+    required void Function({required String nonceValue}) onNotification,
+  })
+  onAccountNotification;
+}
+
+/// Creates a factory function that returns a promise that rejects when a
+/// durable nonce value changes (nonce has been advanced).
+///
+/// When a transaction's lifetime is tied to the value stored in a nonce
+/// account, that transaction can be landed on the network until the nonce is
+/// advanced to a new value.
+///
+/// Throws [SolanaError] with:
+/// - [SolanaErrorCode.invalidNonce] when the nonce has been advanced.
+/// - [SolanaErrorCode.nonceAccountNotFound] when the nonce account is not
+///   found.
+Future<Never> Function({
+  required AbortSignal abortSignal,
+  required Commitment commitment,
+  required String expectedNonceValue,
+  required String nonceAccountAddress,
+})
+createNonceInvalidationPromiseFactory(NonceInvalidationConfig config) {
+  return ({
+    required AbortSignal abortSignal,
+    required Commitment commitment,
+    required String expectedNonceValue,
+    required String nonceAccountAddress,
+  }) async {
+    final abortController = AbortController();
+
+    abortSignal.future.then((_) {
+      abortController.abort(abortSignal.reason);
+    }).ignore();
+
+    try {
+      // STEP 1: Set up a subscription for nonce account changes.
+      final nonceInvalidationCompleter = Completer<Never>();
+
+      // The subscription future is intentionally not awaited because it runs
+      // in parallel with the one-shot nonce account check.
+      // ignore: unawaited_futures
+      config.onAccountNotification(
+        nonceAccountAddress,
+        abortSignal: abortController.signal,
+        commitment: commitment,
+        onNotification: ({required String nonceValue}) {
+          if (nonceInvalidationCompleter.isCompleted) return;
+          if (nonceValue != expectedNonceValue) {
+            nonceInvalidationCompleter.completeError(
+              SolanaError(SolanaErrorCode.invalidNonce, {
+                'actualNonceValue': nonceValue,
+                'expectedNonceValue': expectedNonceValue,
+              }),
+            );
+          }
+        },
+      );
+
+      // STEP 2: Having subscribed for updates, make a one-shot request for
+      // the current nonce value to check if it has already been advanced.
+      final nonceIsAlreadyInvalidCompleter = Completer<Never>();
+      unawaited(
+        config
+            .getNonceAccount(
+              nonceAccountAddress,
+              abortSignal: abortController.signal,
+              commitment: commitment,
+            )
+            .then((nonceAccount) {
+              if (nonceIsAlreadyInvalidCompleter.isCompleted) return;
+              if (nonceAccount == null) {
+                nonceIsAlreadyInvalidCompleter.completeError(
+                  SolanaError(SolanaErrorCode.nonceAccountNotFound, {
+                    'nonceAccountAddress': nonceAccountAddress,
+                  }),
+                );
+              } else if (nonceAccount.nonceValue != expectedNonceValue) {
+                nonceIsAlreadyInvalidCompleter.completeError(
+                  SolanaError(SolanaErrorCode.invalidNonce, {
+                    'actualNonceValue': nonceAccount.nonceValue,
+                    'expectedNonceValue': expectedNonceValue,
+                  }),
+                );
+              }
+              // Otherwise, leave the completer pending (never resolves).
+            })
+            .catchError((Object error) {
+              if (!nonceIsAlreadyInvalidCompleter.isCompleted) {
+                nonceIsAlreadyInvalidCompleter.completeError(error);
+              }
+            }),
+      );
+
+      return await Future.any([
+        nonceInvalidationCompleter.future,
+        nonceIsAlreadyInvalidCompleter.future,
+      ]);
+    } finally {
+      abortController.abort();
+    }
+  };
+}

--- a/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_racer.dart
+++ b/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_racer.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// The type of a function that creates a recent signature confirmation promise.
+typedef GetRecentSignatureConfirmationPromise =
+    Future<void> Function({
+      required AbortSignal abortSignal,
+      required Commitment commitment,
+      required String signature,
+    });
+
+/// Configuration for a confirmation strategy race.
+class BaseTransactionConfirmationStrategyConfig {
+  /// Creates a [BaseTransactionConfirmationStrategyConfig].
+  const BaseTransactionConfirmationStrategyConfig({
+    required this.commitment,
+    required this.getRecentSignatureConfirmationPromise,
+    this.abortSignal,
+  });
+
+  /// An optional abort signal to cancel the confirmation.
+  final AbortSignal? abortSignal;
+
+  /// The target commitment level.
+  final Commitment commitment;
+
+  /// A function that returns a promise resolving when a signature reaches
+  /// the target commitment level.
+  final GetRecentSignatureConfirmationPromise
+  getRecentSignatureConfirmationPromise;
+}
+
+/// Races a signature confirmation promise against specific strategies.
+///
+/// The first strategy to resolve or reject determines the outcome. All
+/// strategies are aborted when one completes.
+///
+/// [signature] is the transaction signature to confirm.
+/// [config] contains the base configuration for the race.
+/// [getSpecificStrategiesForRace] returns the specific strategy futures to
+/// race against the signature confirmation promise.
+Future<void> raceStrategies(
+  String signature,
+  BaseTransactionConfirmationStrategyConfig config,
+  List<Future<void>> Function({required AbortSignal abortSignal})
+  getSpecificStrategiesForRace,
+) async {
+  final callerAbortSignal = config.abortSignal;
+
+  if (callerAbortSignal != null && callerAbortSignal.isAborted) {
+    throw StateError('The operation was aborted: ${callerAbortSignal.reason}');
+  }
+
+  final abortController = AbortController();
+
+  if (callerAbortSignal != null) {
+    callerAbortSignal.future.then((_) {
+      abortController.abort(callerAbortSignal.reason);
+    }).ignore();
+  }
+
+  try {
+    final specificStrategies = getSpecificStrategiesForRace(
+      abortSignal: abortController.signal,
+    );
+
+    final signatureConfirmation = config.getRecentSignatureConfirmationPromise(
+      abortSignal: abortController.signal,
+      commitment: config.commitment,
+      signature: signature,
+    );
+
+    final allFutures = [signatureConfirmation, ...specificStrategies];
+
+    // Implement a safe race equivalent to TypeScript's `safeRace`.
+    // Using a Completer that completes with the first future to settle.
+    // `then<void>` with `onError` is used instead of `catchError` because
+    // some futures may be `Future<Never>` at runtime, and `catchError`
+    // requires the handler to return the same type as the future.
+    final raceCompleter = Completer<void>();
+    for (final future in allFutures) {
+      unawaited(
+        future.then<void>(
+          (value) {
+            if (!raceCompleter.isCompleted) {
+              raceCompleter.complete();
+            }
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            if (!raceCompleter.isCompleted) {
+              raceCompleter.completeError(error, stackTrace);
+            }
+          },
+        ),
+      );
+    }
+
+    await raceCompleter.future;
+  } finally {
+    abortController.abort();
+  }
+}

--- a/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_recent_signature.dart
+++ b/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_recent_signature.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/src/signature_status.dart';
+
+/// Configuration for the recent signature confirmation strategy factory.
+class RecentSignatureConfirmationConfig {
+  /// Creates a [RecentSignatureConfirmationConfig].
+  const RecentSignatureConfirmationConfig({
+    required this.getSignatureStatuses,
+    required this.onSignatureNotification,
+  });
+
+  /// Function to get the current status of signatures via RPC.
+  ///
+  /// Should return a list of [SignatureStatus] results, one per input
+  /// signature. The result may be `null` if the signature is not found.
+  final Future<List<SignatureStatus?>> Function(
+    List<String> signatures, {
+    required AbortSignal abortSignal,
+  })
+  getSignatureStatuses;
+
+  /// Function to subscribe to signature notifications via RPC subscriptions.
+  ///
+  /// This should set up a subscription and call the `onNotification` callback
+  /// each time a notification arrives. Returns a future that completes when
+  /// the subscription ends.
+  ///
+  /// The callback receives an `err` field (null if no error).
+  final Future<void> Function(
+    String signature, {
+    required AbortSignal abortSignal,
+    required Commitment commitment,
+    required void Function({required Object? err}) onNotification,
+  })
+  onSignatureNotification;
+}
+
+/// Creates a factory function for signature confirmation promises.
+///
+/// The returned function will resolve when a recently-landed transaction
+/// achieves the target confirmation commitment, and throw when the transaction
+/// fails with an error.
+///
+/// The strategy works in two parallel steps:
+/// 1. Sets up a subscription for status changes to the signature.
+/// 2. Makes a one-shot request for the current status to handle the case where
+///    the signature reached the target commitment before the subscription
+///    started.
+Future<void> Function({
+  required AbortSignal abortSignal,
+  required Commitment commitment,
+  required String signature,
+})
+createRecentSignatureConfirmationPromiseFactory(
+  RecentSignatureConfirmationConfig config,
+) {
+  return ({
+    required AbortSignal abortSignal,
+    required Commitment commitment,
+    required String signature,
+  }) async {
+    final abortController = AbortController();
+
+    abortSignal.future.then((_) {
+      abortController.abort(abortSignal.reason);
+    }).ignore();
+
+    try {
+      // STEP 1: Set up a subscription for status changes to the signature.
+      final signatureDidCommitCompleter = Completer<void>();
+
+      // The subscription future is intentionally not awaited because it runs
+      // in parallel with the one-shot status check.
+      // ignore: unawaited_futures, document_ignores
+      config.onSignatureNotification(
+        signature,
+        abortSignal: abortController.signal,
+        commitment: commitment,
+        onNotification: ({required Object? err}) {
+          if (signatureDidCommitCompleter.isCompleted) return;
+          if (err != null) {
+            signatureDidCommitCompleter.completeError(
+              StateError('Transaction failed: $err'),
+            );
+          } else {
+            signatureDidCommitCompleter.complete();
+          }
+        },
+      );
+
+      // STEP 2: Having subscribed for updates, make a one-shot request for
+      // the current status.
+      final signatureStatusLookupCompleter = Completer<void>();
+      unawaited(
+        config
+            .getSignatureStatuses([
+              signature,
+            ], abortSignal: abortController.signal)
+            .then((results) {
+              if (signatureStatusLookupCompleter.isCompleted) return;
+              final signatureStatus = results.isNotEmpty ? results[0] : null;
+              if (signatureStatus?.err != null) {
+                signatureStatusLookupCompleter.completeError(
+                  StateError('Transaction failed: ${signatureStatus!.err}'),
+                );
+              } else if (signatureStatus?.confirmationStatus != null &&
+                  commitmentComparator(
+                        signatureStatus!.confirmationStatus!,
+                        commitment,
+                      ) >=
+                      0) {
+                signatureStatusLookupCompleter.complete();
+              }
+              // Otherwise, leave the completer pending (never resolves).
+            })
+            .catchError((Object error) {
+              if (!signatureStatusLookupCompleter.isCompleted) {
+                signatureStatusLookupCompleter.completeError(error);
+              }
+            }),
+      );
+
+      await Future.any([
+        signatureDidCommitCompleter.future,
+        signatureStatusLookupCompleter.future,
+      ]);
+    } finally {
+      abortController.abort();
+    }
+  };
+}

--- a/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_timeout.dart
+++ b/packages/solana_kit_transaction_confirmation/lib/src/confirmation_strategy_timeout.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Returns a [Future] that rejects after a timeout.
+///
+/// The timeout is 30 seconds when [commitment] is [Commitment.processed], and
+/// 60 seconds otherwise.
+///
+/// When no other heuristic exists to infer that a transaction has expired, you
+/// can use this promise factory with a commitment level. You would typically
+/// race this with another confirmation strategy.
+///
+/// Throws a [TimeoutException] after the timeout elapses.
+/// Throws a [StateError] if the [abortSignal] is aborted before the timeout.
+Future<Never> getTimeoutPromise({
+  required AbortSignal abortSignal,
+  required Commitment commitment,
+}) async {
+  final completer = Completer<Never>();
+
+  if (abortSignal.isAborted) {
+    throw StateError('The operation was aborted: ${abortSignal.reason}');
+  }
+
+  final timeoutMs = commitment == Commitment.processed ? 30000 : 60000;
+  final stopwatch = Stopwatch()..start();
+
+  final timer = Timer(Duration(milliseconds: timeoutMs), () {
+    final elapsedMs = stopwatch.elapsedMilliseconds;
+    stopwatch.stop();
+    if (!completer.isCompleted) {
+      completer.completeError(
+        TimeoutException(
+          'Timeout elapsed after $elapsedMs ms',
+          Duration(milliseconds: timeoutMs),
+        ),
+      );
+    }
+  });
+
+  abortSignal.future.then((_) {
+    timer.cancel();
+    stopwatch.stop();
+    if (!completer.isCompleted) {
+      completer.completeError(
+        StateError('The operation was aborted: ${abortSignal.reason}'),
+      );
+    }
+  }).ignore();
+
+  return completer.future;
+}

--- a/packages/solana_kit_transaction_confirmation/lib/src/signature_status.dart
+++ b/packages/solana_kit_transaction_confirmation/lib/src/signature_status.dart
@@ -1,0 +1,17 @@
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// The status of a transaction signature.
+class SignatureStatus {
+  /// Creates a [SignatureStatus].
+  const SignatureStatus({this.confirmationStatus, this.err});
+
+  /// The commitment level the signature has reached.
+  ///
+  /// Will be `null` if the signature is not found in the status cache.
+  final Commitment? confirmationStatus;
+
+  /// The error associated with this transaction, if any.
+  ///
+  /// A non-null value indicates the transaction failed.
+  final Object? err;
+}

--- a/packages/solana_kit_transaction_confirmation/lib/src/waiters.dart
+++ b/packages/solana_kit_transaction_confirmation/lib/src/waiters.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+import 'package:solana_kit_transaction_confirmation/src/confirmation_strategy_racer.dart';
+
+/// Waits for a transaction using a durable nonce to confirm.
+///
+/// Races the signature confirmation against nonce invalidation detection.
+/// If the nonce is invalidated before the signature confirms, the returned
+/// future will reject with the nonce invalidation error.
+///
+/// [abortSignal] can be used to cancel the confirmation process.
+/// [commitment] is the target commitment level.
+/// [getNonceInvalidationPromise] is a function that rejects when the nonce
+/// is invalidated.
+/// [getRecentSignatureConfirmationPromise] is a function that resolves when
+/// the signature reaches the target commitment.
+/// [nonceAccountAddress] is the address of the nonce account.
+/// [nonceValue] is the expected nonce value.
+/// [signature] is the transaction signature to confirm.
+Future<void> waitForDurableNonceTransactionConfirmation({
+  required AbortSignal abortSignal,
+  required Commitment commitment,
+  required Future<Never> Function({
+    required AbortSignal abortSignal,
+    required Commitment commitment,
+    required String expectedNonceValue,
+    required String nonceAccountAddress,
+  })
+  getNonceInvalidationPromise,
+  required GetRecentSignatureConfirmationPromise
+  getRecentSignatureConfirmationPromise,
+  required String nonceAccountAddress,
+  required String nonceValue,
+  required String signature,
+}) async {
+  await raceStrategies(
+    signature,
+    BaseTransactionConfirmationStrategyConfig(
+      abortSignal: abortSignal,
+      commitment: commitment,
+      getRecentSignatureConfirmationPromise:
+          getRecentSignatureConfirmationPromise,
+    ),
+    ({required AbortSignal abortSignal}) => [
+      getNonceInvalidationPromise(
+        abortSignal: abortSignal,
+        commitment: commitment,
+        expectedNonceValue: nonceValue,
+        nonceAccountAddress: nonceAccountAddress,
+      ),
+    ],
+  );
+}
+
+/// Waits for a transaction using block height for lifetime to confirm.
+///
+/// Races the signature confirmation against block height exceedence detection.
+/// If the block height exceeds the last valid block height before the
+/// signature confirms, the returned future will reject with a block height
+/// exceeded error.
+///
+/// [abortSignal] can be used to cancel the confirmation process.
+/// [commitment] is the target commitment level.
+/// [getBlockHeightExceedencePromise] is a function that rejects when the
+/// block height has been exceeded.
+/// [getRecentSignatureConfirmationPromise] is a function that resolves when
+/// the signature reaches the target commitment.
+/// [lastValidBlockHeight] is the last block height at which the transaction
+/// is still valid.
+/// [signature] is the transaction signature to confirm.
+Future<void> waitForRecentTransactionConfirmation({
+  required AbortSignal abortSignal,
+  required Commitment commitment,
+  required Future<Never> Function({
+    required AbortSignal abortSignal,
+    required BigInt lastValidBlockHeight,
+    Commitment? commitment,
+  })
+  getBlockHeightExceedencePromise,
+  required GetRecentSignatureConfirmationPromise
+  getRecentSignatureConfirmationPromise,
+  required BigInt lastValidBlockHeight,
+  required String signature,
+}) async {
+  await raceStrategies(
+    signature,
+    BaseTransactionConfirmationStrategyConfig(
+      abortSignal: abortSignal,
+      commitment: commitment,
+      getRecentSignatureConfirmationPromise:
+          getRecentSignatureConfirmationPromise,
+    ),
+    ({required AbortSignal abortSignal}) => [
+      getBlockHeightExceedencePromise(
+        abortSignal: abortSignal,
+        commitment: commitment,
+        lastValidBlockHeight: lastValidBlockHeight,
+      ),
+    ],
+  );
+}
+
+/// Waits for a transaction to confirm using a timeout strategy.
+///
+/// Races the signature confirmation against a timeout. If the timeout elapses
+/// before the signature confirms, the returned future will reject with a
+/// timeout error.
+///
+/// [abortSignal] can be used to cancel the confirmation process.
+/// [commitment] is the target commitment level.
+/// [getTimeoutPromise] is a function that rejects after a timeout.
+/// [getRecentSignatureConfirmationPromise] is a function that resolves when
+/// the signature reaches the target commitment.
+/// [signature] is the transaction signature to confirm.
+@Deprecated('Use waitForRecentTransactionConfirmation instead')
+Future<void> waitForRecentTransactionConfirmationUntilTimeout({
+  required AbortSignal abortSignal,
+  required Commitment commitment,
+  required Future<Never> Function({
+    required AbortSignal abortSignal,
+    required Commitment commitment,
+  })
+  getTimeoutPromise,
+  required GetRecentSignatureConfirmationPromise
+  getRecentSignatureConfirmationPromise,
+  required String signature,
+}) async {
+  await raceStrategies(
+    signature,
+    BaseTransactionConfirmationStrategyConfig(
+      abortSignal: abortSignal,
+      commitment: commitment,
+      getRecentSignatureConfirmationPromise:
+          getRecentSignatureConfirmationPromise,
+    ),
+    ({required AbortSignal abortSignal}) => [
+      getTimeoutPromise(abortSignal: abortSignal, commitment: commitment),
+    ],
+  );
+}

--- a/packages/solana_kit_transaction_confirmation/pubspec.yaml
+++ b/packages/solana_kit_transaction_confirmation/pubspec.yaml
@@ -9,7 +9,11 @@ resolution: workspace
 
 dependencies:
   solana_kit_errors:
+  solana_kit_rpc_subscriptions_channel_websocket:
   solana_kit_rpc_types:
+  solana_kit_subscribable:
 
 dev_dependencies:
+  fake_async: ^1.3.2
   solana_kit_lints:
+  test: ^1.25.8

--- a/packages/solana_kit_transaction_confirmation/test/commitment_comparator_test.dart
+++ b/packages/solana_kit_transaction_confirmation/test/commitment_comparator_test.dart
@@ -1,0 +1,58 @@
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart'
+    as tc;
+import 'package:test/test.dart';
+
+void main() {
+  group('commitmentComparator', () {
+    test('processed < confirmed', () {
+      expect(
+        tc.commitmentComparator(Commitment.processed, Commitment.confirmed),
+        isNegative,
+      );
+    });
+
+    test('confirmed < finalized', () {
+      expect(
+        tc.commitmentComparator(Commitment.confirmed, Commitment.finalized),
+        isNegative,
+      );
+    });
+
+    test('processed < finalized', () {
+      expect(
+        tc.commitmentComparator(Commitment.processed, Commitment.finalized),
+        isNegative,
+      );
+    });
+
+    test('finalized > confirmed', () {
+      expect(
+        tc.commitmentComparator(Commitment.finalized, Commitment.confirmed),
+        isPositive,
+      );
+    });
+
+    test('confirmed > processed', () {
+      expect(
+        tc.commitmentComparator(Commitment.confirmed, Commitment.processed),
+        isPositive,
+      );
+    });
+
+    test('same commitment returns 0', () {
+      expect(
+        tc.commitmentComparator(Commitment.processed, Commitment.processed),
+        equals(0),
+      );
+      expect(
+        tc.commitmentComparator(Commitment.confirmed, Commitment.confirmed),
+        equals(0),
+      );
+      expect(
+        tc.commitmentComparator(Commitment.finalized, Commitment.finalized),
+        equals(0),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_blockheight_test.dart
+++ b/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_blockheight_test.dart
@@ -1,0 +1,310 @@
+import 'dart:async';
+
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('createBlockHeightExceedencePromiseFactory', () {
+    late List<Completer<EpochInfo>> epochInfoCompleters;
+    late void Function(SlotNotification notification)? slotCallback;
+    late Future<Never> Function({
+      required AbortSignal abortSignal,
+      required BigInt lastValidBlockHeight,
+      Commitment? commitment,
+    })
+    getBlockHeightExceedencePromise;
+
+    setUp(() {
+      epochInfoCompleters = [];
+      slotCallback = null;
+
+      getBlockHeightExceedencePromise =
+          createBlockHeightExceedencePromiseFactory(
+            BlockHeightExceedenceConfig(
+              getEpochInfo:
+                  ({required AbortSignal abortSignal, Commitment? commitment}) {
+                    final completer = Completer<EpochInfo>();
+                    epochInfoCompleters.add(completer);
+                    return completer.future;
+                  },
+              onSlotNotification:
+                  ({
+                    required AbortSignal abortSignal,
+                    required void Function(SlotNotification notification)
+                    onNotification,
+                  }) async {
+                    slotCallback = onNotification;
+                    // Keep subscription open.
+                    await Completer<void>().future;
+                  },
+            ),
+          );
+    });
+
+    test(
+      'throws when the block height has already been exceeded when called',
+      () async {
+        epochInfoCompleters.clear();
+        final future = getBlockHeightExceedencePromise(
+          abortSignal: AbortController().signal,
+          lastValidBlockHeight: BigInt.from(100),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+        epochInfoCompleters[0].complete(
+          EpochInfo(
+            absoluteSlot: BigInt.from(101),
+            blockHeight: BigInt.from(101),
+          ),
+        );
+
+        await expectLater(
+          future,
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              equals(SolanaErrorCode.blockHeightExceeded),
+            ),
+          ),
+        );
+      },
+    );
+
+    test('continues to pend when the block height in the initial fetch '
+        'is equal to the last valid block height', () async {
+      final future = getBlockHeightExceedencePromise(
+        abortSignal: AbortController().signal,
+        lastValidBlockHeight: BigInt.from(100),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      epochInfoCompleters[0].complete(
+        EpochInfo(
+          absoluteSlot: BigInt.from(100),
+          blockHeight: BigInt.from(100),
+        ),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await Future.any([
+        future.then<String>((_) => 'resolved').catchError((_) => 'rejected'),
+        Future<String>.delayed(
+          const Duration(milliseconds: 50),
+          () => 'pending',
+        ),
+      ]);
+      expect(result, equals('pending'));
+    });
+
+    test('throws when the slot at which the block height is expected to '
+        'be exceeded is reached', () async {
+      final future = getBlockHeightExceedencePromise(
+        abortSignal: AbortController().signal,
+        lastValidBlockHeight: BigInt.from(100),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      // Initial: slot 198, height 98 (difference of 100).
+      epochInfoCompleters[0].complete(
+        EpochInfo(absoluteSlot: BigInt.from(198), blockHeight: BigInt.from(98)),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // Emit slot notifications.
+      slotCallback!(SlotNotification(slot: BigInt.from(199)));
+      await Future<void>.delayed(Duration.zero);
+      slotCallback!(SlotNotification(slot: BigInt.from(200)));
+      await Future<void>.delayed(Duration.zero);
+      // At slot 201, 201 - 100 = 101 > 100 (last valid).
+      slotCallback!(SlotNotification(slot: BigInt.from(201)));
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // Recheck confirms exceedence.
+      epochInfoCompleters[1].complete(
+        EpochInfo(
+          absoluteSlot: BigInt.from(201),
+          blockHeight: BigInt.from(101),
+        ),
+      );
+
+      await expectLater(
+        future,
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            equals(SolanaErrorCode.blockHeightExceeded),
+          ),
+        ),
+      );
+    });
+
+    test('continues to pend when the recheck shows block height has not '
+        'actually exceeded (difference grew)', () async {
+      final future = getBlockHeightExceedencePromise(
+        abortSignal: AbortController().signal,
+        lastValidBlockHeight: BigInt.from(100),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      // Initial: slot 198, height 98 (difference of 100).
+      epochInfoCompleters[0].complete(
+        EpochInfo(absoluteSlot: BigInt.from(198), blockHeight: BigInt.from(98)),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      slotCallback!(SlotNotification(slot: BigInt.from(199)));
+      await Future<void>.delayed(Duration.zero);
+      slotCallback!(SlotNotification(slot: BigInt.from(200)));
+      await Future<void>.delayed(Duration.zero);
+      slotCallback!(SlotNotification(slot: BigInt.from(201)));
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // Recheck shows the difference grew (some blocks skipped).
+      epochInfoCompleters[1].complete(
+        EpochInfo(
+          absoluteSlot: BigInt.from(201),
+          blockHeight: BigInt.from(100),
+        ),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await Future.any([
+        future.then<String>((_) => 'resolved').catchError((_) => 'rejected'),
+        Future<String>.delayed(
+          const Duration(milliseconds: 50),
+          () => 'pending',
+        ),
+      ]);
+      expect(result, equals('pending'));
+    });
+
+    test('throws if started aborted', () async {
+      final abortController = AbortController()..abort();
+
+      await expectLater(
+        getBlockHeightExceedencePromise(
+          abortSignal: abortController.signal,
+          lastValidBlockHeight: BigInt.from(100),
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('operation was aborted'),
+          ),
+        ),
+      );
+    });
+
+    test('throws errors thrown from the epoch info fetcher', () async {
+      final future = getBlockHeightExceedencePromise(
+        abortSignal: AbortController().signal,
+        lastValidBlockHeight: BigInt.from(100),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      epochInfoCompleters[0].completeError(StateError('o no'));
+
+      await expectLater(
+        future,
+        throwsA(
+          isA<StateError>().having((e) => e.message, 'message', equals('o no')),
+        ),
+      );
+    });
+
+    test('throws errors thrown from the slot subscription', () async {
+      final fn = createBlockHeightExceedencePromiseFactory(
+        BlockHeightExceedenceConfig(
+          getEpochInfo:
+              ({
+                required AbortSignal abortSignal,
+                Commitment? commitment,
+              }) async {
+                return EpochInfo(
+                  absoluteSlot: BigInt.from(100),
+                  blockHeight: BigInt.from(100),
+                );
+              },
+          onSlotNotification:
+              ({
+                required AbortSignal abortSignal,
+                required void Function(SlotNotification notification)
+                onNotification,
+              }) async {
+                throw StateError('o no');
+              },
+        ),
+      );
+
+      await expectLater(
+        fn(
+          abortSignal: AbortController().signal,
+          lastValidBlockHeight: BigInt.from(100),
+        ),
+        throwsA(
+          isA<StateError>().having((e) => e.message, 'message', equals('o no')),
+        ),
+      );
+    });
+
+    test('passes commitment to the epoch info getter', () async {
+      Commitment? capturedCommitment;
+
+      final fn = createBlockHeightExceedencePromiseFactory(
+        BlockHeightExceedenceConfig(
+          getEpochInfo:
+              ({
+                required AbortSignal abortSignal,
+                Commitment? commitment,
+              }) async {
+                capturedCommitment = commitment;
+                return EpochInfo(
+                  absoluteSlot: BigInt.from(101),
+                  blockHeight: BigInt.from(101),
+                );
+              },
+          onSlotNotification:
+              ({
+                required AbortSignal abortSignal,
+                required void Function(SlotNotification notification)
+                onNotification,
+              }) async {
+                await Completer<void>().future;
+              },
+        ),
+      );
+
+      try {
+        await fn(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.confirmed,
+          lastValidBlockHeight: BigInt.from(100),
+        );
+      } on SolanaError catch (_) {
+        // Expected - block height exceeded.
+      }
+
+      expect(capturedCommitment, equals(Commitment.confirmed));
+    });
+  });
+}

--- a/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_nonce_test.dart
+++ b/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_nonce_test.dart
@@ -1,0 +1,336 @@
+import 'dart:async';
+
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('createNonceInvalidationPromiseFactory', () {
+    late Completer<NonceAccountInfo?> getNonceAccountCompleter;
+    late void Function({required String nonceValue})?
+    accountNotificationCallback;
+    late Future<Never> Function({
+      required AbortSignal abortSignal,
+      required Commitment commitment,
+      required String expectedNonceValue,
+      required String nonceAccountAddress,
+    })
+    getNonceInvalidationPromise;
+
+    setUp(() {
+      getNonceAccountCompleter = Completer<NonceAccountInfo?>();
+      accountNotificationCallback = null;
+
+      getNonceInvalidationPromise = createNonceInvalidationPromiseFactory(
+        NonceInvalidationConfig(
+          getNonceAccount:
+              (
+                String nonceAccountAddress, {
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+              }) {
+                return getNonceAccountCompleter.future;
+              },
+          onAccountNotification:
+              (
+                String nonceAccountAddress, {
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required void Function({required String nonceValue})
+                onNotification,
+              }) async {
+                accountNotificationCallback = onNotification;
+                // Keep subscription open.
+                await Completer<void>().future;
+              },
+        ),
+      );
+    });
+
+    test('continues to pend when the nonce value returned by the one-shot '
+        'query is the same as the expected one', () async {
+      getNonceAccountCompleter.complete(
+        const NonceAccountInfo(nonceValue: 'expected_nonce'),
+      );
+
+      final completer = Completer<String>();
+      unawaited(
+        getNonceInvalidationPromise(
+              abortSignal: AbortController().signal,
+              commitment: Commitment.finalized,
+              expectedNonceValue: 'expected_nonce',
+              nonceAccountAddress: 'nonce_address',
+            )
+            .then<String>((_) {
+              completer.complete('resolved');
+              return 'resolved';
+            })
+            .catchError((Object error) {
+              completer.complete('rejected');
+              return 'rejected';
+            }),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await Future.any([
+        completer.future,
+        Future<String>.delayed(
+          const Duration(milliseconds: 50),
+          () => 'pending',
+        ),
+      ]);
+      expect(result, equals('pending'));
+    });
+
+    test('fatals when the nonce account is not found', () async {
+      getNonceAccountCompleter.complete(null);
+
+      await expectLater(
+        getNonceInvalidationPromise(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          expectedNonceValue: 'expected_nonce',
+          nonceAccountAddress: 'nonce_address',
+        ),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            equals(SolanaErrorCode.nonceAccountNotFound),
+          ),
+        ),
+      );
+    });
+
+    test('fatals when the nonce value returned by the one-shot query is '
+        'different than the expected one', () async {
+      getNonceAccountCompleter.complete(
+        const NonceAccountInfo(nonceValue: 'different_nonce'),
+      );
+
+      await expectLater(
+        getNonceInvalidationPromise(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          expectedNonceValue: 'expected_nonce',
+          nonceAccountAddress: 'nonce_address',
+        ),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            equals(SolanaErrorCode.invalidNonce),
+          ),
+        ),
+      );
+    });
+
+    test('continues to pend when the nonce value returned by the '
+        'account subscription is the same as expected', () async {
+      // Don't resolve the one-shot query.
+
+      final completer = Completer<String>();
+      unawaited(
+        getNonceInvalidationPromise(
+              abortSignal: AbortController().signal,
+              commitment: Commitment.finalized,
+              expectedNonceValue: 'expected_nonce',
+              nonceAccountAddress: 'nonce_address',
+            )
+            .then<String>((_) {
+              completer.complete('resolved');
+              return 'resolved';
+            })
+            .catchError((Object error) {
+              completer.complete('rejected');
+              return 'rejected';
+            }),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // Trigger subscription notification with matching nonce.
+      accountNotificationCallback!(nonceValue: 'expected_nonce');
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await Future.any([
+        completer.future,
+        Future<String>.delayed(
+          const Duration(milliseconds: 50),
+          () => 'pending',
+        ),
+      ]);
+      expect(result, equals('pending'));
+    });
+
+    test('fatals when the nonce value returned by the account subscription '
+        'is different than the expected one', () async {
+      final future = getNonceInvalidationPromise(
+        abortSignal: AbortController().signal,
+        commitment: Commitment.finalized,
+        expectedNonceValue: 'expected_nonce',
+        nonceAccountAddress: 'nonce_address',
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      accountNotificationCallback!(nonceValue: 'different_nonce');
+
+      await expectLater(
+        future,
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            equals(SolanaErrorCode.invalidNonce),
+          ),
+        ),
+      );
+    });
+
+    test('aborts internal abort controller when caller aborts', () async {
+      AbortSignal? capturedAbortSignal;
+
+      final fn = createNonceInvalidationPromiseFactory(
+        NonceInvalidationConfig(
+          getNonceAccount:
+              (
+                String nonceAccountAddress, {
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+              }) {
+                capturedAbortSignal = abortSignal;
+                return Completer<NonceAccountInfo?>().future;
+              },
+          onAccountNotification:
+              (
+                String nonceAccountAddress, {
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required void Function({required String nonceValue})
+                onNotification,
+              }) async {
+                await Completer<void>().future;
+              },
+        ),
+      );
+
+      final callerAbortController = AbortController();
+      unawaited(
+        fn(
+          abortSignal: callerAbortController.signal,
+          commitment: Commitment.finalized,
+          expectedNonceValue: 'expected_nonce',
+          nonceAccountAddress: 'nonce_address',
+        ).then<void>((_) {}).catchError((_) {}),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(capturedAbortSignal, isNotNull);
+      expect(capturedAbortSignal!.isAborted, isFalse);
+
+      callerAbortController.abort('test');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(capturedAbortSignal!.isAborted, isTrue);
+    });
+
+    test('passes commitment to the nonce account getter', () async {
+      Commitment? capturedCommitment;
+
+      final fn = createNonceInvalidationPromiseFactory(
+        NonceInvalidationConfig(
+          getNonceAccount:
+              (
+                String nonceAccountAddress, {
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+              }) async {
+                capturedCommitment = commitment;
+                return null;
+              },
+          onAccountNotification:
+              (
+                String nonceAccountAddress, {
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required void Function({required String nonceValue})
+                onNotification,
+              }) async {
+                await Completer<void>().future;
+              },
+        ),
+      );
+
+      try {
+        await fn(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.confirmed,
+          expectedNonceValue: 'expected_nonce',
+          nonceAccountAddress: 'nonce_address',
+        );
+      } on SolanaError catch (_) {
+        // Expected - nonce account not found.
+      }
+
+      expect(capturedCommitment, equals(Commitment.confirmed));
+    });
+
+    test(
+      'passes address and commitment to the account notification subscriber',
+      () async {
+        String? capturedAddress;
+        Commitment? capturedCommitment;
+
+        final fn = createNonceInvalidationPromiseFactory(
+          NonceInvalidationConfig(
+            getNonceAccount:
+                (
+                  String nonceAccountAddress, {
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                }) {
+                  return Completer<NonceAccountInfo?>().future;
+                },
+            onAccountNotification:
+                (
+                  String nonceAccountAddress, {
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required void Function({required String nonceValue})
+                  onNotification,
+                }) async {
+                  capturedAddress = nonceAccountAddress;
+                  capturedCommitment = commitment;
+                  await Completer<void>().future;
+                },
+          ),
+        );
+
+        unawaited(
+          fn(
+            abortSignal: AbortController().signal,
+            commitment: Commitment.finalized,
+            expectedNonceValue: 'expected_nonce',
+            nonceAccountAddress: 'my_nonce_address',
+          ).then<void>((_) {}).catchError((_) {}),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedAddress, equals('my_nonce_address'));
+        expect(capturedCommitment, equals(Commitment.finalized));
+      },
+    );
+  });
+}

--- a/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_racer_test.dart
+++ b/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_racer_test.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('raceStrategies', () {
+    test('aborts the AbortSignal passed to '
+        'getRecentSignatureConfirmationPromise when finished', () async {
+      AbortSignal? capturedSignal;
+
+      await raceStrategies(
+        'abc',
+        BaseTransactionConfirmationStrategyConfig(
+          commitment: Commitment.finalized,
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) {
+                capturedSignal = abortSignal;
+                return Future.value();
+              },
+        ),
+        ({required AbortSignal abortSignal}) => [],
+      );
+
+      // After completion, the internal abort controller should be aborted.
+      expect(capturedSignal, isNotNull);
+      expect(capturedSignal!.isAborted, isTrue);
+    });
+
+    test(
+      'aborts the AbortSignal passed to '
+      'getRecentSignatureConfirmationPromise when the caller aborts',
+      () async {
+        AbortSignal? capturedSignal;
+        final callerAbortController = AbortController();
+
+        final future = raceStrategies(
+          'abc',
+          BaseTransactionConfirmationStrategyConfig(
+            abortSignal: callerAbortController.signal,
+            commitment: Commitment.finalized,
+            getRecentSignatureConfirmationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String signature,
+                }) {
+                  capturedSignal = abortSignal;
+                  // Never resolve.
+                  return Completer<void>().future;
+                },
+          ),
+          ({required AbortSignal abortSignal}) => [
+            // Also never resolve.
+            Completer<void>().future,
+          ],
+        );
+
+        // Signal should not be aborted yet.
+        expect(capturedSignal, isNotNull);
+        expect(capturedSignal!.isAborted, isFalse);
+
+        callerAbortController.abort('test');
+
+        // Give microtask queue a chance to process.
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedSignal!.isAborted, isTrue);
+
+        // The future should eventually settle.
+        // We don't await it since nothing resolves the inner completers,
+        // but that's fine - the test verifies the abort propagation.
+        unawaited(future.catchError((_) {}));
+      },
+    );
+
+    test(
+      'aborts the AbortSignal passed to specific strategies when finished',
+      () async {
+        AbortSignal? capturedStrategySignal;
+
+        await raceStrategies(
+          'abc',
+          BaseTransactionConfirmationStrategyConfig(
+            commitment: Commitment.finalized,
+            getRecentSignatureConfirmationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String signature,
+                }) {
+                  return Future.value();
+                },
+          ),
+          ({required AbortSignal abortSignal}) {
+            capturedStrategySignal = abortSignal;
+            return [];
+          },
+        );
+
+        expect(capturedStrategySignal, isNotNull);
+        expect(capturedStrategySignal!.isAborted, isTrue);
+      },
+    );
+
+    test('aborts the AbortSignal passed to specific strategies '
+        'when the caller aborts', () async {
+      AbortSignal? capturedStrategySignal;
+      final callerAbortController = AbortController();
+
+      final future = raceStrategies(
+        'abc',
+        BaseTransactionConfirmationStrategyConfig(
+          abortSignal: callerAbortController.signal,
+          commitment: Commitment.finalized,
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) {
+                return Completer<void>().future;
+              },
+        ),
+        ({required AbortSignal abortSignal}) {
+          capturedStrategySignal = abortSignal;
+          return [Completer<void>().future];
+        },
+      );
+
+      expect(capturedStrategySignal, isNotNull);
+      expect(capturedStrategySignal!.isAborted, isFalse);
+
+      callerAbortController.abort('test');
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(capturedStrategySignal!.isAborted, isTrue);
+
+      unawaited(future.catchError((_) {}));
+    });
+
+    test('propagates strategy rejection', () async {
+      final future = raceStrategies(
+        'abc',
+        BaseTransactionConfirmationStrategyConfig(
+          commitment: Commitment.finalized,
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) {
+                return Completer<void>().future;
+              },
+        ),
+        ({required AbortSignal abortSignal}) => [
+          Future.error(StateError('strategy failed')),
+        ],
+      );
+
+      await expectLater(future, throwsA(isA<StateError>()));
+    });
+
+    test('propagates signature confirmation resolution', () async {
+      await raceStrategies(
+        'abc',
+        BaseTransactionConfirmationStrategyConfig(
+          commitment: Commitment.finalized,
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) {
+                return Future.value();
+              },
+        ),
+        ({required AbortSignal abortSignal}) => [Completer<void>().future],
+      );
+      // If we reach here, it resolved successfully.
+    });
+
+    test('throws when the signal is already aborted', () async {
+      final abortController = AbortController()..abort();
+
+      await expectLater(
+        raceStrategies(
+          'abc',
+          BaseTransactionConfirmationStrategyConfig(
+            abortSignal: abortController.signal,
+            commitment: Commitment.finalized,
+            getRecentSignatureConfirmationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String signature,
+                }) {
+                  return Completer<void>().future;
+                },
+          ),
+          ({required AbortSignal abortSignal}) => [],
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_recent_signature_test.dart
+++ b/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_recent_signature_test.dart
@@ -1,0 +1,255 @@
+import 'dart:async';
+
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('createRecentSignatureConfirmationPromiseFactory', () {
+    late Completer<List<SignatureStatus?>> getSignatureStatusesCompleter;
+    late void Function({required Object? err})? signatureNotificationCallback;
+    late Future<void> Function({
+      required AbortSignal abortSignal,
+      required Commitment commitment,
+      required String signature,
+    })
+    getSignatureConfirmationPromise;
+
+    setUp(() {
+      getSignatureStatusesCompleter = Completer<List<SignatureStatus?>>();
+      signatureNotificationCallback = null;
+
+      getSignatureConfirmationPromise =
+          createRecentSignatureConfirmationPromiseFactory(
+            RecentSignatureConfirmationConfig(
+              getSignatureStatuses:
+                  (
+                    List<String> signatures, {
+                    required AbortSignal abortSignal,
+                  }) {
+                    return getSignatureStatusesCompleter.future;
+                  },
+              onSignatureNotification:
+                  (
+                    String signature, {
+                    required Commitment commitment,
+                    required AbortSignal abortSignal,
+                    required void Function({required Object? err})
+                    onNotification,
+                  }) async {
+                    signatureNotificationCallback = onNotification;
+                    // Never resolve (keeps subscription open).
+                    await Completer<void>().future;
+                  },
+            ),
+          );
+    });
+
+    test('resolves when the signature status returned by the one-shot query '
+        'is at the target level of commitment', () async {
+      getSignatureStatusesCompleter.complete([
+        const SignatureStatus(confirmationStatus: Commitment.finalized),
+      ]);
+
+      await getSignatureConfirmationPromise(
+        abortSignal: AbortController().signal,
+        commitment: Commitment.finalized,
+        signature: 'abc',
+      );
+      // If we get here, the promise resolved.
+    });
+
+    test('resolves when the signature status returned by the one-shot query '
+        'exceeds the target commitment', () async {
+      getSignatureStatusesCompleter.complete([
+        const SignatureStatus(confirmationStatus: Commitment.finalized),
+      ]);
+
+      await getSignatureConfirmationPromise(
+        abortSignal: AbortController().signal,
+        commitment: Commitment.confirmed,
+        signature: 'abc',
+      );
+    });
+
+    test('continues to pend when the signature status returned by '
+        'the one-shot query is at a lower level of commitment', () async {
+      getSignatureStatusesCompleter.complete([
+        const SignatureStatus(confirmationStatus: Commitment.processed),
+      ]);
+
+      final completer = Completer<String>();
+      unawaited(
+        getSignatureConfirmationPromise(
+              abortSignal: AbortController().signal,
+              commitment: Commitment.finalized,
+              signature: 'abc',
+            )
+            .then((_) {
+              completer.complete('resolved');
+            })
+            .catchError((Object error) {
+              completer.complete('rejected');
+            }),
+      );
+
+      // Give microtasks a chance to process.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // The promise should still be pending.
+      final result = await Future.any([
+        completer.future,
+        Future<String>.delayed(
+          const Duration(milliseconds: 50),
+          () => 'pending',
+        ),
+      ]);
+      expect(result, equals('pending'));
+    });
+
+    test('continues to pend when no signature status is returned by '
+        'the one-shot query', () async {
+      getSignatureStatusesCompleter.complete([null]);
+
+      final completer = Completer<String>();
+      unawaited(
+        getSignatureConfirmationPromise(
+              abortSignal: AbortController().signal,
+              commitment: Commitment.finalized,
+              signature: 'abc',
+            )
+            .then((_) {
+              completer.complete('resolved');
+            })
+            .catchError((Object error) {
+              completer.complete('rejected');
+            }),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await Future.any([
+        completer.future,
+        Future<String>.delayed(
+          const Duration(milliseconds: 50),
+          () => 'pending',
+        ),
+      ]);
+      expect(result, equals('pending'));
+    });
+
+    test('fatals when the signature status returned by the one-shot query '
+        'is an error', () async {
+      getSignatureStatusesCompleter.complete([
+        const SignatureStatus(
+          confirmationStatus: Commitment.finalized,
+          err: 'o no',
+        ),
+      ]);
+
+      await expectLater(
+        getSignatureConfirmationPromise(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          signature: 'abc',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('Transaction failed'),
+          ),
+        ),
+      );
+    });
+
+    test('resolves when a signature notification indicates success', () async {
+      // Don't resolve the one-shot query.
+
+      final future = getSignatureConfirmationPromise(
+        abortSignal: AbortController().signal,
+        commitment: Commitment.finalized,
+        signature: 'abc',
+      );
+
+      // Give microtasks a chance to set up the subscription.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      // Now trigger the subscription notification.
+      signatureNotificationCallback!(err: null);
+
+      await future;
+    });
+
+    test('fatals when the signature subscription returns an error', () async {
+      final future = getSignatureConfirmationPromise(
+        abortSignal: AbortController().signal,
+        commitment: Commitment.finalized,
+        signature: 'abc',
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      signatureNotificationCallback!(err: 'o no');
+
+      await expectLater(
+        future,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('Transaction failed'),
+          ),
+        ),
+      );
+    });
+
+    test('aborts internal abort controller when caller aborts', () async {
+      AbortSignal? capturedAbortSignal;
+
+      final confirmationFn = createRecentSignatureConfirmationPromiseFactory(
+        RecentSignatureConfirmationConfig(
+          getSignatureStatuses:
+              (List<String> signatures, {required AbortSignal abortSignal}) {
+                capturedAbortSignal = abortSignal;
+                return Completer<List<SignatureStatus?>>().future;
+              },
+          onSignatureNotification:
+              (
+                String signature, {
+                required Commitment commitment,
+                required AbortSignal abortSignal,
+                required void Function({required Object? err}) onNotification,
+              }) async {
+                await Completer<void>().future;
+              },
+        ),
+      );
+
+      final callerAbortController = AbortController();
+      unawaited(
+        confirmationFn(
+          abortSignal: callerAbortController.signal,
+          commitment: Commitment.finalized,
+          signature: 'abc',
+        ).catchError((_) {}),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(capturedAbortSignal, isNotNull);
+      expect(capturedAbortSignal!.isAborted, isFalse);
+
+      callerAbortController.abort('test');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(capturedAbortSignal!.isAborted, isTrue);
+    });
+  });
+}

--- a/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_timeout_test.dart
+++ b/packages/solana_kit_transaction_confirmation/test/confirmation_strategy_timeout_test.dart
@@ -1,0 +1,120 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getTimeoutPromise', () {
+    test('pends for 30 seconds when the commitment is processed', () {
+      fakeAsync((async) {
+        var isCompleted = false;
+        Object? caughtError;
+        final abortController = AbortController();
+
+        getTimeoutPromise(
+          abortSignal: abortController.signal,
+          commitment: Commitment.processed,
+        ).then<void>(
+          (_) {
+            isCompleted = true;
+          },
+          onError: (Object error) {
+            caughtError = error;
+          },
+        );
+
+        // Advance to 29.999 seconds - should still be pending.
+        async.elapse(const Duration(milliseconds: 29999));
+        expect(isCompleted, isFalse);
+        expect(caughtError, isNull);
+
+        // Advance 1 more millisecond - should now be timed out.
+        async.elapse(const Duration(milliseconds: 1));
+        expect(caughtError, isNotNull);
+
+        abortController.abort();
+      });
+    });
+
+    test('pends for 60 seconds when the commitment is confirmed', () {
+      fakeAsync((async) {
+        Object? caughtError;
+        final abortController = AbortController();
+
+        getTimeoutPromise(
+          abortSignal: abortController.signal,
+          commitment: Commitment.confirmed,
+        ).then<void>(
+          (_) {},
+          onError: (Object error) {
+            caughtError = error;
+          },
+        );
+
+        // Advance to 59.999 seconds - should still be pending.
+        async.elapse(const Duration(milliseconds: 59999));
+        expect(caughtError, isNull);
+
+        // Advance 1 more millisecond - should now be timed out.
+        async.elapse(const Duration(milliseconds: 1));
+        expect(caughtError, isNotNull);
+
+        abortController.abort();
+      });
+    });
+
+    test('pends for 60 seconds when the commitment is finalized', () {
+      fakeAsync((async) {
+        Object? caughtError;
+        final abortController = AbortController();
+
+        getTimeoutPromise(
+          abortSignal: abortController.signal,
+          commitment: Commitment.finalized,
+        ).then<void>(
+          (_) {},
+          onError: (Object error) {
+            caughtError = error;
+          },
+        );
+
+        // Advance to 59.999 seconds - should still be pending.
+        async.elapse(const Duration(milliseconds: 59999));
+        expect(caughtError, isNull);
+
+        // Advance 1 more millisecond - should now be timed out.
+        async.elapse(const Duration(milliseconds: 1));
+        expect(caughtError, isNotNull);
+
+        abortController.abort();
+      });
+    });
+
+    test('throws a StateError when aborted before the timeout', () {
+      fakeAsync((async) {
+        Object? caughtError;
+        final abortController = AbortController();
+
+        getTimeoutPromise(
+          abortSignal: abortController.signal,
+          commitment: Commitment.finalized,
+        ).then<void>(
+          (_) {},
+          onError: (Object error) {
+            caughtError = error;
+          },
+        );
+
+        abortController.abort('test abort');
+        async.elapse(Duration.zero);
+
+        expect(caughtError, isA<StateError>());
+        expect(
+          (caughtError! as StateError).message,
+          contains('operation was aborted'),
+        );
+      });
+    });
+  });
+}

--- a/packages/solana_kit_transaction_confirmation/test/waiters_test.dart
+++ b/packages/solana_kit_transaction_confirmation/test/waiters_test.dart
@@ -1,0 +1,717 @@
+import 'dart:async';
+
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('waitForDurableNonceTransactionConfirmation', () {
+    late Future<Never> Function({
+      required AbortSignal abortSignal,
+      required Commitment commitment,
+      required String expectedNonceValue,
+      required String nonceAccountAddress,
+    })
+    getNonceInvalidationPromise;
+    late Future<void> Function({
+      required AbortSignal abortSignal,
+      required Commitment commitment,
+      required String signature,
+    })
+    getRecentSignatureConfirmationPromise;
+
+    late Completer<Never> nonceInvalidationCompleter;
+    late Completer<void> signatureConfirmationCompleter;
+
+    setUp(() {
+      nonceInvalidationCompleter = Completer<Never>();
+      signatureConfirmationCompleter = Completer<void>();
+
+      getNonceInvalidationPromise =
+          ({
+            required AbortSignal abortSignal,
+            required Commitment commitment,
+            required String expectedNonceValue,
+            required String nonceAccountAddress,
+          }) {
+            return nonceInvalidationCompleter.future;
+          };
+
+      getRecentSignatureConfirmationPromise =
+          ({
+            required AbortSignal abortSignal,
+            required Commitment commitment,
+            required String signature,
+          }) {
+            return signatureConfirmationCompleter.future;
+          };
+    });
+
+    test('throws when the signal is already aborted', () async {
+      final abortController = AbortController()..abort();
+
+      await expectLater(
+        waitForDurableNonceTransactionConfirmation(
+          abortSignal: abortController.signal,
+          commitment: Commitment.finalized,
+          getNonceInvalidationPromise: getNonceInvalidationPromise,
+          getRecentSignatureConfirmationPromise:
+              getRecentSignatureConfirmationPromise,
+          nonceAccountAddress: 'nonce_address',
+          nonceValue: 'xyz',
+          signature: 'test_signature',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('aborted'),
+          ),
+        ),
+      );
+    });
+
+    test('resolves when the signature confirmation promise resolves '
+        'despite the nonce invalidation promise having thrown', () async {
+      // Complete the signature confirmation immediately.
+      signatureConfirmationCompleter.complete();
+
+      // Schedule the nonce error to fire asynchronously so the futures
+      // are being listened to before the error occurs.
+      Future<void>.delayed(Duration.zero, () {
+        nonceInvalidationCompleter.completeError(StateError('o no'));
+      }).ignore();
+
+      await waitForDurableNonceTransactionConfirmation(
+        abortSignal: AbortController().signal,
+        commitment: Commitment.finalized,
+        getNonceInvalidationPromise: getNonceInvalidationPromise,
+        getRecentSignatureConfirmationPromise:
+            getRecentSignatureConfirmationPromise,
+        nonceAccountAddress: 'nonce_address',
+        nonceValue: 'xyz',
+        signature: 'test_signature',
+      );
+      // If we get here, it resolved successfully.
+    });
+
+    test('throws when the nonce invalidation promise throws', () async {
+      nonceInvalidationCompleter.completeError(StateError('o no'));
+
+      await expectLater(
+        waitForDurableNonceTransactionConfirmation(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          getNonceInvalidationPromise: getNonceInvalidationPromise,
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) {
+                return Completer<void>().future;
+              },
+          nonceAccountAddress: 'nonce_address',
+          nonceValue: 'xyz',
+          signature: 'test_signature',
+        ),
+        throwsA(
+          isA<StateError>().having((e) => e.message, 'message', equals('o no')),
+        ),
+      );
+    });
+
+    test('throws when the signature confirmation promise throws', () async {
+      signatureConfirmationCompleter.completeError(StateError('o no'));
+
+      await expectLater(
+        waitForDurableNonceTransactionConfirmation(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          getNonceInvalidationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String expectedNonceValue,
+                required String nonceAccountAddress,
+              }) {
+                return Completer<Never>().future;
+              },
+          getRecentSignatureConfirmationPromise:
+              getRecentSignatureConfirmationPromise,
+          nonceAccountAddress: 'nonce_address',
+          nonceValue: 'xyz',
+          signature: 'test_signature',
+        ),
+        throwsA(
+          isA<StateError>().having((e) => e.message, 'message', equals('o no')),
+        ),
+      );
+    });
+
+    test(
+      'calls getNonceInvalidationPromise with the necessary input',
+      () async {
+        String? capturedNonceValue;
+        String? capturedNonceAddress;
+        Commitment? capturedCommitment;
+
+        unawaited(
+          waitForDurableNonceTransactionConfirmation(
+            abortSignal: AbortController().signal,
+            commitment: Commitment.finalized,
+            getNonceInvalidationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String expectedNonceValue,
+                  required String nonceAccountAddress,
+                }) {
+                  capturedNonceValue = expectedNonceValue;
+                  capturedNonceAddress = nonceAccountAddress;
+                  capturedCommitment = commitment;
+                  return Completer<Never>().future;
+                },
+            getRecentSignatureConfirmationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String signature,
+                }) {
+                  return Completer<void>().future;
+                },
+            nonceAccountAddress: 'my_nonce_address',
+            nonceValue: 'xyz',
+            signature: 'test_signature',
+          ).catchError((_) {}),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedNonceValue, equals('xyz'));
+        expect(capturedNonceAddress, equals('my_nonce_address'));
+        expect(capturedCommitment, equals(Commitment.finalized));
+      },
+    );
+
+    test(
+      'calls getRecentSignatureConfirmationPromise with the necessary input',
+      () async {
+        String? capturedSignature;
+        Commitment? capturedCommitment;
+
+        unawaited(
+          waitForDurableNonceTransactionConfirmation(
+            abortSignal: AbortController().signal,
+            commitment: Commitment.finalized,
+            getNonceInvalidationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String expectedNonceValue,
+                  required String nonceAccountAddress,
+                }) {
+                  return Completer<Never>().future;
+                },
+            getRecentSignatureConfirmationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String signature,
+                }) {
+                  capturedSignature = signature;
+                  capturedCommitment = commitment;
+                  return Completer<void>().future;
+                },
+            nonceAccountAddress: 'nonce_address',
+            nonceValue: 'xyz',
+            signature: 'test_signature',
+          ).catchError((_) {}),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedSignature, equals('test_signature'));
+        expect(capturedCommitment, equals(Commitment.finalized));
+      },
+    );
+
+    test(
+      'aborts the abort signal passed to strategies when caller aborts',
+      () async {
+        AbortSignal? capturedNonceAbortSignal;
+        AbortSignal? capturedSignatureAbortSignal;
+        final callerAbortController = AbortController();
+
+        unawaited(
+          waitForDurableNonceTransactionConfirmation(
+            abortSignal: callerAbortController.signal,
+            commitment: Commitment.finalized,
+            getNonceInvalidationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String expectedNonceValue,
+                  required String nonceAccountAddress,
+                }) {
+                  capturedNonceAbortSignal = abortSignal;
+                  return Completer<Never>().future;
+                },
+            getRecentSignatureConfirmationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String signature,
+                }) {
+                  capturedSignatureAbortSignal = abortSignal;
+                  return Completer<void>().future;
+                },
+            nonceAccountAddress: 'nonce_address',
+            nonceValue: 'xyz',
+            signature: 'test_signature',
+          ).catchError((_) {}),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedNonceAbortSignal!.isAborted, isFalse);
+        expect(capturedSignatureAbortSignal!.isAborted, isFalse);
+
+        callerAbortController.abort('test');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedNonceAbortSignal!.isAborted, isTrue);
+        expect(capturedSignatureAbortSignal!.isAborted, isTrue);
+      },
+    );
+  });
+
+  group('waitForRecentTransactionConfirmation', () {
+    late Completer<Never> blockHeightExceedenceCompleter;
+    late Completer<void> signatureConfirmationCompleter;
+
+    late Future<Never> Function({
+      required AbortSignal abortSignal,
+      required BigInt lastValidBlockHeight,
+      Commitment? commitment,
+    })
+    getBlockHeightExceedencePromise;
+    late Future<void> Function({
+      required AbortSignal abortSignal,
+      required Commitment commitment,
+      required String signature,
+    })
+    getRecentSignatureConfirmationPromise;
+
+    setUp(() {
+      blockHeightExceedenceCompleter = Completer<Never>();
+      signatureConfirmationCompleter = Completer<void>();
+
+      getBlockHeightExceedencePromise =
+          ({
+            required AbortSignal abortSignal,
+            required BigInt lastValidBlockHeight,
+            Commitment? commitment,
+          }) {
+            return blockHeightExceedenceCompleter.future;
+          };
+
+      getRecentSignatureConfirmationPromise =
+          ({
+            required AbortSignal abortSignal,
+            required Commitment commitment,
+            required String signature,
+          }) {
+            return signatureConfirmationCompleter.future;
+          };
+    });
+
+    test('throws when the signal is already aborted', () async {
+      final abortController = AbortController()..abort();
+
+      await expectLater(
+        waitForRecentTransactionConfirmation(
+          abortSignal: abortController.signal,
+          commitment: Commitment.finalized,
+          getBlockHeightExceedencePromise: getBlockHeightExceedencePromise,
+          getRecentSignatureConfirmationPromise:
+              getRecentSignatureConfirmationPromise,
+          lastValidBlockHeight: BigInt.from(123),
+          signature: 'test_signature',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('aborted'),
+          ),
+        ),
+      );
+    });
+
+    test('resolves when the signature confirmation promise resolves '
+        'despite the block height exceedence promise having thrown', () async {
+      // Complete the signature confirmation immediately.
+      signatureConfirmationCompleter.complete();
+
+      // Schedule the block height error to fire asynchronously so the
+      // futures are being listened to before the error occurs.
+      Future<void>.delayed(Duration.zero, () {
+        blockHeightExceedenceCompleter.completeError(StateError('o no'));
+      }).ignore();
+
+      await waitForRecentTransactionConfirmation(
+        abortSignal: AbortController().signal,
+        commitment: Commitment.finalized,
+        getBlockHeightExceedencePromise: getBlockHeightExceedencePromise,
+        getRecentSignatureConfirmationPromise:
+            getRecentSignatureConfirmationPromise,
+        lastValidBlockHeight: BigInt.from(123),
+        signature: 'test_signature',
+      );
+    });
+
+    test('throws when the block height exceedence promise throws', () async {
+      blockHeightExceedenceCompleter.completeError(StateError('o no'));
+
+      await expectLater(
+        waitForRecentTransactionConfirmation(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          getBlockHeightExceedencePromise: getBlockHeightExceedencePromise,
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) {
+                return Completer<void>().future;
+              },
+          lastValidBlockHeight: BigInt.from(123),
+          signature: 'test_signature',
+        ),
+        throwsA(
+          isA<StateError>().having((e) => e.message, 'message', equals('o no')),
+        ),
+      );
+    });
+
+    test('throws when the signature confirmation promise throws', () async {
+      signatureConfirmationCompleter.completeError(StateError('o no'));
+
+      await expectLater(
+        waitForRecentTransactionConfirmation(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          getBlockHeightExceedencePromise:
+              ({
+                required AbortSignal abortSignal,
+                required BigInt lastValidBlockHeight,
+                Commitment? commitment,
+              }) {
+                return Completer<Never>().future;
+              },
+          getRecentSignatureConfirmationPromise:
+              getRecentSignatureConfirmationPromise,
+          lastValidBlockHeight: BigInt.from(123),
+          signature: 'test_signature',
+        ),
+        throwsA(
+          isA<StateError>().having((e) => e.message, 'message', equals('o no')),
+        ),
+      );
+    });
+
+    test(
+      'calls getBlockHeightExceedencePromise with the necessary input',
+      () async {
+        Commitment? capturedCommitment;
+        BigInt? capturedLastValidBlockHeight;
+
+        unawaited(
+          waitForRecentTransactionConfirmation(
+            abortSignal: AbortController().signal,
+            commitment: Commitment.finalized,
+            getBlockHeightExceedencePromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required BigInt lastValidBlockHeight,
+                  Commitment? commitment,
+                }) {
+                  capturedCommitment = commitment;
+                  capturedLastValidBlockHeight = lastValidBlockHeight;
+                  return Completer<Never>().future;
+                },
+            getRecentSignatureConfirmationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String signature,
+                }) {
+                  return Completer<void>().future;
+                },
+            lastValidBlockHeight: BigInt.from(123),
+            signature: 'test_signature',
+          ).catchError((_) {}),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedCommitment, equals(Commitment.finalized));
+        expect(capturedLastValidBlockHeight, equals(BigInt.from(123)));
+      },
+    );
+
+    test(
+      'calls getRecentSignatureConfirmationPromise with the necessary input',
+      () async {
+        String? capturedSignature;
+        Commitment? capturedCommitment;
+
+        unawaited(
+          waitForRecentTransactionConfirmation(
+            abortSignal: AbortController().signal,
+            commitment: Commitment.finalized,
+            getBlockHeightExceedencePromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required BigInt lastValidBlockHeight,
+                  Commitment? commitment,
+                }) {
+                  return Completer<Never>().future;
+                },
+            getRecentSignatureConfirmationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String signature,
+                }) {
+                  capturedSignature = signature;
+                  capturedCommitment = commitment;
+                  return Completer<void>().future;
+                },
+            lastValidBlockHeight: BigInt.from(123),
+            signature: 'test_signature',
+          ).catchError((_) {}),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedSignature, equals('test_signature'));
+        expect(capturedCommitment, equals(Commitment.finalized));
+      },
+    );
+
+    test(
+      'aborts the abort signal passed to strategies when caller aborts',
+      () async {
+        AbortSignal? capturedBlockHeightAbortSignal;
+        AbortSignal? capturedSignatureAbortSignal;
+        final callerAbortController = AbortController();
+
+        unawaited(
+          waitForRecentTransactionConfirmation(
+            abortSignal: callerAbortController.signal,
+            commitment: Commitment.finalized,
+            getBlockHeightExceedencePromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required BigInt lastValidBlockHeight,
+                  Commitment? commitment,
+                }) {
+                  capturedBlockHeightAbortSignal = abortSignal;
+                  return Completer<Never>().future;
+                },
+            getRecentSignatureConfirmationPromise:
+                ({
+                  required AbortSignal abortSignal,
+                  required Commitment commitment,
+                  required String signature,
+                }) {
+                  capturedSignatureAbortSignal = abortSignal;
+                  return Completer<void>().future;
+                },
+            lastValidBlockHeight: BigInt.from(123),
+            signature: 'test_signature',
+          ).catchError((_) {}),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedBlockHeightAbortSignal!.isAborted, isFalse);
+        expect(capturedSignatureAbortSignal!.isAborted, isFalse);
+
+        callerAbortController.abort('test');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(capturedBlockHeightAbortSignal!.isAborted, isTrue);
+        expect(capturedSignatureAbortSignal!.isAborted, isTrue);
+      },
+    );
+  });
+
+  group('waitForRecentTransactionConfirmationUntilTimeout', () {
+    test('throws when the signal is already aborted', () async {
+      final abortController = AbortController()..abort();
+
+      await expectLater(
+        // Deprecated method under test.
+        // ignore: deprecated_member_use_from_same_package
+        waitForRecentTransactionConfirmationUntilTimeout(
+          abortSignal: abortController.signal,
+          commitment: Commitment.finalized,
+          getTimeoutPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+              }) {
+                return Completer<Never>().future;
+              },
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) {
+                return Completer<void>().future;
+              },
+          signature: 'test_signature',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('aborted'),
+          ),
+        ),
+      );
+    });
+
+    test('resolves when the signature confirmation promise resolves '
+        'despite the timeout promise having thrown', () async {
+      final timeoutCompleter = Completer<Never>();
+
+      // Schedule the timeout error to fire asynchronously so the
+      // futures are being listened to before the error occurs.
+      Future<void>.delayed(Duration.zero, () {
+        timeoutCompleter.completeError(StateError('timeout'));
+      }).ignore();
+
+      // Deprecated method under test.
+      // ignore: deprecated_member_use_from_same_package
+      await waitForRecentTransactionConfirmationUntilTimeout(
+        abortSignal: AbortController().signal,
+        commitment: Commitment.finalized,
+        getTimeoutPromise:
+            ({
+              required AbortSignal abortSignal,
+              required Commitment commitment,
+            }) {
+              return timeoutCompleter.future;
+            },
+        getRecentSignatureConfirmationPromise:
+            ({
+              required AbortSignal abortSignal,
+              required Commitment commitment,
+              required String signature,
+            }) async {},
+        signature: 'test_signature',
+      );
+    });
+
+    test('throws when the timeout promise throws', () async {
+      await expectLater(
+        // Deprecated method under test.
+        // ignore: deprecated_member_use_from_same_package
+        waitForRecentTransactionConfirmationUntilTimeout(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          getTimeoutPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+              }) async {
+                throw StateError('o no');
+              },
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) {
+                return Completer<void>().future;
+              },
+          signature: 'test_signature',
+        ),
+        throwsA(
+          isA<StateError>().having((e) => e.message, 'message', equals('o no')),
+        ),
+      );
+    });
+
+    test('throws when the signature confirmation promise throws', () async {
+      await expectLater(
+        // Deprecated method under test.
+        // ignore: deprecated_member_use_from_same_package
+        waitForRecentTransactionConfirmationUntilTimeout(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          getTimeoutPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+              }) {
+                return Completer<Never>().future;
+              },
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) async {
+                throw StateError('o no');
+              },
+          signature: 'test_signature',
+        ),
+        throwsA(
+          isA<StateError>().having((e) => e.message, 'message', equals('o no')),
+        ),
+      );
+    });
+
+    test('calls getTimeoutPromise with the necessary input', () async {
+      Commitment? capturedCommitment;
+
+      unawaited(
+        // Deprecated method under test.
+        // ignore: deprecated_member_use_from_same_package
+        waitForRecentTransactionConfirmationUntilTimeout(
+          abortSignal: AbortController().signal,
+          commitment: Commitment.finalized,
+          getTimeoutPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+              }) {
+                capturedCommitment = commitment;
+                return Completer<Never>().future;
+              },
+          getRecentSignatureConfirmationPromise:
+              ({
+                required AbortSignal abortSignal,
+                required Commitment commitment,
+                required String signature,
+              }) {
+                return Completer<void>().future;
+              },
+          signature: 'test_signature',
+        ).catchError((_) {}),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(capturedCommitment, equals(Commitment.finalized));
+    });
+  });
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -284,9 +284,9 @@
 
 ### solana_kit_transaction_confirmation (~10 source files, ~9 test files)
 
-- [ ] T119 [US4] Port confirmation strategies (blockheight, nonce, signature, timeout) from `.repos/kit/packages/transaction-confirmation/src/` to `packages/solana_kit_transaction_confirmation/lib/src/`
-- [ ] T120 [US4] Update barrel export `packages/solana_kit_transaction_confirmation/lib/solana_kit_transaction_confirmation.dart`
-- [ ] T121 [US4] Port all 9 test files from `.repos/kit/packages/transaction-confirmation/src/__tests__/` to `packages/solana_kit_transaction_confirmation/test/`
+- [x] T119 [US4] Port confirmation strategies (blockheight, nonce, signature, timeout) from `.repos/kit/packages/transaction-confirmation/src/` to `packages/solana_kit_transaction_confirmation/lib/src/`
+- [x] T120 [US4] Update barrel export `packages/solana_kit_transaction_confirmation/lib/solana_kit_transaction_confirmation.dart`
+- [x] T121 [US4] Port all 9 test files from `.repos/kit/packages/transaction-confirmation/src/__tests__/` to `packages/solana_kit_transaction_confirmation/test/`
 
 ### solana_kit_instruction_plans (~8 source files, ~15 test files)
 


### PR DESCRIPTION
## Summary
- Port `@solana/transaction-confirmation` to Dart as `solana_kit_transaction_confirmation`
- Multiple confirmation strategies: signature, block height, nonce, timeout
- Strategy racing with safe future handling for `Future<Never>` at runtime
- High-level waiters: `waitForRecentTransactionConfirmation`, `waitForDurableNonceTransactionConfirmation`
- Dependency injection pattern for RPC functions (minimal dependencies)
- 60 tests passing, all analysis clean

## Test plan
- [x] `dart analyze` passes with no issues
- [x] `dart test` passes (60 tests)
- [x] `dart format` produces no changes
- [x] Changeset file included