### PR TITLE
✨ feat(solana_kit_instruction_plans): implement instruction plans package

### DIFF
--- a/.changeset/instruction-plans.md
+++ b/.changeset/instruction-plans.md
@@ -1,0 +1,19 @@
+---
+solana_kit_instruction_plans: minor
+---
+
+Implement instruction plans package ported from `@solana/instruction-plans`.
+
+**solana_kit_instruction_plans** (215 tests):
+
+- `InstructionPlan` sealed class hierarchy: `SingleInstructionPlan`, `SequentialInstructionPlan`, `ParallelInstructionPlan`, `MessagePackerInstructionPlan`
+- `TransactionPlan` sealed class hierarchy: `SingleTransactionPlan`, `SequentialTransactionPlan`, `ParallelTransactionPlan`
+- `TransactionPlanResult` sealed class hierarchy with successful, failed, canceled, sequential, and parallel result types
+- `createTransactionPlanner` converting instruction plans to transaction plans with size-aware message packing
+- `createTransactionPlanExecutor` for executing transaction plans with context propagation
+- `MessagePacker` with linear, instruction-based, and realloc message packer factories
+- Tree traversal utilities: `findInstructionPlan`, `everyInstructionPlan`, `transformInstructionPlan`, `flattenTransactionPlan`
+- Type guards and assertions for all plan types
+- `appendTransactionMessageInstructionPlan` helper for adding instructions to messages
+- `passthroughFailedTransactionPlanExecution` for error handling passthrough
+- `TransactionPlanResultSummary` with `summarizeTransactionPlanResult` for result aggregation

--- a/packages/solana_kit_instruction_plans/lib/solana_kit_instruction_plans.dart
+++ b/packages/solana_kit_instruction_plans/lib/solana_kit_instruction_plans.dart
@@ -1,1 +1,35 @@
+/// Instruction plans describe operations that go beyond a single instruction
+/// and may even span multiple transactions.
+///
+/// They define a set of instructions that must be executed following a
+/// specific order. For instance, imagine we wanted to create an instruction
+/// plan for a simple escrow transfer between Alice and Bob. First, both
+/// would need to deposit their assets into a vault. This could happen in
+/// any order. Then and only then, the vault can be activated to switch the
+/// assets. Alice and Bob can now both withdraw each other's assets (again,
+/// in any order).
+///
+/// ```dart
+/// final instructionPlan = sequentialInstructionPlan([
+///   parallelInstructionPlan([depositFromAlice, depositFromBob]),
+///   activateVault,
+///   parallelInstructionPlan([withdrawToAlice, withdrawToBob]),
+/// ]);
+/// ```
+///
+/// Instruction plans don't concern themselves with building transaction
+/// messages from these instructions. Instead, they solely focus on
+/// describing operations and delegate all that to two components:
+/// - **Transaction planner**: builds transaction messages from an
+///   instruction plan and returns an appropriate transaction plan.
+/// - **Transaction plan executor**: compiles, signs and sends
+///   transaction plans and returns a detailed result of this operation.
+library;
 
+export 'src/append_instruction_plan.dart';
+export 'src/instruction_plan.dart';
+export 'src/instruction_plan_input.dart';
+export 'src/transaction_plan.dart';
+export 'src/transaction_plan_executor.dart';
+export 'src/transaction_plan_result.dart';
+export 'src/transaction_planner.dart';

--- a/packages/solana_kit_instruction_plans/lib/src/append_instruction_plan.dart
+++ b/packages/solana_kit_instruction_plans/lib/src/append_instruction_plan.dart
@@ -1,0 +1,37 @@
+import 'package:solana_kit_instruction_plans/src/instruction_plan.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+/// Appends all instructions from an instruction plan to a transaction
+/// message.
+///
+/// This function flattens the instruction plan into its leaf plans and
+/// sequentially appends each instruction to the provided transaction
+/// message. It handles both single instructions and message packer plans.
+TransactionMessage appendTransactionMessageInstructionPlan(
+  InstructionPlan instructionPlan,
+  TransactionMessage transactionMessage,
+) {
+  final leafInstructionPlans = flattenInstructionPlan(instructionPlan);
+  var messageSoFar = transactionMessage;
+
+  for (final plan in leafInstructionPlans) {
+    switch (plan) {
+      case SingleInstructionPlan(:final instruction):
+        messageSoFar = appendTransactionMessageInstruction(
+          instruction,
+          messageSoFar,
+        );
+      case MessagePackerInstructionPlan(:final getMessagePacker):
+        final packer = getMessagePacker();
+        while (!packer.done()) {
+          messageSoFar = packer.packMessageToCapacity(messageSoFar);
+        }
+      default:
+        // Should not happen as flattenInstructionPlan only returns
+        // SingleInstructionPlan and MessagePackerInstructionPlan.
+        break;
+    }
+  }
+
+  return messageSoFar;
+}

--- a/packages/solana_kit_instruction_plans/lib/src/instruction_plan.dart
+++ b/packages/solana_kit_instruction_plans/lib/src/instruction_plan.dart
@@ -1,0 +1,506 @@
+import 'dart:math' as math;
+
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// A set of instructions with constraints on how they can be executed.
+///
+/// This is structured as a recursive tree of plans in order to allow for
+/// parallel execution, sequential execution and combinations of both.
+///
+/// The following plans are supported:
+/// - [SingleInstructionPlan] - A plan that contains a single instruction.
+/// - [ParallelInstructionPlan] - A plan that contains other plans that
+///   can be executed in parallel.
+/// - [SequentialInstructionPlan] - A plan that contains other plans that
+///   must be executed sequentially.
+/// - [MessagePackerInstructionPlan] - A plan that can dynamically pack
+///   instructions into transaction messages.
+sealed class InstructionPlan {
+  /// Creates an [InstructionPlan].
+  const InstructionPlan();
+
+  /// The kind discriminator for this instruction plan.
+  String get kind;
+}
+
+/// A plan that contains a single instruction.
+///
+/// This is a simple instruction wrapper and the simplest leaf in the
+/// instruction plan tree.
+class SingleInstructionPlan extends InstructionPlan {
+  /// Creates a [SingleInstructionPlan] wrapping the given [instruction].
+  const SingleInstructionPlan({required this.instruction});
+
+  /// The instruction contained in this plan.
+  final Instruction instruction;
+
+  @override
+  String get kind => 'single';
+}
+
+/// A plan wrapping other plans that must be executed sequentially.
+///
+/// It also defines whether nested plans are [divisible] -- meaning that
+/// the instructions inside them can be split into separate transactions.
+/// When [divisible] is `false`, the instructions inside the plan should
+/// all be executed atomically -- either in a single transaction or in a
+/// transaction bundle.
+class SequentialInstructionPlan extends InstructionPlan {
+  /// Creates a [SequentialInstructionPlan] with the given [plans] and
+  /// [divisible] flag.
+  const SequentialInstructionPlan({required this.plans, this.divisible = true});
+
+  /// The nested plans that must be executed sequentially.
+  final List<InstructionPlan> plans;
+
+  /// Whether the instructions inside this plan can be split into separate
+  /// transactions.
+  final bool divisible;
+
+  @override
+  String get kind => 'sequential';
+}
+
+/// A plan wrapping other plans that can be executed in parallel.
+///
+/// This means direct children of this plan can be executed in separate
+/// parallel transactions without consequence.
+class ParallelInstructionPlan extends InstructionPlan {
+  /// Creates a [ParallelInstructionPlan] with the given [plans].
+  const ParallelInstructionPlan({required this.plans});
+
+  /// The nested plans that can be executed in parallel.
+  final List<InstructionPlan> plans;
+
+  @override
+  String get kind => 'parallel';
+}
+
+/// A plan that can dynamically pack instructions into transaction messages.
+///
+/// This plan provides a [MessagePacker] via the [getMessagePacker]
+/// method, which enables instructions to be dynamically packed into the
+/// provided transaction message until there are no more instructions to pack.
+class MessagePackerInstructionPlan extends InstructionPlan {
+  /// Creates a [MessagePackerInstructionPlan] with the given
+  /// [getMessagePacker] factory.
+  const MessagePackerInstructionPlan({required this.getMessagePacker});
+
+  /// Returns a new [MessagePacker] for this plan.
+  final MessagePacker Function() getMessagePacker;
+
+  @override
+  String get kind => 'messagePacker';
+}
+
+/// The message packer returned by the [MessagePackerInstructionPlan].
+///
+/// It offers a [packMessageToCapacity] method that packs as many instructions
+/// as possible into the provided transaction message, while still being able
+/// to fit into the transaction size limit.
+///
+/// The [done] method checks whether there are more instructions to pack into
+/// transaction messages.
+class MessagePacker {
+  /// Creates a [MessagePacker] with the given [done] and
+  /// [packMessageToCapacity] functions.
+  const MessagePacker({
+    required this.done,
+    required this.packMessageToCapacity,
+  });
+
+  /// Checks whether the message packer has more instructions to pack.
+  final bool Function() done;
+
+  /// Packs the provided transaction message with instructions or throws
+  /// if not possible.
+  ///
+  /// Throws a [SolanaError] with code
+  /// [SolanaErrorCode.instructionPlansMessageCannotAccommodatePlan]
+  /// if the provided transaction message cannot be used to fill the next
+  /// instructions.
+  ///
+  /// Throws a [SolanaError] with code
+  /// [SolanaErrorCode.instructionPlansMessagePackerAlreadyComplete]
+  /// if the message packer is already done and no more instructions can
+  /// be packed.
+  final TransactionMessage Function(TransactionMessage) packMessageToCapacity;
+}
+
+// ---------------------------------------------------------------------------
+// Constructor helpers
+// ---------------------------------------------------------------------------
+
+List<InstructionPlan> _parseSingleInstructionPlans(List<Object> plans) =>
+    List<InstructionPlan>.unmodifiable(
+      plans.map(
+        (plan) => plan is InstructionPlan
+            ? plan
+            : SingleInstructionPlan(instruction: plan as Instruction),
+      ),
+    );
+
+/// Creates a [SingleInstructionPlan] from an [Instruction].
+SingleInstructionPlan singleInstructionPlan(Instruction instruction) =>
+    SingleInstructionPlan(instruction: instruction);
+
+/// Creates a divisible [SequentialInstructionPlan] from an array of nested
+/// plans.
+///
+/// It can accept [Instruction] objects directly, which will be wrapped
+/// in [SingleInstructionPlan]s automatically.
+SequentialInstructionPlan sequentialInstructionPlan(List<Object> plans) =>
+    SequentialInstructionPlan(plans: _parseSingleInstructionPlans(plans));
+
+/// Creates a non-divisible [SequentialInstructionPlan] from an array of
+/// nested plans.
+///
+/// It can accept [Instruction] objects directly, which will be wrapped
+/// in [SingleInstructionPlan]s automatically.
+SequentialInstructionPlan nonDivisibleSequentialInstructionPlan(
+  List<Object> plans,
+) => SequentialInstructionPlan(
+  plans: _parseSingleInstructionPlans(plans),
+  divisible: false,
+);
+
+/// Creates a [ParallelInstructionPlan] from an array of nested plans.
+///
+/// It can accept [Instruction] objects directly, which will be wrapped
+/// in [SingleInstructionPlan]s automatically.
+ParallelInstructionPlan parallelInstructionPlan(List<Object> plans) =>
+    ParallelInstructionPlan(plans: _parseSingleInstructionPlans(plans));
+
+// ---------------------------------------------------------------------------
+// Type checks and assertions
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if [value] is an [InstructionPlan].
+bool isInstructionPlan(Object? value) => value is InstructionPlan;
+
+/// Returns `true` if [plan] is a [SingleInstructionPlan].
+bool isSingleInstructionPlan(InstructionPlan plan) =>
+    plan is SingleInstructionPlan;
+
+/// Asserts that [plan] is a [SingleInstructionPlan].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansUnexpectedInstructionPlan] if the plan
+/// is not a single instruction plan.
+void assertIsSingleInstructionPlan(InstructionPlan plan) {
+  if (plan is! SingleInstructionPlan) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedInstructionPlan,
+      {'actualKind': plan.kind, 'expectedKind': 'single'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a [MessagePackerInstructionPlan].
+bool isMessagePackerInstructionPlan(InstructionPlan plan) =>
+    plan is MessagePackerInstructionPlan;
+
+/// Asserts that [plan] is a [MessagePackerInstructionPlan].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansUnexpectedInstructionPlan] if the plan
+/// is not a message packer instruction plan.
+void assertIsMessagePackerInstructionPlan(InstructionPlan plan) {
+  if (plan is! MessagePackerInstructionPlan) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedInstructionPlan,
+      {'actualKind': plan.kind, 'expectedKind': 'messagePacker'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a [SequentialInstructionPlan].
+bool isSequentialInstructionPlan(InstructionPlan plan) =>
+    plan is SequentialInstructionPlan;
+
+/// Asserts that [plan] is a [SequentialInstructionPlan].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansUnexpectedInstructionPlan] if the plan
+/// is not a sequential instruction plan.
+void assertIsSequentialInstructionPlan(InstructionPlan plan) {
+  if (plan is! SequentialInstructionPlan) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedInstructionPlan,
+      {'actualKind': plan.kind, 'expectedKind': 'sequential'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a non-divisible [SequentialInstructionPlan].
+bool isNonDivisibleSequentialInstructionPlan(InstructionPlan plan) =>
+    plan is SequentialInstructionPlan && !plan.divisible;
+
+/// Asserts that [plan] is a non-divisible [SequentialInstructionPlan].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansUnexpectedInstructionPlan] if the plan
+/// is not a non-divisible sequential instruction plan.
+void assertIsNonDivisibleSequentialInstructionPlan(InstructionPlan plan) {
+  if (plan is! SequentialInstructionPlan || plan.divisible) {
+    final actualKind = plan is SequentialInstructionPlan && plan.divisible
+        ? 'divisible sequential'
+        : plan.kind;
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedInstructionPlan,
+      {'actualKind': actualKind, 'expectedKind': 'non-divisible sequential'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a [ParallelInstructionPlan].
+bool isParallelInstructionPlan(InstructionPlan plan) =>
+    plan is ParallelInstructionPlan;
+
+/// Asserts that [plan] is a [ParallelInstructionPlan].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansUnexpectedInstructionPlan] if the plan
+/// is not a parallel instruction plan.
+void assertIsParallelInstructionPlan(InstructionPlan plan) {
+  if (plan is! ParallelInstructionPlan) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedInstructionPlan,
+      {'actualKind': plan.kind, 'expectedKind': 'parallel'},
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tree helpers
+// ---------------------------------------------------------------------------
+
+/// Finds the first instruction plan in the tree that matches the given
+/// [predicate].
+///
+/// This function performs a depth-first search through the instruction plan
+/// tree, returning the first plan that satisfies the predicate.
+InstructionPlan? findInstructionPlan(
+  InstructionPlan instructionPlan,
+  bool Function(InstructionPlan) predicate,
+) {
+  if (predicate(instructionPlan)) {
+    return instructionPlan;
+  }
+  return switch (instructionPlan) {
+    SingleInstructionPlan() || MessagePackerInstructionPlan() => null,
+    SequentialInstructionPlan(:final plans) ||
+    ParallelInstructionPlan(:final plans) => _findInPlans(plans, predicate),
+  };
+}
+
+InstructionPlan? _findInPlans(
+  List<InstructionPlan> plans,
+  bool Function(InstructionPlan) predicate,
+) {
+  for (final subPlan in plans) {
+    final found = findInstructionPlan(subPlan, predicate);
+    if (found != null) {
+      return found;
+    }
+  }
+  return null;
+}
+
+/// Checks if every instruction plan in the tree satisfies the given
+/// [predicate].
+bool everyInstructionPlan(
+  InstructionPlan instructionPlan,
+  bool Function(InstructionPlan) predicate,
+) {
+  if (!predicate(instructionPlan)) {
+    return false;
+  }
+  return switch (instructionPlan) {
+    SingleInstructionPlan() || MessagePackerInstructionPlan() => true,
+    SequentialInstructionPlan(:final plans) ||
+    ParallelInstructionPlan(
+      :final plans,
+    ) => plans.every((p) => everyInstructionPlan(p, predicate)),
+  };
+}
+
+/// Transforms an instruction plan tree using a bottom-up approach.
+///
+/// Nested plans are transformed first, then the parent plans receive
+/// the already-transformed children before being transformed themselves.
+InstructionPlan transformInstructionPlan(
+  InstructionPlan instructionPlan,
+  InstructionPlan Function(InstructionPlan) fn,
+) => switch (instructionPlan) {
+  SingleInstructionPlan() ||
+  MessagePackerInstructionPlan() => fn(instructionPlan),
+  SequentialInstructionPlan(:final plans, :final divisible) => fn(
+    SequentialInstructionPlan(
+      plans: List<InstructionPlan>.unmodifiable(
+        plans.map((p) => transformInstructionPlan(p, fn)),
+      ),
+      divisible: divisible,
+    ),
+  ),
+  ParallelInstructionPlan(:final plans) => fn(
+    ParallelInstructionPlan(
+      plans: List<InstructionPlan>.unmodifiable(
+        plans.map((p) => transformInstructionPlan(p, fn)),
+      ),
+    ),
+  ),
+};
+
+/// Retrieves all individual [SingleInstructionPlan] and
+/// [MessagePackerInstructionPlan] instances from an instruction plan tree.
+List<InstructionPlan> flattenInstructionPlan(InstructionPlan instructionPlan) =>
+    switch (instructionPlan) {
+      SingleInstructionPlan() ||
+      MessagePackerInstructionPlan() => [instructionPlan],
+      SequentialInstructionPlan(:final plans) ||
+      ParallelInstructionPlan(
+        :final plans,
+      ) => plans.expand(flattenInstructionPlan).toList(),
+    };
+
+// ---------------------------------------------------------------------------
+// Message packer factories
+// ---------------------------------------------------------------------------
+
+/// The realloc limit in bytes (10,240).
+const _reallocLimit = 10240;
+
+/// Creates a [MessagePackerInstructionPlan] that packs instructions
+/// such that each instruction consumes as many bytes as possible from the
+/// given [totalLength] while still being able to fit into the given
+/// transaction messages.
+///
+/// This is particularly useful for instructions that write data to accounts
+/// and must span multiple transactions due to their size limit.
+MessagePackerInstructionPlan getLinearMessagePackerInstructionPlan({
+  required Instruction Function(int offset, int length) getInstruction,
+  required int totalLength,
+}) => MessagePackerInstructionPlan(
+  getMessagePacker: () {
+    var offset = 0;
+    return MessagePacker(
+      done: () => offset >= totalLength,
+      packMessageToCapacity: (TransactionMessage message) {
+        if (offset >= totalLength) {
+          throw SolanaError(
+            SolanaErrorCode.instructionPlansMessagePackerAlreadyComplete,
+          );
+        }
+
+        final messageSizeWithBaseInstruction = getTransactionMessageSize(
+          appendTransactionMessageInstruction(
+            getInstruction(offset, 0),
+            message,
+          ),
+        );
+        // Leeway for shortU16 numbers in transaction headers.
+        final freeSpace =
+            transactionSizeLimit - messageSizeWithBaseInstruction - 1;
+
+        if (freeSpace <= 0) {
+          final messageSize = getTransactionMessageSize(message);
+          throw SolanaError(
+            SolanaErrorCode.instructionPlansMessageCannotAccommodatePlan,
+            {
+              'numBytesRequired':
+                  messageSizeWithBaseInstruction - messageSize + 1,
+              'numFreeBytes': transactionSizeLimit - messageSize - 1,
+            },
+          );
+        }
+
+        final length = math.min(totalLength - offset, freeSpace);
+        final instruction = getInstruction(offset, length);
+        offset += length;
+        return appendTransactionMessageInstruction(instruction, message);
+      },
+    );
+  },
+);
+
+/// Creates a [MessagePackerInstructionPlan] from a list of instructions.
+///
+/// This can be useful to prepare a set of instructions that can be iterated
+/// over -- e.g. to pack a list of instructions that gradually reallocate
+/// the size of an account one `REALLOC_LIMIT` (10,240 bytes) at a time.
+MessagePackerInstructionPlan getMessagePackerInstructionPlanFromInstructions(
+  List<Instruction> instructions,
+) => MessagePackerInstructionPlan(
+  getMessagePacker: () {
+    var instructionIndex = 0;
+    return MessagePacker(
+      done: () => instructionIndex >= instructions.length,
+      packMessageToCapacity: (TransactionMessage message) {
+        if (instructionIndex >= instructions.length) {
+          throw SolanaError(
+            SolanaErrorCode.instructionPlansMessagePackerAlreadyComplete,
+          );
+        }
+
+        final originalMessageSize = getTransactionMessageSize(message);
+        var currentMessage = message;
+
+        for (
+          var index = instructionIndex;
+          index < instructions.length;
+          index++
+        ) {
+          currentMessage = appendTransactionMessageInstruction(
+            instructions[index],
+            currentMessage,
+          );
+          final messageSize = getTransactionMessageSize(currentMessage);
+
+          if (messageSize > transactionSizeLimit) {
+            if (index == instructionIndex) {
+              throw SolanaError(
+                SolanaErrorCode.instructionPlansMessageCannotAccommodatePlan,
+                {
+                  'numBytesRequired': messageSize - originalMessageSize,
+                  'numFreeBytes': transactionSizeLimit - originalMessageSize,
+                },
+              );
+            }
+            instructionIndex = index;
+            return currentMessage;
+          }
+        }
+
+        instructionIndex = instructions.length;
+        return currentMessage;
+      },
+    );
+  },
+);
+
+/// Creates a [MessagePackerInstructionPlan] that packs a list of realloc
+/// instructions.
+///
+/// It splits instruction by chunks of `REALLOC_LIMIT` (10,240) bytes until
+/// the given [totalSize] is reached.
+MessagePackerInstructionPlan getReallocMessagePackerInstructionPlan({
+  required Instruction Function(int size) getInstruction,
+  required int totalSize,
+}) {
+  final numberOfInstructions = (totalSize + _reallocLimit - 1) ~/ _reallocLimit;
+  final lastInstructionSize = totalSize % _reallocLimit;
+  final instructions = List<Instruction>.generate(
+    numberOfInstructions,
+    (i) => getInstruction(
+      i == numberOfInstructions - 1 && lastInstructionSize != 0
+          ? lastInstructionSize
+          : _reallocLimit,
+    ),
+  );
+
+  return getMessagePackerInstructionPlanFromInstructions(instructions);
+}

--- a/packages/solana_kit_instruction_plans/lib/src/instruction_plan_input.dart
+++ b/packages/solana_kit_instruction_plans/lib/src/instruction_plan_input.dart
@@ -1,0 +1,74 @@
+import 'package:solana_kit_instruction_plans/src/instruction_plan.dart';
+import 'package:solana_kit_instruction_plans/src/transaction_plan.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+/// Parses a flexible input and returns an [InstructionPlan].
+///
+/// This function handles the following input types:
+/// - A single [Instruction] is wrapped in a [SingleInstructionPlan].
+/// - An existing [InstructionPlan] is returned as-is.
+/// - A [List] with a single element is unwrapped and parsed recursively.
+/// - A [List] with multiple elements is wrapped in a divisible
+///   [SequentialInstructionPlan].
+InstructionPlan parseInstructionPlanInput(Object input) {
+  if (input is List) {
+    if (input.length == 1) {
+      return parseInstructionPlanInput(input[0] as Object);
+    }
+    return sequentialInstructionPlan(
+      input.map((e) => parseInstructionPlanInput(e as Object)).toList(),
+    );
+  }
+  if (input is InstructionPlan) {
+    return input;
+  }
+  return singleInstructionPlan(input as Instruction);
+}
+
+/// Parses a flexible input and returns a [TransactionPlan].
+///
+/// This function handles the following input types:
+/// - A single [TransactionMessage] is wrapped in a
+///   [SingleTransactionPlan].
+/// - An existing [TransactionPlan] is returned as-is.
+/// - A [List] with a single element is unwrapped and parsed recursively.
+/// - A [List] with multiple elements is wrapped in a divisible
+///   [SequentialTransactionPlan].
+TransactionPlan parseTransactionPlanInput(Object input) {
+  if (input is List) {
+    if (input.length == 1) {
+      return parseTransactionPlanInput(input[0] as Object);
+    }
+    return sequentialTransactionPlan(
+      input.map((e) => parseTransactionPlanInput(e as Object)).toList(),
+    );
+  }
+  if (input is TransactionPlan) {
+    return input;
+  }
+  return singleTransactionPlan(input as TransactionMessage);
+}
+
+/// Parses a flexible input and returns an [InstructionPlan] or
+/// [TransactionPlan].
+///
+/// Automatically detects whether the input represents instructions
+/// or transactions and delegates to the appropriate parser.
+Object parseInstructionOrTransactionPlanInput(Object input) {
+  if (input is List && input.isEmpty) {
+    return parseTransactionPlanInput(input);
+  }
+  if (input is List && _isTransactionPlanInput(input[0] as Object)) {
+    return parseTransactionPlanInput(input);
+  }
+  if (_isTransactionPlanInput(input)) {
+    return parseTransactionPlanInput(input);
+  }
+  return parseInstructionPlanInput(input);
+}
+
+bool _isTransactionPlanInput(Object value) =>
+    value is TransactionPlan || _isTransactionMessage(value);
+
+bool _isTransactionMessage(Object value) => value is TransactionMessage;

--- a/packages/solana_kit_instruction_plans/lib/src/transaction_plan.dart
+++ b/packages/solana_kit_instruction_plans/lib/src/transaction_plan.dart
@@ -1,0 +1,274 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+/// A set of transaction messages with constraints on how they can be executed.
+///
+/// This is structured as a recursive tree of plans to allow for
+/// parallel execution, sequential execution and combinations of both.
+sealed class TransactionPlan {
+  /// Creates a [TransactionPlan].
+  const TransactionPlan();
+
+  /// The kind discriminator for this transaction plan.
+  String get kind;
+}
+
+/// A plan that contains a single transaction message.
+class SingleTransactionPlan extends TransactionPlan {
+  /// Creates a [SingleTransactionPlan] wrapping the given [message].
+  const SingleTransactionPlan({required this.message});
+
+  /// The transaction message contained in this plan.
+  final TransactionMessage message;
+
+  @override
+  String get kind => 'single';
+}
+
+/// A plan wrapping other plans that must be executed sequentially.
+///
+/// It also defines whether nested plans are [divisible] -- meaning that
+/// the transaction messages inside them can be split into separate batches.
+/// When [divisible] is `false`, the transaction messages inside the plan
+/// should all be executed atomically -- usually in a transaction bundle.
+class SequentialTransactionPlan extends TransactionPlan {
+  /// Creates a [SequentialTransactionPlan] with the given [plans] and
+  /// [divisible] flag.
+  const SequentialTransactionPlan({required this.plans, this.divisible = true});
+
+  /// The nested plans that must be executed sequentially.
+  final List<TransactionPlan> plans;
+
+  /// Whether the transaction messages inside this plan can be split into
+  /// separate batches.
+  final bool divisible;
+
+  @override
+  String get kind => 'sequential';
+}
+
+/// A plan wrapping other plans that can be executed in parallel.
+class ParallelTransactionPlan extends TransactionPlan {
+  /// Creates a [ParallelTransactionPlan] with the given [plans].
+  const ParallelTransactionPlan({required this.plans});
+
+  /// The nested plans that can be executed in parallel.
+  final List<TransactionPlan> plans;
+
+  @override
+  String get kind => 'parallel';
+}
+
+// ---------------------------------------------------------------------------
+// Constructor helpers
+// ---------------------------------------------------------------------------
+
+List<TransactionPlan> _parseSingleTransactionPlans(List<Object> plans) =>
+    List<TransactionPlan>.unmodifiable(
+      plans.map(
+        (plan) => plan is TransactionPlan
+            ? plan
+            : SingleTransactionPlan(message: plan as TransactionMessage),
+      ),
+    );
+
+/// Creates a [SingleTransactionPlan] from a [TransactionMessage].
+SingleTransactionPlan singleTransactionPlan(TransactionMessage message) =>
+    SingleTransactionPlan(message: message);
+
+/// Creates a divisible [SequentialTransactionPlan] from an array of nested
+/// plans.
+///
+/// It can accept [TransactionMessage] objects directly, which will be
+/// wrapped in [SingleTransactionPlan]s automatically.
+SequentialTransactionPlan sequentialTransactionPlan(List<Object> plans) =>
+    SequentialTransactionPlan(plans: _parseSingleTransactionPlans(plans));
+
+/// Creates a non-divisible [SequentialTransactionPlan] from an array of
+/// nested plans.
+///
+/// It can accept [TransactionMessage] objects directly, which will be
+/// wrapped in [SingleTransactionPlan]s automatically.
+SequentialTransactionPlan nonDivisibleSequentialTransactionPlan(
+  List<Object> plans,
+) => SequentialTransactionPlan(
+  plans: _parseSingleTransactionPlans(plans),
+  divisible: false,
+);
+
+/// Creates a [ParallelTransactionPlan] from an array of nested plans.
+///
+/// It can accept [TransactionMessage] objects directly, which will be
+/// wrapped in [SingleTransactionPlan]s automatically.
+ParallelTransactionPlan parallelTransactionPlan(List<Object> plans) =>
+    ParallelTransactionPlan(plans: _parseSingleTransactionPlans(plans));
+
+// ---------------------------------------------------------------------------
+// Type checks and assertions
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if [value] is a [TransactionPlan].
+bool isTransactionPlan(Object? value) => value is TransactionPlan;
+
+/// Returns `true` if [plan] is a [SingleTransactionPlan].
+bool isSingleTransactionPlan(TransactionPlan plan) =>
+    plan is SingleTransactionPlan;
+
+/// Asserts that [plan] is a [SingleTransactionPlan].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansUnexpectedTransactionPlan] if the plan
+/// is not a single transaction plan.
+void assertIsSingleTransactionPlan(TransactionPlan plan) {
+  if (plan is! SingleTransactionPlan) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlan,
+      {'actualKind': plan.kind, 'expectedKind': 'single'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a [SequentialTransactionPlan].
+bool isSequentialTransactionPlan(TransactionPlan plan) =>
+    plan is SequentialTransactionPlan;
+
+/// Asserts that [plan] is a [SequentialTransactionPlan].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansUnexpectedTransactionPlan] if the plan
+/// is not a sequential transaction plan.
+void assertIsSequentialTransactionPlan(TransactionPlan plan) {
+  if (plan is! SequentialTransactionPlan) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlan,
+      {'actualKind': plan.kind, 'expectedKind': 'sequential'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a non-divisible [SequentialTransactionPlan].
+bool isNonDivisibleSequentialTransactionPlan(TransactionPlan plan) =>
+    plan is SequentialTransactionPlan && !plan.divisible;
+
+/// Asserts that [plan] is a non-divisible [SequentialTransactionPlan].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansUnexpectedTransactionPlan] if the plan
+/// is not a non-divisible sequential transaction plan.
+void assertIsNonDivisibleSequentialTransactionPlan(TransactionPlan plan) {
+  if (plan is! SequentialTransactionPlan || plan.divisible) {
+    final actualKind = plan is SequentialTransactionPlan && plan.divisible
+        ? 'divisible sequential'
+        : plan.kind;
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlan,
+      {'actualKind': actualKind, 'expectedKind': 'non-divisible sequential'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a [ParallelTransactionPlan].
+bool isParallelTransactionPlan(TransactionPlan plan) =>
+    plan is ParallelTransactionPlan;
+
+/// Asserts that [plan] is a [ParallelTransactionPlan].
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansUnexpectedTransactionPlan] if the plan
+/// is not a parallel transaction plan.
+void assertIsParallelTransactionPlan(TransactionPlan plan) {
+  if (plan is! ParallelTransactionPlan) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlan,
+      {'actualKind': plan.kind, 'expectedKind': 'parallel'},
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tree helpers
+// ---------------------------------------------------------------------------
+
+/// Retrieves all individual [SingleTransactionPlan] instances from a
+/// transaction plan tree.
+List<SingleTransactionPlan> flattenTransactionPlan(
+  TransactionPlan transactionPlan,
+) => switch (transactionPlan) {
+  SingleTransactionPlan() => [transactionPlan],
+  SequentialTransactionPlan(:final plans) ||
+  ParallelTransactionPlan(
+    :final plans,
+  ) => plans.expand(flattenTransactionPlan).toList(),
+};
+
+/// Finds the first transaction plan in the tree that matches the given
+/// [predicate].
+TransactionPlan? findTransactionPlan(
+  TransactionPlan transactionPlan,
+  bool Function(TransactionPlan) predicate,
+) {
+  if (predicate(transactionPlan)) {
+    return transactionPlan;
+  }
+  return switch (transactionPlan) {
+    SingleTransactionPlan() => null,
+    SequentialTransactionPlan(:final plans) ||
+    ParallelTransactionPlan(
+      :final plans,
+    ) => _findInTransactionPlans(plans, predicate),
+  };
+}
+
+TransactionPlan? _findInTransactionPlans(
+  List<TransactionPlan> plans,
+  bool Function(TransactionPlan) predicate,
+) {
+  for (final subPlan in plans) {
+    final found = findTransactionPlan(subPlan, predicate);
+    if (found != null) {
+      return found;
+    }
+  }
+  return null;
+}
+
+/// Checks if every transaction plan in the tree satisfies the given
+/// [predicate].
+bool everyTransactionPlan(
+  TransactionPlan transactionPlan,
+  bool Function(TransactionPlan) predicate,
+) {
+  if (!predicate(transactionPlan)) {
+    return false;
+  }
+  return switch (transactionPlan) {
+    SingleTransactionPlan() => true,
+    SequentialTransactionPlan(:final plans) ||
+    ParallelTransactionPlan(
+      :final plans,
+    ) => plans.every((p) => everyTransactionPlan(p, predicate)),
+  };
+}
+
+/// Transforms a transaction plan tree using a bottom-up approach.
+TransactionPlan transformTransactionPlan(
+  TransactionPlan transactionPlan,
+  TransactionPlan Function(TransactionPlan) fn,
+) => switch (transactionPlan) {
+  SingleTransactionPlan() => fn(transactionPlan),
+  SequentialTransactionPlan(:final plans, :final divisible) => fn(
+    SequentialTransactionPlan(
+      plans: List<TransactionPlan>.unmodifiable(
+        plans.map((p) => transformTransactionPlan(p, fn)),
+      ),
+      divisible: divisible,
+    ),
+  ),
+  ParallelTransactionPlan(:final plans) => fn(
+    ParallelTransactionPlan(
+      plans: List<TransactionPlan>.unmodifiable(
+        plans.map((p) => transformTransactionPlan(p, fn)),
+      ),
+    ),
+  ),
+};

--- a/packages/solana_kit_instruction_plans/lib/src/transaction_plan_executor.dart
+++ b/packages/solana_kit_instruction_plans/lib/src/transaction_plan_executor.dart
@@ -1,0 +1,255 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instruction_plans/src/transaction_plan.dart';
+import 'package:solana_kit_instruction_plans/src/transaction_plan_result.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// Executes a transaction plan and returns the execution results.
+typedef TransactionPlanExecutor =
+    Future<TransactionPlanResult> Function(TransactionPlan transactionPlan);
+
+/// A function called whenever a transaction message must be sent to the
+/// blockchain.
+///
+/// The [context] is a mutable map that can be used to incrementally store
+/// useful data as execution progresses. The callback must return either a
+/// [Signature] or a full [Transaction] object.
+typedef ExecuteTransactionMessage =
+    Future<Object> Function(
+      Map<String, Object?> context,
+      TransactionMessage message,
+    );
+
+/// Configuration object for creating a new transaction plan executor.
+class TransactionPlanExecutorConfig {
+  /// Creates a [TransactionPlanExecutorConfig].
+  const TransactionPlanExecutorConfig({
+    required this.executeTransactionMessage,
+  });
+
+  /// Called whenever a transaction message must be sent to the blockchain.
+  final ExecuteTransactionMessage executeTransactionMessage;
+}
+
+/// Creates a new transaction plan executor based on the provided
+/// configuration.
+///
+/// The executor will traverse the provided [TransactionPlan] sequentially
+/// or in parallel, executing each transaction message using the
+/// [TransactionPlanExecutorConfig.executeTransactionMessage] function.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansFailedToExecuteTransactionPlan]
+/// if any transaction in the plan fails to execute.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansNonDivisibleTransactionPlansNotSupported]
+/// if the transaction plan contains non-divisible sequential plans.
+TransactionPlanExecutor createTransactionPlanExecutor(
+  TransactionPlanExecutorConfig config,
+) {
+  return (TransactionPlan plan) async {
+    // Fail early if there are non-divisible sequential plans.
+    _assertDivisibleSequentialPlansOnly(plan);
+
+    var canceled = false;
+
+    final transactionPlanResult = await _traverse(
+      plan,
+      config,
+      () => canceled,
+      () => canceled = true,
+    );
+
+    if (canceled) {
+      final cause = _findErrorFromTransactionPlanResult(transactionPlanResult);
+      throw SolanaError(
+        SolanaErrorCode.instructionPlansFailedToExecuteTransactionPlan,
+        {'cause': cause},
+      );
+    }
+
+    return transactionPlanResult;
+  };
+}
+
+Future<TransactionPlanResult> _traverse(
+  TransactionPlan transactionPlan,
+  TransactionPlanExecutorConfig config,
+  bool Function() isCanceled,
+  void Function() setCanceled,
+) async {
+  switch (transactionPlan) {
+    case SequentialTransactionPlan():
+      return _traverseSequential(
+        transactionPlan,
+        config,
+        isCanceled,
+        setCanceled,
+      );
+    case ParallelTransactionPlan():
+      return _traverseParallel(
+        transactionPlan,
+        config,
+        isCanceled,
+        setCanceled,
+      );
+    case SingleTransactionPlan():
+      return _traverseSingle(transactionPlan, config, isCanceled, setCanceled);
+  }
+}
+
+Future<TransactionPlanResult> _traverseSequential(
+  SequentialTransactionPlan transactionPlan,
+  TransactionPlanExecutorConfig config,
+  bool Function() isCanceled,
+  void Function() setCanceled,
+) async {
+  if (!transactionPlan.divisible) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansNonDivisibleTransactionPlansNotSupported,
+    );
+  }
+
+  final results = <TransactionPlanResult>[];
+
+  for (final subPlan in transactionPlan.plans) {
+    final result = await _traverse(subPlan, config, isCanceled, setCanceled);
+    results.add(result);
+  }
+
+  return sequentialTransactionPlanResult(results);
+}
+
+Future<TransactionPlanResult> _traverseParallel(
+  ParallelTransactionPlan transactionPlan,
+  TransactionPlanExecutorConfig config,
+  bool Function() isCanceled,
+  void Function() setCanceled,
+) async {
+  final results = await Future.wait(
+    transactionPlan.plans.map(
+      (plan) => _traverse(plan, config, isCanceled, setCanceled),
+    ),
+  );
+  return parallelTransactionPlanResult(results);
+}
+
+Future<TransactionPlanResult> _traverseSingle(
+  SingleTransactionPlan transactionPlan,
+  TransactionPlanExecutorConfig config,
+  bool Function() isCanceled,
+  void Function() setCanceled,
+) async {
+  final context = <String, Object?>{};
+  if (isCanceled()) {
+    return canceledSingleTransactionPlanResult(
+      transactionPlan.message,
+      context,
+    );
+  }
+
+  try {
+    final result = await config.executeTransactionMessage(
+      context,
+      transactionPlan.message,
+    );
+    if (result is String) {
+      return successfulSingleTransactionPlanResult(transactionPlan.message, {
+        ...context,
+        'signature': Signature(result),
+      });
+    }
+    return successfulSingleTransactionPlanResultFromTransaction(
+      transactionPlan.message,
+      result as Transaction,
+      context,
+    );
+  } on Object catch (error) {
+    setCanceled();
+    // If the context contains a transaction but no signature, extract it.
+    final contextWithSignature =
+        context.containsKey('transaction') &&
+            context['transaction'] is Transaction &&
+            !context.containsKey('signature')
+        ? {
+            ...context,
+            'signature': getSignatureFromTransaction(
+              context['transaction']! as Transaction,
+            ),
+          }
+        : context;
+    return failedSingleTransactionPlanResult(
+      transactionPlan.message,
+      error,
+      contextWithSignature,
+    );
+  }
+}
+
+Object? _findErrorFromTransactionPlanResult(TransactionPlanResult result) {
+  switch (result) {
+    case FailedSingleTransactionPlanResult(:final error):
+      return error;
+    case SingleTransactionPlanResult():
+      return null;
+    case SequentialTransactionPlanResult(:final plans):
+    case ParallelTransactionPlanResult(:final plans):
+      for (final plan in plans) {
+        final error = _findErrorFromTransactionPlanResult(plan);
+        if (error != null) {
+          return error;
+        }
+      }
+      return null;
+  }
+}
+
+void _assertDivisibleSequentialPlansOnly(TransactionPlan transactionPlan) {
+  switch (transactionPlan) {
+    case SequentialTransactionPlan(:final divisible, :final plans):
+      if (!divisible) {
+        throw SolanaError(
+          SolanaErrorCode
+              .instructionPlansNonDivisibleTransactionPlansNotSupported,
+        );
+      }
+      for (final subPlan in plans) {
+        _assertDivisibleSequentialPlansOnly(subPlan);
+      }
+    case ParallelTransactionPlan(:final plans):
+      for (final subPlan in plans) {
+        _assertDivisibleSequentialPlansOnly(subPlan);
+      }
+    case SingleTransactionPlan():
+      return;
+  }
+}
+
+/// Wraps a transaction plan execution promise to return a
+/// [TransactionPlanResult] even on execution failure.
+///
+/// When a transaction plan executor throws a
+/// [SolanaErrorCode.instructionPlansFailedToExecuteTransactionPlan]
+/// error, this helper catches it and returns the [TransactionPlanResult]
+/// from the error context instead of throwing.
+Future<TransactionPlanResult> passthroughFailedTransactionPlanExecution(
+  Future<TransactionPlanResult> future,
+) async {
+  try {
+    return await future;
+  } on Object catch (error) {
+    if (isSolanaError(
+      error,
+      SolanaErrorCode.instructionPlansFailedToExecuteTransactionPlan,
+    )) {
+      final solanaError = error as SolanaError;
+      if (solanaError.context.containsKey('transactionPlanResult')) {
+        return solanaError.context['transactionPlanResult']!
+            as TransactionPlanResult;
+      }
+    }
+    rethrow;
+  }
+}

--- a/packages/solana_kit_instruction_plans/lib/src/transaction_plan_result.dart
+++ b/packages/solana_kit_instruction_plans/lib/src/transaction_plan_result.dart
@@ -1,0 +1,503 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// The result of executing a transaction plan.
+///
+/// This is structured as a recursive tree of results that mirrors the
+/// structure of the original transaction plan.
+sealed class TransactionPlanResult {
+  /// Creates a [TransactionPlanResult].
+  const TransactionPlanResult();
+
+  /// The kind discriminator for this transaction plan result.
+  String get kind;
+}
+
+/// The status of a single transaction plan result.
+enum TransactionPlanResultStatus {
+  /// The transaction was successfully executed.
+  successful,
+
+  /// The transaction failed during execution.
+  failed,
+
+  /// The transaction execution was canceled.
+  canceled,
+}
+
+/// A result for a single transaction plan.
+///
+/// This represents the execution result of a single transaction plan and
+/// contains the original transaction message along with its execution status.
+sealed class SingleTransactionPlanResult extends TransactionPlanResult {
+  /// Creates a [SingleTransactionPlanResult].
+  const SingleTransactionPlanResult({
+    required this.plannedMessage,
+    required this.context,
+  });
+
+  /// The original transaction message from the plan.
+  final TransactionMessage plannedMessage;
+
+  /// Context data associated with this result.
+  final Map<String, Object?> context;
+
+  /// The execution status of this transaction.
+  TransactionPlanResultStatus get status;
+
+  @override
+  String get kind => 'single';
+}
+
+/// A successful [SingleTransactionPlanResult].
+///
+/// The [context] will contain at least a `signature` field.
+class SuccessfulSingleTransactionPlanResult
+    extends SingleTransactionPlanResult {
+  /// Creates a [SuccessfulSingleTransactionPlanResult].
+  const SuccessfulSingleTransactionPlanResult({
+    required super.plannedMessage,
+    required super.context,
+  });
+
+  /// The signature of the successfully executed transaction.
+  Signature get signature => context['signature']! as Signature;
+
+  @override
+  TransactionPlanResultStatus get status =>
+      TransactionPlanResultStatus.successful;
+}
+
+/// A failed [SingleTransactionPlanResult].
+class FailedSingleTransactionPlanResult extends SingleTransactionPlanResult {
+  /// Creates a [FailedSingleTransactionPlanResult].
+  const FailedSingleTransactionPlanResult({
+    required super.plannedMessage,
+    required this.error,
+    required super.context,
+  });
+
+  /// The error that caused the transaction to fail.
+  final Object error;
+
+  @override
+  TransactionPlanResultStatus get status => TransactionPlanResultStatus.failed;
+}
+
+/// A canceled [SingleTransactionPlanResult].
+class CanceledSingleTransactionPlanResult extends SingleTransactionPlanResult {
+  /// Creates a [CanceledSingleTransactionPlanResult].
+  const CanceledSingleTransactionPlanResult({
+    required super.plannedMessage,
+    required super.context,
+  });
+
+  @override
+  TransactionPlanResultStatus get status =>
+      TransactionPlanResultStatus.canceled;
+}
+
+/// A result for a sequential transaction plan.
+class SequentialTransactionPlanResult extends TransactionPlanResult {
+  /// Creates a [SequentialTransactionPlanResult].
+  const SequentialTransactionPlanResult({
+    required this.plans,
+    this.divisible = true,
+  });
+
+  /// The child results that were executed sequentially.
+  final List<TransactionPlanResult> plans;
+
+  /// Whether the plan was divisible.
+  final bool divisible;
+
+  @override
+  String get kind => 'sequential';
+}
+
+/// A result for a parallel transaction plan.
+class ParallelTransactionPlanResult extends TransactionPlanResult {
+  /// Creates a [ParallelTransactionPlanResult].
+  const ParallelTransactionPlanResult({required this.plans});
+
+  /// The child results that were executed in parallel.
+  final List<TransactionPlanResult> plans;
+
+  @override
+  String get kind => 'parallel';
+}
+
+// ---------------------------------------------------------------------------
+// Constructor helpers
+// ---------------------------------------------------------------------------
+
+/// Creates a divisible [SequentialTransactionPlanResult].
+SequentialTransactionPlanResult sequentialTransactionPlanResult(
+  List<TransactionPlanResult> plans,
+) => SequentialTransactionPlanResult(plans: plans);
+
+/// Creates a non-divisible [SequentialTransactionPlanResult].
+SequentialTransactionPlanResult nonDivisibleSequentialTransactionPlanResult(
+  List<TransactionPlanResult> plans,
+) => SequentialTransactionPlanResult(plans: plans, divisible: false);
+
+/// Creates a [ParallelTransactionPlanResult].
+ParallelTransactionPlanResult parallelTransactionPlanResult(
+  List<TransactionPlanResult> plans,
+) => ParallelTransactionPlanResult(plans: plans);
+
+/// Creates a successful [SingleTransactionPlanResult] from a transaction
+/// message and a [Transaction].
+SuccessfulSingleTransactionPlanResult
+successfulSingleTransactionPlanResultFromTransaction(
+  TransactionMessage plannedMessage,
+  Transaction transaction, [
+  Map<String, Object?>? context,
+]) {
+  final sig = getSignatureFromTransaction(transaction);
+  return SuccessfulSingleTransactionPlanResult(
+    plannedMessage: plannedMessage,
+    context: Map<String, Object?>.unmodifiable({
+      ...?context,
+      'signature': sig,
+      'transaction': transaction,
+    }),
+  );
+}
+
+/// Creates a successful [SingleTransactionPlanResult] from a transaction
+/// message and a context containing at least a `signature`.
+SuccessfulSingleTransactionPlanResult successfulSingleTransactionPlanResult(
+  TransactionMessage plannedMessage,
+  Map<String, Object?> context,
+) => SuccessfulSingleTransactionPlanResult(
+  plannedMessage: plannedMessage,
+  context: Map<String, Object?>.unmodifiable(context),
+);
+
+/// Creates a failed [SingleTransactionPlanResult] from a transaction
+/// message and an error.
+FailedSingleTransactionPlanResult failedSingleTransactionPlanResult(
+  TransactionMessage plannedMessage,
+  Object error, [
+  Map<String, Object?>? context,
+]) => FailedSingleTransactionPlanResult(
+  plannedMessage: plannedMessage,
+  error: error,
+  context: Map<String, Object?>.unmodifiable(context ?? const {}),
+);
+
+/// Creates a canceled [SingleTransactionPlanResult] from a transaction
+/// message.
+CanceledSingleTransactionPlanResult canceledSingleTransactionPlanResult(
+  TransactionMessage plannedMessage, [
+  Map<String, Object?>? context,
+]) => CanceledSingleTransactionPlanResult(
+  plannedMessage: plannedMessage,
+  context: Map<String, Object?>.unmodifiable(context ?? const {}),
+);
+
+// ---------------------------------------------------------------------------
+// Type checks and assertions
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if [value] is a [TransactionPlanResult].
+bool isTransactionPlanResult(Object? value) => value is TransactionPlanResult;
+
+/// Returns `true` if [plan] is a [SingleTransactionPlanResult].
+bool isSingleTransactionPlanResult(TransactionPlanResult plan) =>
+    plan is SingleTransactionPlanResult;
+
+/// Asserts that [plan] is a [SingleTransactionPlanResult].
+void assertIsSingleTransactionPlanResult(TransactionPlanResult plan) {
+  if (plan is! SingleTransactionPlanResult) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlanResult,
+      {'actualKind': plan.kind, 'expectedKind': 'single'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a successful [SingleTransactionPlanResult].
+bool isSuccessfulSingleTransactionPlanResult(TransactionPlanResult plan) =>
+    plan is SuccessfulSingleTransactionPlanResult;
+
+/// Asserts that [plan] is a successful [SingleTransactionPlanResult].
+void assertIsSuccessfulSingleTransactionPlanResult(TransactionPlanResult plan) {
+  if (plan is! SuccessfulSingleTransactionPlanResult) {
+    final actualKind = plan is SingleTransactionPlanResult
+        ? '${plan.status.name} single'
+        : plan.kind;
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlanResult,
+      {'actualKind': actualKind, 'expectedKind': 'successful single'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a failed [SingleTransactionPlanResult].
+bool isFailedSingleTransactionPlanResult(TransactionPlanResult plan) =>
+    plan is FailedSingleTransactionPlanResult;
+
+/// Asserts that [plan] is a failed [SingleTransactionPlanResult].
+void assertIsFailedSingleTransactionPlanResult(TransactionPlanResult plan) {
+  if (plan is! FailedSingleTransactionPlanResult) {
+    final actualKind = plan is SingleTransactionPlanResult
+        ? '${plan.status.name} single'
+        : plan.kind;
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlanResult,
+      {'actualKind': actualKind, 'expectedKind': 'failed single'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a canceled [SingleTransactionPlanResult].
+bool isCanceledSingleTransactionPlanResult(TransactionPlanResult plan) =>
+    plan is CanceledSingleTransactionPlanResult;
+
+/// Asserts that [plan] is a canceled [SingleTransactionPlanResult].
+void assertIsCanceledSingleTransactionPlanResult(TransactionPlanResult plan) {
+  if (plan is! CanceledSingleTransactionPlanResult) {
+    final actualKind = plan is SingleTransactionPlanResult
+        ? '${plan.status.name} single'
+        : plan.kind;
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlanResult,
+      {'actualKind': actualKind, 'expectedKind': 'canceled single'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a [SequentialTransactionPlanResult].
+bool isSequentialTransactionPlanResult(TransactionPlanResult plan) =>
+    plan is SequentialTransactionPlanResult;
+
+/// Asserts that [plan] is a [SequentialTransactionPlanResult].
+void assertIsSequentialTransactionPlanResult(TransactionPlanResult plan) {
+  if (plan is! SequentialTransactionPlanResult) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlanResult,
+      {'actualKind': plan.kind, 'expectedKind': 'sequential'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a non-divisible
+/// [SequentialTransactionPlanResult].
+bool isNonDivisibleSequentialTransactionPlanResult(
+  TransactionPlanResult plan,
+) => plan is SequentialTransactionPlanResult && !plan.divisible;
+
+/// Asserts that [plan] is a non-divisible
+/// [SequentialTransactionPlanResult].
+void assertIsNonDivisibleSequentialTransactionPlanResult(
+  TransactionPlanResult plan,
+) {
+  if (plan is! SequentialTransactionPlanResult || plan.divisible) {
+    final actualKind = plan is SequentialTransactionPlanResult && plan.divisible
+        ? 'divisible sequential'
+        : plan.kind;
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlanResult,
+      {'actualKind': actualKind, 'expectedKind': 'non-divisible sequential'},
+    );
+  }
+}
+
+/// Returns `true` if [plan] is a [ParallelTransactionPlanResult].
+bool isParallelTransactionPlanResult(TransactionPlanResult plan) =>
+    plan is ParallelTransactionPlanResult;
+
+/// Asserts that [plan] is a [ParallelTransactionPlanResult].
+void assertIsParallelTransactionPlanResult(TransactionPlanResult plan) {
+  if (plan is! ParallelTransactionPlanResult) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansUnexpectedTransactionPlanResult,
+      {'actualKind': plan.kind, 'expectedKind': 'parallel'},
+    );
+  }
+}
+
+/// Returns `true` if the entire transaction plan result tree contains only
+/// successful single transaction results.
+bool isSuccessfulTransactionPlanResult(TransactionPlanResult plan) =>
+    everyTransactionPlanResult(
+      plan,
+      (r) =>
+          r is! SingleTransactionPlanResult ||
+          r is SuccessfulSingleTransactionPlanResult,
+    );
+
+/// Asserts that the entire transaction plan result tree contains only
+/// successful single transaction results.
+void assertIsSuccessfulTransactionPlanResult(TransactionPlanResult plan) {
+  if (!isSuccessfulTransactionPlanResult(plan)) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansExpectedSuccessfulTransactionPlanResult,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tree helpers
+// ---------------------------------------------------------------------------
+
+/// Finds the first transaction plan result in the tree that matches the
+/// given [predicate].
+TransactionPlanResult? findTransactionPlanResult(
+  TransactionPlanResult transactionPlanResult,
+  bool Function(TransactionPlanResult) predicate,
+) {
+  if (predicate(transactionPlanResult)) {
+    return transactionPlanResult;
+  }
+  return switch (transactionPlanResult) {
+    SingleTransactionPlanResult() => null,
+    SequentialTransactionPlanResult(:final plans) ||
+    ParallelTransactionPlanResult(
+      :final plans,
+    ) => _findInResultPlans(plans, predicate),
+  };
+}
+
+TransactionPlanResult? _findInResultPlans(
+  List<TransactionPlanResult> plans,
+  bool Function(TransactionPlanResult) predicate,
+) {
+  for (final subResult in plans) {
+    final found = findTransactionPlanResult(subResult, predicate);
+    if (found != null) {
+      return found;
+    }
+  }
+  return null;
+}
+
+/// Retrieves the first failed transaction plan result from a transaction
+/// plan result tree.
+///
+/// Throws a [SolanaError] with code
+/// [SolanaErrorCode.instructionPlansFailedSingleTransactionPlanResultNotFound]
+/// if no failed result is found.
+FailedSingleTransactionPlanResult getFirstFailedSingleTransactionPlanResult(
+  TransactionPlanResult transactionPlanResult,
+) {
+  final result = findTransactionPlanResult(
+    transactionPlanResult,
+    (r) => r is FailedSingleTransactionPlanResult,
+  );
+
+  if (result == null) {
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansFailedSingleTransactionPlanResultNotFound,
+    );
+  }
+
+  return result as FailedSingleTransactionPlanResult;
+}
+
+/// Checks if every transaction plan result in the tree satisfies the given
+/// [predicate].
+bool everyTransactionPlanResult(
+  TransactionPlanResult transactionPlanResult,
+  bool Function(TransactionPlanResult) predicate,
+) {
+  if (!predicate(transactionPlanResult)) {
+    return false;
+  }
+  return switch (transactionPlanResult) {
+    SingleTransactionPlanResult() => true,
+    SequentialTransactionPlanResult(:final plans) ||
+    ParallelTransactionPlanResult(
+      :final plans,
+    ) => plans.every((p) => everyTransactionPlanResult(p, predicate)),
+  };
+}
+
+/// Transforms a transaction plan result tree using a bottom-up approach.
+TransactionPlanResult transformTransactionPlanResult(
+  TransactionPlanResult transactionPlanResult,
+  TransactionPlanResult Function(TransactionPlanResult) fn,
+) => switch (transactionPlanResult) {
+  SingleTransactionPlanResult() => fn(transactionPlanResult),
+  SequentialTransactionPlanResult(:final plans, :final divisible) => fn(
+    SequentialTransactionPlanResult(
+      plans: plans.map((p) => transformTransactionPlanResult(p, fn)).toList(),
+      divisible: divisible,
+    ),
+  ),
+  ParallelTransactionPlanResult(:final plans) => fn(
+    ParallelTransactionPlanResult(
+      plans: plans.map((p) => transformTransactionPlanResult(p, fn)).toList(),
+    ),
+  ),
+};
+
+/// Retrieves all individual [SingleTransactionPlanResult] instances from a
+/// transaction plan result tree.
+List<SingleTransactionPlanResult> flattenTransactionPlanResult(
+  TransactionPlanResult result,
+) => switch (result) {
+  SingleTransactionPlanResult() => [result],
+  SequentialTransactionPlanResult(:final plans) ||
+  ParallelTransactionPlanResult(
+    :final plans,
+  ) => plans.expand(flattenTransactionPlanResult).toList(),
+};
+
+/// A summary of a [TransactionPlanResult], categorizing transactions by
+/// their execution status.
+class TransactionPlanResultSummary {
+  /// Creates a [TransactionPlanResultSummary].
+  const TransactionPlanResultSummary({
+    required this.successful,
+    required this.successfulTransactions,
+    required this.failedTransactions,
+    required this.canceledTransactions,
+  });
+
+  /// Whether all transactions were successful.
+  final bool successful;
+
+  /// The list of successful transactions.
+  final List<SuccessfulSingleTransactionPlanResult> successfulTransactions;
+
+  /// The list of failed transactions.
+  final List<FailedSingleTransactionPlanResult> failedTransactions;
+
+  /// The list of canceled transactions.
+  final List<CanceledSingleTransactionPlanResult> canceledTransactions;
+}
+
+/// Summarizes a [TransactionPlanResult] into a
+/// [TransactionPlanResultSummary].
+TransactionPlanResultSummary summarizeTransactionPlanResult(
+  TransactionPlanResult result,
+) {
+  final successfulTransactions = <SuccessfulSingleTransactionPlanResult>[];
+  final failedTransactions = <FailedSingleTransactionPlanResult>[];
+  final canceledTransactions = <CanceledSingleTransactionPlanResult>[];
+
+  final flattenedResults = flattenTransactionPlanResult(result);
+
+  for (final singleResult in flattenedResults) {
+    switch (singleResult) {
+      case SuccessfulSingleTransactionPlanResult():
+        successfulTransactions.add(singleResult);
+      case FailedSingleTransactionPlanResult():
+        failedTransactions.add(singleResult);
+      case CanceledSingleTransactionPlanResult():
+        canceledTransactions.add(singleResult);
+    }
+  }
+
+  return TransactionPlanResultSummary(
+    successful: failedTransactions.isEmpty && canceledTransactions.isEmpty,
+    successfulTransactions: successfulTransactions,
+    failedTransactions: failedTransactions,
+    canceledTransactions: canceledTransactions,
+  );
+}

--- a/packages/solana_kit_instruction_plans/lib/src/transaction_planner.dart
+++ b/packages/solana_kit_instruction_plans/lib/src/transaction_planner.dart
@@ -1,0 +1,418 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instruction_plans/src/instruction_plan.dart';
+import 'package:solana_kit_instruction_plans/src/transaction_plan.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// Plans one or more transactions according to the provided instruction plan.
+typedef TransactionPlanner =
+    Future<TransactionPlan> Function(InstructionPlan instructionPlan);
+
+/// A function that creates a new transaction message.
+typedef CreateTransactionMessage = Future<TransactionMessage> Function();
+
+/// A function called whenever a transaction message is updated.
+typedef OnTransactionMessageUpdated =
+    Future<TransactionMessage> Function(TransactionMessage message);
+
+/// Configuration object for creating a new transaction planner.
+class TransactionPlannerConfig {
+  /// Creates a [TransactionPlannerConfig].
+  const TransactionPlannerConfig({
+    required this.createTransactionMessage,
+    this.onTransactionMessageUpdated,
+  });
+
+  /// Called whenever a new transaction message is needed.
+  final CreateTransactionMessage createTransactionMessage;
+
+  /// Called whenever a transaction message is updated.
+  final OnTransactionMessageUpdated? onTransactionMessageUpdated;
+}
+
+/// Creates a new transaction planner based on the provided configuration.
+///
+/// At the very least, the [TransactionPlannerConfig.createTransactionMessage]
+/// function must be provided.
+TransactionPlanner createTransactionPlanner(TransactionPlannerConfig config) {
+  return (InstructionPlan instructionPlan) async {
+    final plan = await _traverse(
+      instructionPlan,
+      _TraverseContext(
+        createTransactionMessage: config.createTransactionMessage,
+        onTransactionMessageUpdated:
+            config.onTransactionMessageUpdated ?? (msg) async => msg,
+        parent: null,
+        parentCandidates: [],
+      ),
+    );
+
+    if (plan == null) {
+      throw SolanaError(SolanaErrorCode.instructionPlansEmptyInstructionPlan);
+    }
+
+    return _freezeTransactionPlan(plan);
+  };
+}
+
+class _MutableSingleTransactionPlan {
+  _MutableSingleTransactionPlan({required this.message});
+  TransactionMessage message;
+}
+
+class _TraverseContext {
+  _TraverseContext({
+    required this.createTransactionMessage,
+    required this.onTransactionMessageUpdated,
+    required this.parent,
+    required this.parentCandidates,
+  });
+
+  final CreateTransactionMessage createTransactionMessage;
+  final OnTransactionMessageUpdated onTransactionMessageUpdated;
+  final InstructionPlan? parent;
+  final List<_MutableSingleTransactionPlan> parentCandidates;
+}
+
+sealed class _MutableTransactionPlan {}
+
+class _MutableSingle extends _MutableTransactionPlan {
+  _MutableSingle({required this.candidate});
+  final _MutableSingleTransactionPlan candidate;
+}
+
+class _MutableSequential extends _MutableTransactionPlan {
+  _MutableSequential({required this.plans, required this.divisible});
+  final List<_MutableTransactionPlan> plans;
+  final bool divisible;
+}
+
+class _MutableParallel extends _MutableTransactionPlan {
+  _MutableParallel({required this.plans});
+  final List<_MutableTransactionPlan> plans;
+}
+
+Future<_MutableTransactionPlan?> _traverse(
+  InstructionPlan instructionPlan,
+  _TraverseContext context,
+) async {
+  switch (instructionPlan) {
+    case SequentialInstructionPlan():
+      return _traverseSequential(instructionPlan, context);
+    case ParallelInstructionPlan():
+      return _traverseParallel(instructionPlan, context);
+    case SingleInstructionPlan():
+      return _traverseSingle(instructionPlan, context);
+    case MessagePackerInstructionPlan():
+      return _traverseMessagePacker(instructionPlan, context);
+  }
+}
+
+Future<_MutableTransactionPlan?> _traverseSequential(
+  SequentialInstructionPlan instructionPlan,
+  _TraverseContext context,
+) async {
+  _MutableSingleTransactionPlan? candidate;
+
+  // Check if the sequential plan must fit entirely in its parent candidates
+  // due to constraints like being inside a parallel plan or not being
+  // divisible.
+  final mustEntirelyFitInParentCandidate =
+      context.parent != null &&
+      (context.parent is ParallelInstructionPlan || !instructionPlan.divisible);
+
+  if (mustEntirelyFitInParentCandidate) {
+    final selectedCandidate = await _selectAndMutateCandidate(
+      context,
+      context.parentCandidates,
+      (message) => _fitEntirePlanInsideMessage(instructionPlan, message),
+    );
+    if (selectedCandidate != null) {
+      return null;
+    }
+  } else {
+    candidate = context.parentCandidates.isNotEmpty
+        ? context.parentCandidates[0]
+        : null;
+  }
+
+  final transactionPlans = <_MutableTransactionPlan>[];
+  for (final plan in instructionPlan.plans) {
+    final transactionPlan = await _traverse(
+      plan,
+      _TraverseContext(
+        createTransactionMessage: context.createTransactionMessage,
+        onTransactionMessageUpdated: context.onTransactionMessageUpdated,
+        parent: instructionPlan,
+        parentCandidates: candidate != null ? [candidate] : [],
+      ),
+    );
+    if (transactionPlan != null) {
+      candidate = _getSequentialCandidate(transactionPlan);
+      final isFlattened =
+          transactionPlan is _MutableSequential &&
+          (transactionPlan.divisible || !instructionPlan.divisible);
+      if (isFlattened) {
+        transactionPlans.addAll(transactionPlan.plans);
+      } else {
+        transactionPlans.add(transactionPlan);
+      }
+    }
+  }
+
+  if (transactionPlans.length == 1) {
+    return transactionPlans[0];
+  }
+  if (transactionPlans.isEmpty) {
+    return null;
+  }
+  return _MutableSequential(
+    plans: transactionPlans,
+    divisible: instructionPlan.divisible,
+  );
+}
+
+Future<_MutableTransactionPlan?> _traverseParallel(
+  ParallelInstructionPlan instructionPlan,
+  _TraverseContext context,
+) async {
+  final candidates = <_MutableSingleTransactionPlan>[
+    ...context.parentCandidates,
+  ];
+  final transactionPlans = <_MutableTransactionPlan>[];
+
+  // Reorder children so message packer plans are last.
+  final sortedChildren = List<InstructionPlan>.from(instructionPlan.plans)
+    ..sort(
+      (a, b) =>
+          (a is MessagePackerInstructionPlan ? 1 : 0) -
+          (b is MessagePackerInstructionPlan ? 1 : 0),
+    );
+
+  for (final plan in sortedChildren) {
+    final transactionPlan = await _traverse(
+      plan,
+      _TraverseContext(
+        createTransactionMessage: context.createTransactionMessage,
+        onTransactionMessageUpdated: context.onTransactionMessageUpdated,
+        parent: instructionPlan,
+        parentCandidates: candidates,
+      ),
+    );
+    if (transactionPlan != null) {
+      candidates.addAll(_getParallelCandidates(transactionPlan));
+      if (transactionPlan is _MutableParallel) {
+        transactionPlans.addAll(transactionPlan.plans);
+      } else {
+        transactionPlans.add(transactionPlan);
+      }
+    }
+  }
+
+  if (transactionPlans.length == 1) {
+    return transactionPlans[0];
+  }
+  if (transactionPlans.isEmpty) {
+    return null;
+  }
+  return _MutableParallel(plans: transactionPlans);
+}
+
+Future<_MutableTransactionPlan?> _traverseSingle(
+  SingleInstructionPlan instructionPlan,
+  _TraverseContext context,
+) async {
+  TransactionMessage predicate(TransactionMessage message) =>
+      appendTransactionMessageInstructions([
+        instructionPlan.instruction,
+      ], message);
+
+  final candidate = await _selectAndMutateCandidate(
+    context,
+    context.parentCandidates,
+    predicate,
+  );
+  if (candidate != null) {
+    return null;
+  }
+  final message = await _createNewMessage(context, predicate);
+  return _MutableSingle(
+    candidate: _MutableSingleTransactionPlan(message: message),
+  );
+}
+
+Future<_MutableTransactionPlan?> _traverseMessagePacker(
+  MessagePackerInstructionPlan instructionPlan,
+  _TraverseContext context,
+) async {
+  final messagePacker = instructionPlan.getMessagePacker();
+  final transactionPlans = <_MutableSingle>[];
+  final candidates = <_MutableSingleTransactionPlan>[
+    ...context.parentCandidates,
+  ];
+
+  while (!messagePacker.done()) {
+    final candidate = await _selectAndMutateCandidate(
+      context,
+      candidates,
+      messagePacker.packMessageToCapacity,
+    );
+    if (candidate == null) {
+      final message = await _createNewMessage(
+        context,
+        messagePacker.packMessageToCapacity,
+      );
+      final newCandidate = _MutableSingleTransactionPlan(message: message);
+      final newPlan = _MutableSingle(candidate: newCandidate);
+      transactionPlans.add(newPlan);
+    }
+  }
+
+  if (transactionPlans.length == 1) {
+    return transactionPlans[0];
+  }
+  if (transactionPlans.isEmpty) {
+    return null;
+  }
+  if (context.parent is ParallelInstructionPlan) {
+    return _MutableParallel(plans: transactionPlans);
+  }
+  return _MutableSequential(
+    plans: transactionPlans,
+    divisible:
+        context.parent is! SequentialInstructionPlan ||
+        (context.parent! as SequentialInstructionPlan).divisible,
+  );
+}
+
+_MutableSingleTransactionPlan? _getSequentialCandidate(
+  _MutableTransactionPlan latestPlan,
+) {
+  if (latestPlan is _MutableSingle) {
+    return latestPlan.candidate;
+  }
+  if (latestPlan is _MutableSequential && latestPlan.plans.isNotEmpty) {
+    return _getSequentialCandidate(
+      latestPlan.plans[latestPlan.plans.length - 1],
+    );
+  }
+  return null;
+}
+
+List<_MutableSingleTransactionPlan> _getParallelCandidates(
+  _MutableTransactionPlan latestPlan,
+) {
+  if (latestPlan is _MutableSingle) {
+    return [latestPlan.candidate];
+  }
+  if (latestPlan is _MutableSequential) {
+    return latestPlan.plans.expand(_getParallelCandidates).toList();
+  }
+  if (latestPlan is _MutableParallel) {
+    return latestPlan.plans.expand(_getParallelCandidates).toList();
+  }
+  return [];
+}
+
+Future<_MutableSingleTransactionPlan?> _selectAndMutateCandidate(
+  _TraverseContext context,
+  List<_MutableSingleTransactionPlan> candidates,
+  TransactionMessage Function(TransactionMessage) predicate,
+) async {
+  for (final candidate in candidates) {
+    try {
+      final updatedMessage = predicate(candidate.message);
+      final message = await context.onTransactionMessageUpdated(updatedMessage);
+      if (getTransactionMessageSize(message) <= transactionSizeLimit) {
+        candidate.message = message;
+        return candidate;
+      }
+    } on Object catch (error) {
+      if (isSolanaError(
+        error,
+        SolanaErrorCode.instructionPlansMessageCannotAccommodatePlan,
+      )) {
+        // Try the next candidate.
+        continue;
+      }
+      rethrow;
+    }
+  }
+  return null;
+}
+
+Future<TransactionMessage> _createNewMessage(
+  _TraverseContext context,
+  TransactionMessage Function(TransactionMessage) predicate,
+) async {
+  final newMessage = await context.createTransactionMessage();
+  final updatedMessage = await context.onTransactionMessageUpdated(
+    predicate(newMessage),
+  );
+  final updatedMessageSize = getTransactionMessageSize(updatedMessage);
+  if (updatedMessageSize > transactionSizeLimit) {
+    final newMessageSize = getTransactionMessageSize(newMessage);
+    throw SolanaError(
+      SolanaErrorCode.instructionPlansMessageCannotAccommodatePlan,
+      {
+        'numBytesRequired': updatedMessageSize - newMessageSize,
+        'numFreeBytes': transactionSizeLimit - newMessageSize,
+      },
+    );
+  }
+  return updatedMessage;
+}
+
+TransactionPlan _freezeTransactionPlan(_MutableTransactionPlan plan) {
+  switch (plan) {
+    case _MutableSingle(:final candidate):
+      return singleTransactionPlan(candidate.message);
+    case _MutableSequential(:final plans, :final divisible):
+      final frozenPlans = plans.map(_freezeTransactionPlan).toList();
+      return divisible
+          ? sequentialTransactionPlan(frozenPlans)
+          : nonDivisibleSequentialTransactionPlan(frozenPlans);
+    case _MutableParallel(:final plans):
+      return parallelTransactionPlan(
+        plans.map(_freezeTransactionPlan).toList(),
+      );
+  }
+}
+
+TransactionMessage _fitEntirePlanInsideMessage(
+  InstructionPlan instructionPlan,
+  TransactionMessage message,
+) {
+  switch (instructionPlan) {
+    case SequentialInstructionPlan(:final plans):
+    case ParallelInstructionPlan(:final plans):
+      var newMessage = message;
+      for (final plan in plans) {
+        newMessage = _fitEntirePlanInsideMessage(plan, newMessage);
+      }
+      return newMessage;
+    case SingleInstructionPlan(:final instruction):
+      final newMessage = appendTransactionMessageInstructions([
+        instruction,
+      ], message);
+      final newMessageSize = getTransactionMessageSize(newMessage);
+      if (newMessageSize > transactionSizeLimit) {
+        final baseMessageSize = getTransactionMessageSize(message);
+        throw SolanaError(
+          SolanaErrorCode.instructionPlansMessageCannotAccommodatePlan,
+          {
+            'numBytesRequired': newMessageSize - baseMessageSize,
+            'numFreeBytes': transactionSizeLimit - baseMessageSize,
+          },
+        );
+      }
+      return newMessage;
+    case MessagePackerInstructionPlan(:final getMessagePacker):
+      final packer = getMessagePacker();
+      var newMessage = message;
+      while (!packer.done()) {
+        newMessage = packer.packMessageToCapacity(newMessage);
+      }
+      return newMessage;
+  }
+}

--- a/packages/solana_kit_instruction_plans/pubspec.yaml
+++ b/packages/solana_kit_instruction_plans/pubspec.yaml
@@ -10,6 +10,11 @@ resolution: workspace
 dependencies:
   solana_kit_errors:
   solana_kit_instructions:
+  solana_kit_keys:
+  solana_kit_transaction_messages:
+  solana_kit_transactions:
 
 dev_dependencies:
+  solana_kit_addresses:
   solana_kit_lints:
+  test: ^1.25.8

--- a/packages/solana_kit_instruction_plans/test/append_instruction_plan_test.dart
+++ b/packages/solana_kit_instruction_plans/test/append_instruction_plan_test.dart
@@ -1,0 +1,120 @@
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('appendTransactionMessageInstructionPlan', () {
+    test('appends a single instruction to a message', () {
+      final instruction = createInstruction('A');
+      final plan = singleInstructionPlan(instruction);
+      final message = createMessage();
+
+      final result = appendTransactionMessageInstructionPlan(plan, message);
+
+      expect(result.instructions, hasLength(1));
+      expect(result.instructions[0], same(instruction));
+    });
+
+    test('appends instructions from a sequential plan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = sequentialInstructionPlan([instructionA, instructionB]);
+      final message = createMessage();
+
+      final result = appendTransactionMessageInstructionPlan(plan, message);
+
+      expect(result.instructions, hasLength(2));
+      expect(result.instructions[0], same(instructionA));
+      expect(result.instructions[1], same(instructionB));
+    });
+
+    test('appends instructions from a parallel plan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = parallelInstructionPlan([instructionA, instructionB]);
+      final message = createMessage();
+
+      final result = appendTransactionMessageInstructionPlan(plan, message);
+
+      expect(result.instructions, hasLength(2));
+    });
+
+    test('appends instructions from a nested plan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final instructionC = createInstruction('C');
+      final plan = sequentialInstructionPlan([
+        instructionA,
+        parallelInstructionPlan([instructionB, instructionC]),
+      ]);
+      final message = createMessage();
+
+      final result = appendTransactionMessageInstructionPlan(plan, message);
+
+      expect(result.instructions, hasLength(3));
+    });
+
+    test('appends instructions from a non-divisible sequential plan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = nonDivisibleSequentialInstructionPlan([
+        instructionA,
+        instructionB,
+      ]);
+      final message = createMessage();
+
+      final result = appendTransactionMessageInstructionPlan(plan, message);
+
+      expect(result.instructions, hasLength(2));
+    });
+
+    test('handles a message packer instruction plan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = getMessagePackerInstructionPlanFromInstructions([
+        instructionA,
+        instructionB,
+      ]);
+      final message = createMessage();
+
+      final result = appendTransactionMessageInstructionPlan(plan, message);
+
+      expect(result.instructions, hasLength(2));
+    });
+
+    test('preserves existing instructions on the message', () {
+      final existingInstruction = createInstruction('existing');
+      final newInstruction = createInstruction('new');
+      final plan = singleInstructionPlan(newInstruction);
+      final message = createMessage().copyWith(
+        instructions: [existingInstruction],
+      );
+
+      final result = appendTransactionMessageInstructionPlan(plan, message);
+
+      expect(result.instructions, hasLength(2));
+      expect(result.instructions[0], same(existingInstruction));
+      expect(result.instructions[1], same(newInstruction));
+    });
+
+    test('handles deeply nested plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final instructionC = createInstruction('C');
+      final instructionD = createInstruction('D');
+      final plan = sequentialInstructionPlan([
+        parallelInstructionPlan([
+          sequentialInstructionPlan([instructionA, instructionB]),
+          instructionC,
+        ]),
+        instructionD,
+      ]);
+      final message = createMessage();
+
+      final result = appendTransactionMessageInstructionPlan(plan, message);
+
+      expect(result.instructions, hasLength(4));
+    });
+  });
+}

--- a/packages/solana_kit_instruction_plans/test/instruction_plan_helpers_test.dart
+++ b/packages/solana_kit_instruction_plans/test/instruction_plan_helpers_test.dart
@@ -1,0 +1,365 @@
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('findInstructionPlan', () {
+    test('returns the plan itself when it matches the predicate', () {
+      final instructionA = createInstruction('A');
+      final plan = singleInstructionPlan(instructionA);
+      final result = findInstructionPlan(plan, (p) => p.kind == 'single');
+      expect(result, same(plan));
+    });
+
+    test('returns null when no plan matches the predicate', () {
+      final instructionA = createInstruction('A');
+      final plan = singleInstructionPlan(instructionA);
+      final result = findInstructionPlan(plan, (p) => p.kind == 'parallel');
+      expect(result, isNull);
+    });
+
+    test('finds a nested plan in a parallel structure', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final nestedSequential = sequentialInstructionPlan([
+        instructionA,
+        instructionB,
+      ]);
+      final plan = parallelInstructionPlan([nestedSequential]);
+      final result = findInstructionPlan(plan, (p) => p.kind == 'sequential');
+      expect(result, same(nestedSequential));
+    });
+
+    test('finds a nested plan in a sequential structure', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final nestedParallel = parallelInstructionPlan([
+        instructionA,
+        instructionB,
+      ]);
+      final plan = sequentialInstructionPlan([nestedParallel]);
+      final result = findInstructionPlan(plan, (p) => p.kind == 'parallel');
+      expect(result, same(nestedParallel));
+    });
+
+    test('returns the first matching plan in top-down order', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final innerSequential = sequentialInstructionPlan([instructionA]);
+      final outerSequential = sequentialInstructionPlan([
+        innerSequential,
+        instructionB,
+      ]);
+      final result = findInstructionPlan(
+        outerSequential,
+        (p) => p.kind == 'sequential',
+      );
+      expect(result, same(outerSequential));
+    });
+
+    test('finds a deeply nested plan', () {
+      final instructionA = createInstruction('A');
+      final deepSingle = singleInstructionPlan(instructionA);
+      final plan = parallelInstructionPlan([
+        sequentialInstructionPlan([
+          parallelInstructionPlan([deepSingle]),
+        ]),
+      ]);
+      final result = findInstructionPlan(plan, (p) => p.kind == 'single');
+      expect(result, same(deepSingle));
+    });
+
+    test('returns null when searching an empty parallel plan', () {
+      final plan = parallelInstructionPlan([]);
+      final result = findInstructionPlan(plan, (p) => p.kind == 'single');
+      expect(result, isNull);
+    });
+
+    test('finds non-divisible sequential plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final nonDivisible = nonDivisibleSequentialInstructionPlan([
+        instructionA,
+        instructionB,
+      ]);
+      final plan = parallelInstructionPlan([
+        sequentialInstructionPlan([createInstruction('C')]),
+        nonDivisible,
+      ]);
+      final result = findInstructionPlan(
+        plan,
+        (p) => p is SequentialInstructionPlan && !p.divisible,
+      );
+      expect(result, same(nonDivisible));
+    });
+
+    test('returns null when searching a messagePacker that does not match', () {
+      final messagePackerPlan = getMessagePackerInstructionPlanFromInstructions(
+        [createInstruction('A')],
+      );
+      final result = findInstructionPlan(
+        messagePackerPlan,
+        (p) => p.kind == 'single',
+      );
+      expect(result, isNull);
+    });
+
+    test('finds a messagePacker plan when it matches the predicate', () {
+      final messagePackerPlan = getMessagePackerInstructionPlanFromInstructions(
+        [createInstruction('A')],
+      );
+      final plan = parallelInstructionPlan([
+        singleInstructionPlan(createInstruction('B')),
+        messagePackerPlan,
+      ]);
+      final result = findInstructionPlan(
+        plan,
+        (p) => p.kind == 'messagePacker',
+      );
+      expect(result, same(messagePackerPlan));
+    });
+  });
+
+  group('everyInstructionPlan', () {
+    test('returns true when all plans match the predicate', () {
+      final plan = sequentialInstructionPlan([
+        sequentialInstructionPlan([]),
+        sequentialInstructionPlan([]),
+      ]);
+      final result = everyInstructionPlan(plan, (p) => p.kind == 'sequential');
+      expect(result, isTrue);
+    });
+
+    test('returns false when at least one plan does not match', () {
+      final plan = sequentialInstructionPlan([
+        parallelInstructionPlan([]),
+        sequentialInstructionPlan([]),
+      ]);
+      final result = everyInstructionPlan(plan, (p) => p.kind == 'sequential');
+      expect(result, isFalse);
+    });
+
+    test('matches single instruction plans', () {
+      final plan = singleInstructionPlan(createInstruction('A'));
+      final result = everyInstructionPlan(plan, (p) => p.kind == 'single');
+      expect(result, isTrue);
+    });
+
+    test('matches message packer instruction plans', () {
+      final plan = getMessagePackerInstructionPlanFromInstructions([
+        createInstruction('A'),
+      ]);
+      final result = everyInstructionPlan(
+        plan,
+        (p) => p.kind == 'messagePacker',
+      );
+      expect(result, isTrue);
+    });
+
+    test('fails fast before evaluating children', () {
+      var callCount = 0;
+      final plan = sequentialInstructionPlan([
+        singleInstructionPlan(createInstruction('A')),
+        singleInstructionPlan(createInstruction('B')),
+      ]);
+      final result = everyInstructionPlan(plan, (p) {
+        callCount++;
+        return false;
+      });
+      expect(result, isFalse);
+      expect(callCount, 1);
+    });
+
+    test('fails fast before evaluating siblings', () {
+      var callCount = 0;
+      final plan = sequentialInstructionPlan([
+        singleInstructionPlan(createInstruction('A')),
+        singleInstructionPlan(createInstruction('B')),
+      ]);
+      final result = everyInstructionPlan(plan, (p) {
+        callCount++;
+        // First call (sequential) returns true, second call (first child)
+        // returns false.
+        return callCount <= 1;
+      });
+      expect(result, isFalse);
+      // Called for: sequential, first child single (fails)
+      expect(callCount, 2);
+    });
+  });
+
+  group('transformInstructionPlan', () {
+    test('transforms single instruction plans', () {
+      final plan = singleInstructionPlan(createInstruction('A'));
+      final newInstruction = createInstruction('NewA');
+      final transformedPlan = transformInstructionPlan(plan, (p) {
+        if (p is SingleInstructionPlan) {
+          return singleInstructionPlan(newInstruction);
+        }
+        return p;
+      });
+
+      expect(transformedPlan, isA<SingleInstructionPlan>());
+      expect(
+        (transformedPlan as SingleInstructionPlan).instruction,
+        same(newInstruction),
+      );
+    });
+
+    test('transforms sequential instruction plans', () {
+      final plan = sequentialInstructionPlan([
+        createInstruction('A'),
+        createInstruction('B'),
+      ]);
+      final transformedPlan = transformInstructionPlan(plan, (p) {
+        if (p is SequentialInstructionPlan) {
+          return SequentialInstructionPlan(
+            plans: p.plans.reversed.toList(),
+            divisible: p.divisible,
+          );
+        }
+        return p;
+      });
+
+      expect(transformedPlan, isA<SequentialInstructionPlan>());
+      final seqPlan = transformedPlan as SequentialInstructionPlan;
+      expect(seqPlan.plans, hasLength(2));
+    });
+
+    test('transforms parallel instruction plans', () {
+      final plan = parallelInstructionPlan([
+        createInstruction('A'),
+        createInstruction('B'),
+      ]);
+      final transformedPlan = transformInstructionPlan(plan, (p) {
+        if (p is ParallelInstructionPlan) {
+          return ParallelInstructionPlan(plans: p.plans.reversed.toList());
+        }
+        return p;
+      });
+
+      expect(transformedPlan, isA<ParallelInstructionPlan>());
+    });
+
+    test('transforms using a bottom-up approach', () {
+      final plan = sequentialInstructionPlan([
+        createInstruction('A'),
+        sequentialInstructionPlan([
+          createInstruction('B'),
+          createInstruction('C'),
+        ]),
+      ]);
+
+      final seenKinds = <String>[];
+      transformInstructionPlan(plan, (p) {
+        seenKinds.add(p.kind);
+        return p;
+      });
+
+      // Bottom-up: inner single A, inner single B, inner single C,
+      // inner sequential [B,C], outer sequential
+      expect(seenKinds, contains('single'));
+      expect(seenKinds, contains('sequential'));
+    });
+
+    test('can be used to duplicate instructions', () {
+      final plan = sequentialInstructionPlan([
+        createInstruction('A'),
+        createInstruction('B'),
+      ]);
+      final transformedPlan = transformInstructionPlan(plan, (p) {
+        if (p is SingleInstructionPlan) {
+          return sequentialInstructionPlan([p.instruction, p.instruction]);
+        }
+        return p;
+      });
+
+      expect(transformedPlan, isA<SequentialInstructionPlan>());
+      final seqPlan = transformedPlan as SequentialInstructionPlan;
+      expect(seqPlan.plans, hasLength(2));
+      expect(seqPlan.plans[0], isA<SequentialInstructionPlan>());
+      expect(seqPlan.plans[1], isA<SequentialInstructionPlan>());
+    });
+
+    test('can be used to remove parallelism', () {
+      final plan = parallelInstructionPlan([
+        createInstruction('A'),
+        createInstruction('B'),
+      ]);
+      final transformedPlan = transformInstructionPlan(plan, (p) {
+        if (p is ParallelInstructionPlan) {
+          return sequentialInstructionPlan(p.plans);
+        }
+        return p;
+      });
+
+      expect(transformedPlan, isA<SequentialInstructionPlan>());
+    });
+  });
+
+  group('flattenInstructionPlan', () {
+    test('returns the single plan when given a SingleInstructionPlan', () {
+      final instructionA = createInstruction('A');
+      final plan = singleInstructionPlan(instructionA);
+      final result = flattenInstructionPlan(plan);
+      expect(result, hasLength(1));
+      expect(result[0], same(plan));
+    });
+
+    test(
+      'returns the message packer plan when given a MessagePackerInstructionPlan',
+      () {
+        final plan = getMessagePackerInstructionPlanFromInstructions([
+          createInstruction('A'),
+        ]);
+        final result = flattenInstructionPlan(plan);
+        expect(result, hasLength(1));
+        expect(result[0], same(plan));
+      },
+    );
+
+    test('returns all leaf plans from a ParallelInstructionPlan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = parallelInstructionPlan([instructionA, instructionB]);
+      final result = flattenInstructionPlan(plan);
+      expect(result, hasLength(2));
+      expect(result[0], isA<SingleInstructionPlan>());
+      expect(result[1], isA<SingleInstructionPlan>());
+    });
+
+    test('returns all leaf plans from a SequentialInstructionPlan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = sequentialInstructionPlan([instructionA, instructionB]);
+      final result = flattenInstructionPlan(plan);
+      expect(result, hasLength(2));
+    });
+
+    test('returns all leaf plans from a complex nested structure', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final instructionC = createInstruction('C');
+      final instructionD = createInstruction('D');
+      final instructionE = createInstruction('E');
+      final messagePackerPlan = getMessagePackerInstructionPlanFromInstructions(
+        [createInstruction('F')],
+      );
+      final plan = parallelInstructionPlan([
+        sequentialInstructionPlan([instructionA, instructionB]),
+        nonDivisibleSequentialInstructionPlan([instructionC, instructionD]),
+        instructionE,
+        messagePackerPlan,
+      ]);
+      final result = flattenInstructionPlan(plan);
+      expect(result, hasLength(6));
+      expect(result[0], isA<SingleInstructionPlan>());
+      expect(result[1], isA<SingleInstructionPlan>());
+      expect(result[2], isA<SingleInstructionPlan>());
+      expect(result[3], isA<SingleInstructionPlan>());
+      expect(result[4], isA<SingleInstructionPlan>());
+      expect(result[5], isA<MessagePackerInstructionPlan>());
+    });
+  });
+}

--- a/packages/solana_kit_instruction_plans/test/instruction_plan_input_test.dart
+++ b/packages/solana_kit_instruction_plans/test/instruction_plan_input_test.dart
@@ -1,0 +1,170 @@
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('parseInstructionPlanInput', () {
+    test('wraps a single Instruction in a SingleInstructionPlan', () {
+      final instruction = createInstruction('A');
+      final result = parseInstructionPlanInput(instruction);
+
+      expect(result, isA<SingleInstructionPlan>());
+      expect((result as SingleInstructionPlan).instruction, same(instruction));
+    });
+
+    test('returns an existing InstructionPlan as-is', () {
+      final plan = singleInstructionPlan(createInstruction('A'));
+      final result = parseInstructionPlanInput(plan);
+
+      expect(result, same(plan));
+    });
+
+    test('unwraps a single-element list', () {
+      final instruction = createInstruction('A');
+      final result = parseInstructionPlanInput([instruction]);
+
+      expect(result, isA<SingleInstructionPlan>());
+    });
+
+    test('wraps a multi-element list in a SequentialInstructionPlan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final result = parseInstructionPlanInput([instructionA, instructionB]);
+
+      expect(result, isA<SequentialInstructionPlan>());
+      final seqPlan = result as SequentialInstructionPlan;
+      expect(seqPlan.plans, hasLength(2));
+      expect(seqPlan.divisible, isTrue);
+    });
+
+    test('handles nested lists', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final instructionC = createInstruction('C');
+      final result = parseInstructionPlanInput([
+        instructionA,
+        [instructionB, instructionC],
+      ]);
+
+      expect(result, isA<SequentialInstructionPlan>());
+      final seqPlan = result as SequentialInstructionPlan;
+      expect(seqPlan.plans, hasLength(2));
+      expect(seqPlan.plans[0], isA<SingleInstructionPlan>());
+      expect(seqPlan.plans[1], isA<SequentialInstructionPlan>());
+    });
+
+    test('handles a list with an existing InstructionPlan', () {
+      final instruction = createInstruction('A');
+      final existingPlan = parallelInstructionPlan([createInstruction('B')]);
+      final result = parseInstructionPlanInput([instruction, existingPlan]);
+
+      expect(result, isA<SequentialInstructionPlan>());
+      final seqPlan = result as SequentialInstructionPlan;
+      expect(seqPlan.plans, hasLength(2));
+      expect(seqPlan.plans[0], isA<SingleInstructionPlan>());
+      expect(seqPlan.plans[1], isA<ParallelInstructionPlan>());
+    });
+  });
+
+  group('parseTransactionPlanInput', () {
+    test('wraps a single TransactionMessage in a SingleTransactionPlan', () {
+      final message = createMessage();
+      final result = parseTransactionPlanInput(message);
+
+      expect(result, isA<SingleTransactionPlan>());
+      expect((result as SingleTransactionPlan).message, same(message));
+    });
+
+    test('returns an existing TransactionPlan as-is', () {
+      final plan = singleTransactionPlan(createMessage());
+      final result = parseTransactionPlanInput(plan);
+
+      expect(result, same(plan));
+    });
+
+    test('unwraps a single-element list', () {
+      final message = createMessage();
+      final result = parseTransactionPlanInput([message]);
+
+      expect(result, isA<SingleTransactionPlan>());
+    });
+
+    test('wraps a multi-element list in a SequentialTransactionPlan', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final result = parseTransactionPlanInput([messageA, messageB]);
+
+      expect(result, isA<SequentialTransactionPlan>());
+      final seqPlan = result as SequentialTransactionPlan;
+      expect(seqPlan.plans, hasLength(2));
+      expect(seqPlan.divisible, isTrue);
+    });
+
+    test('handles a list with existing TransactionPlans', () {
+      final message = createMessage();
+      final existingPlan = parallelTransactionPlan([createMessage()]);
+      final result = parseTransactionPlanInput([message, existingPlan]);
+
+      expect(result, isA<SequentialTransactionPlan>());
+      final seqPlan = result as SequentialTransactionPlan;
+      expect(seqPlan.plans, hasLength(2));
+      expect(seqPlan.plans[0], isA<SingleTransactionPlan>());
+      expect(seqPlan.plans[1], isA<ParallelTransactionPlan>());
+    });
+  });
+
+  group('parseInstructionOrTransactionPlanInput', () {
+    test('parses an Instruction as an InstructionPlan', () {
+      final instruction = createInstruction('A');
+      final result = parseInstructionOrTransactionPlanInput(instruction);
+
+      expect(result, isA<InstructionPlan>());
+      expect(result, isA<SingleInstructionPlan>());
+    });
+
+    test('parses a TransactionPlan as a TransactionPlan', () {
+      final plan = singleTransactionPlan(createMessage());
+      final result = parseInstructionOrTransactionPlanInput(plan);
+
+      expect(result, isA<TransactionPlan>());
+      expect(result, same(plan));
+    });
+
+    test('parses a TransactionMessage as a TransactionPlan', () {
+      final message = createMessage();
+      final result = parseInstructionOrTransactionPlanInput(message);
+
+      expect(result, isA<TransactionPlan>());
+      expect(result, isA<SingleTransactionPlan>());
+    });
+
+    test('parses a list of Instructions as an InstructionPlan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final result = parseInstructionOrTransactionPlanInput([
+        instructionA,
+        instructionB,
+      ]);
+
+      expect(result, isA<InstructionPlan>());
+      expect(result, isA<SequentialInstructionPlan>());
+    });
+
+    test('parses a list of TransactionMessages as a TransactionPlan', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final result = parseInstructionOrTransactionPlanInput([
+        messageA,
+        messageB,
+      ]);
+
+      expect(result, isA<TransactionPlan>());
+    });
+
+    test('handles an empty list as TransactionPlan', () {
+      final result = parseInstructionOrTransactionPlanInput(<Object>[]);
+      expect(result, isA<TransactionPlan>());
+    });
+  });
+}

--- a/packages/solana_kit_instruction_plans/test/instruction_plan_test.dart
+++ b/packages/solana_kit_instruction_plans/test/instruction_plan_test.dart
@@ -1,0 +1,435 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('singleInstructionPlan', () {
+    test('creates SingleInstructionPlan objects', () {
+      final instruction = createInstruction('A');
+      final plan = singleInstructionPlan(instruction);
+
+      expect(plan, isA<SingleInstructionPlan>());
+      expect(plan.kind, 'single');
+      expect(plan.instruction, same(instruction));
+    });
+  });
+
+  group('sequentialInstructionPlan', () {
+    test('creates divisible SequentialInstructionPlan from plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = sequentialInstructionPlan([
+        singleInstructionPlan(instructionA),
+        singleInstructionPlan(instructionB),
+      ]);
+
+      expect(plan, isA<SequentialInstructionPlan>());
+      expect(plan.kind, 'sequential');
+      expect(plan.divisible, isTrue);
+      expect(plan.plans, hasLength(2));
+    });
+
+    test('accepts instructions directly and wraps them in single plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = sequentialInstructionPlan([instructionA, instructionB]);
+
+      expect(plan.plans, hasLength(2));
+      expect(plan.plans[0], isA<SingleInstructionPlan>());
+      expect(plan.plans[1], isA<SingleInstructionPlan>());
+      expect(
+        (plan.plans[0] as SingleInstructionPlan).instruction,
+        same(instructionA),
+      );
+    });
+
+    test('can nest other sequential plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final instructionC = createInstruction('C');
+      final plan = sequentialInstructionPlan([
+        instructionA,
+        sequentialInstructionPlan([instructionB, instructionC]),
+      ]);
+
+      expect(plan.plans, hasLength(2));
+      expect(plan.plans[0], isA<SingleInstructionPlan>());
+      expect(plan.plans[1], isA<SequentialInstructionPlan>());
+    });
+
+    test('creates unmodifiable plans list', () {
+      final plan = sequentialInstructionPlan([
+        createInstruction('A'),
+        createInstruction('B'),
+      ]);
+      expect(
+        () => (plan.plans as List).add(
+          singleInstructionPlan(createInstruction('C')),
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('nonDivisibleSequentialInstructionPlan', () {
+    test('creates non-divisible SequentialInstructionPlan', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = nonDivisibleSequentialInstructionPlan([
+        singleInstructionPlan(instructionA),
+        singleInstructionPlan(instructionB),
+      ]);
+
+      expect(plan, isA<SequentialInstructionPlan>());
+      expect(plan.kind, 'sequential');
+      expect(plan.divisible, isFalse);
+      expect(plan.plans, hasLength(2));
+    });
+
+    test('accepts instructions directly and wraps them in single plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = nonDivisibleSequentialInstructionPlan([
+        instructionA,
+        instructionB,
+      ]);
+
+      expect(plan.plans, hasLength(2));
+      expect(plan.plans[0], isA<SingleInstructionPlan>());
+      expect(plan.plans[1], isA<SingleInstructionPlan>());
+    });
+
+    test('can nest other non-divisible sequential plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final instructionC = createInstruction('C');
+      final plan = nonDivisibleSequentialInstructionPlan([
+        instructionA,
+        nonDivisibleSequentialInstructionPlan([instructionB, instructionC]),
+      ]);
+
+      expect(plan.plans, hasLength(2));
+      expect(plan.plans[1], isA<SequentialInstructionPlan>());
+      expect((plan.plans[1] as SequentialInstructionPlan).divisible, isFalse);
+    });
+  });
+
+  group('parallelInstructionPlan', () {
+    test('creates ParallelInstructionPlan from plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = parallelInstructionPlan([
+        singleInstructionPlan(instructionA),
+        singleInstructionPlan(instructionB),
+      ]);
+
+      expect(plan, isA<ParallelInstructionPlan>());
+      expect(plan.kind, 'parallel');
+      expect(plan.plans, hasLength(2));
+    });
+
+    test('accepts instructions directly and wraps them in single plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = parallelInstructionPlan([instructionA, instructionB]);
+
+      expect(plan.plans, hasLength(2));
+      expect(plan.plans[0], isA<SingleInstructionPlan>());
+      expect(plan.plans[1], isA<SingleInstructionPlan>());
+    });
+
+    test('can nest other parallel plans', () {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final instructionC = createInstruction('C');
+      final plan = parallelInstructionPlan([
+        instructionA,
+        parallelInstructionPlan([instructionB, instructionC]),
+      ]);
+
+      expect(plan.plans, hasLength(2));
+      expect(plan.plans[0], isA<SingleInstructionPlan>());
+      expect(plan.plans[1], isA<ParallelInstructionPlan>());
+    });
+  });
+
+  group('isSingleInstructionPlan', () {
+    test('returns true for SingleInstructionPlan', () {
+      expect(
+        isSingleInstructionPlan(singleInstructionPlan(createInstruction('A'))),
+        isTrue,
+      );
+    });
+
+    test('returns false for other plans', () {
+      expect(isSingleInstructionPlan(sequentialInstructionPlan([])), isFalse);
+      expect(
+        isSingleInstructionPlan(nonDivisibleSequentialInstructionPlan([])),
+        isFalse,
+      );
+      expect(isSingleInstructionPlan(parallelInstructionPlan([])), isFalse);
+    });
+  });
+
+  group('assertIsSingleInstructionPlan', () {
+    test('does nothing for SingleInstructionPlan', () {
+      expect(
+        () => assertIsSingleInstructionPlan(
+          singleInstructionPlan(createInstruction('A')),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError for other plans', () {
+      expect(
+        () => assertIsSingleInstructionPlan(sequentialInstructionPlan([])),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionPlansUnexpectedInstructionPlan,
+          ),
+        ),
+      );
+      expect(
+        () => assertIsSingleInstructionPlan(parallelInstructionPlan([])),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+  });
+
+  group('isMessagePackerInstructionPlan', () {
+    test('returns true for MessagePackerInstructionPlan', () {
+      final plan = getMessagePackerInstructionPlanFromInstructions([
+        createInstruction('A'),
+      ]);
+      expect(isMessagePackerInstructionPlan(plan), isTrue);
+    });
+
+    test('returns false for other plans', () {
+      expect(
+        isMessagePackerInstructionPlan(
+          singleInstructionPlan(createInstruction('A')),
+        ),
+        isFalse,
+      );
+      expect(
+        isMessagePackerInstructionPlan(sequentialInstructionPlan([])),
+        isFalse,
+      );
+      expect(
+        isMessagePackerInstructionPlan(parallelInstructionPlan([])),
+        isFalse,
+      );
+    });
+  });
+
+  group('assertIsMessagePackerInstructionPlan', () {
+    test('does nothing for MessagePackerInstructionPlan', () {
+      final plan = getMessagePackerInstructionPlanFromInstructions([
+        createInstruction('A'),
+      ]);
+      expect(() => assertIsMessagePackerInstructionPlan(plan), returnsNormally);
+    });
+
+    test('throws SolanaError for other plans', () {
+      expect(
+        () => assertIsMessagePackerInstructionPlan(
+          singleInstructionPlan(createInstruction('A')),
+        ),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionPlansUnexpectedInstructionPlan,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('isSequentialInstructionPlan', () {
+    test('returns true for SequentialInstructionPlan (divisible or not)', () {
+      expect(
+        isSequentialInstructionPlan(sequentialInstructionPlan([])),
+        isTrue,
+      );
+      expect(
+        isSequentialInstructionPlan(nonDivisibleSequentialInstructionPlan([])),
+        isTrue,
+      );
+    });
+
+    test('returns false for other plans', () {
+      expect(
+        isSequentialInstructionPlan(
+          singleInstructionPlan(createInstruction('A')),
+        ),
+        isFalse,
+      );
+      expect(isSequentialInstructionPlan(parallelInstructionPlan([])), isFalse);
+    });
+  });
+
+  group('assertIsSequentialInstructionPlan', () {
+    test('does nothing for SequentialInstructionPlan', () {
+      expect(
+        () => assertIsSequentialInstructionPlan(sequentialInstructionPlan([])),
+        returnsNormally,
+      );
+      expect(
+        () => assertIsSequentialInstructionPlan(
+          nonDivisibleSequentialInstructionPlan([]),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError for other plans', () {
+      expect(
+        () => assertIsSequentialInstructionPlan(
+          singleInstructionPlan(createInstruction('A')),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+      expect(
+        () => assertIsSequentialInstructionPlan(parallelInstructionPlan([])),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+  });
+
+  group('isNonDivisibleSequentialInstructionPlan', () {
+    test('returns true for non-divisible SequentialInstructionPlan', () {
+      expect(
+        isNonDivisibleSequentialInstructionPlan(
+          nonDivisibleSequentialInstructionPlan([]),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for other plans', () {
+      expect(
+        isNonDivisibleSequentialInstructionPlan(
+          singleInstructionPlan(createInstruction('A')),
+        ),
+        isFalse,
+      );
+      expect(
+        isNonDivisibleSequentialInstructionPlan(sequentialInstructionPlan([])),
+        isFalse,
+      );
+      expect(
+        isNonDivisibleSequentialInstructionPlan(parallelInstructionPlan([])),
+        isFalse,
+      );
+    });
+  });
+
+  group('assertIsNonDivisibleSequentialInstructionPlan', () {
+    test('does nothing for non-divisible SequentialInstructionPlan', () {
+      expect(
+        () => assertIsNonDivisibleSequentialInstructionPlan(
+          nonDivisibleSequentialInstructionPlan([]),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError for divisible sequential plan', () {
+      expect(
+        () => assertIsNonDivisibleSequentialInstructionPlan(
+          sequentialInstructionPlan([]),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('throws SolanaError for other plans', () {
+      expect(
+        () => assertIsNonDivisibleSequentialInstructionPlan(
+          singleInstructionPlan(createInstruction('A')),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+      expect(
+        () => assertIsNonDivisibleSequentialInstructionPlan(
+          parallelInstructionPlan([]),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+  });
+
+  group('isParallelInstructionPlan', () {
+    test('returns true for ParallelInstructionPlan', () {
+      expect(isParallelInstructionPlan(parallelInstructionPlan([])), isTrue);
+    });
+
+    test('returns false for other plans', () {
+      expect(
+        isParallelInstructionPlan(
+          singleInstructionPlan(createInstruction('A')),
+        ),
+        isFalse,
+      );
+      expect(isParallelInstructionPlan(sequentialInstructionPlan([])), isFalse);
+      expect(
+        isParallelInstructionPlan(nonDivisibleSequentialInstructionPlan([])),
+        isFalse,
+      );
+    });
+  });
+
+  group('assertIsParallelInstructionPlan', () {
+    test('does nothing for ParallelInstructionPlan', () {
+      expect(
+        () => assertIsParallelInstructionPlan(parallelInstructionPlan([])),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError for other plans', () {
+      expect(
+        () => assertIsParallelInstructionPlan(
+          singleInstructionPlan(createInstruction('A')),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+      expect(
+        () => assertIsParallelInstructionPlan(sequentialInstructionPlan([])),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+  });
+
+  group('isInstructionPlan', () {
+    test('returns true for all instruction plan types', () {
+      expect(
+        isInstructionPlan(singleInstructionPlan(createInstruction('A'))),
+        isTrue,
+      );
+      expect(isInstructionPlan(sequentialInstructionPlan([])), isTrue);
+      expect(
+        isInstructionPlan(nonDivisibleSequentialInstructionPlan([])),
+        isTrue,
+      );
+      expect(isInstructionPlan(parallelInstructionPlan([])), isTrue);
+      expect(
+        isInstructionPlan(getMessagePackerInstructionPlanFromInstructions([])),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-instruction-plan values', () {
+      expect(isInstructionPlan(null), isFalse);
+      expect(isInstructionPlan('string'), isFalse);
+      expect(isInstructionPlan(123), isFalse);
+      expect(isInstructionPlan(true), isFalse);
+    });
+  });
+}

--- a/packages/solana_kit_instruction_plans/test/message_packer_test.dart
+++ b/packages/solana_kit_instruction_plans/test/message_packer_test.dart
@@ -1,0 +1,252 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('getMessagePackerInstructionPlanFromInstructions', () {
+    test('creates a MessagePackerInstructionPlan', () {
+      final plan = getMessagePackerInstructionPlanFromInstructions([
+        createInstruction('A'),
+        createInstruction('B'),
+      ]);
+
+      expect(plan, isA<MessagePackerInstructionPlan>());
+      expect(plan.kind, 'messagePacker');
+    });
+
+    test('packs all instructions into a message', () {
+      final plan = getMessagePackerInstructionPlanFromInstructions([
+        createInstruction('A'),
+        createInstruction('B'),
+      ]);
+      final message = createMessage();
+
+      final messagePacker = plan.getMessagePacker();
+      expect(messagePacker.done(), isFalse);
+
+      final packedMessage = messagePacker.packMessageToCapacity(message);
+      expect(packedMessage.instructions, hasLength(2));
+      expect(messagePacker.done(), isTrue);
+    });
+
+    test('throws when packer is already complete', () {
+      final plan = getMessagePackerInstructionPlanFromInstructions([
+        createInstruction('A'),
+      ]);
+      final message = createMessage();
+
+      final messagePacker = plan.getMessagePacker();
+      messagePacker.packMessageToCapacity(message);
+      expect(messagePacker.done(), isTrue);
+
+      expect(
+        () => messagePacker.packMessageToCapacity(message),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionPlansMessagePackerAlreadyComplete,
+          ),
+        ),
+      );
+    });
+
+    test('creates a new packer each time getMessagePacker is called', () {
+      final plan = getMessagePackerInstructionPlanFromInstructions([
+        createInstruction('A'),
+      ]);
+      final message = createMessage();
+
+      final messagePacker1 = plan.getMessagePacker();
+      messagePacker1.packMessageToCapacity(message);
+      expect(messagePacker1.done(), isTrue);
+
+      // A new packer should start fresh.
+      final messagePacker2 = plan.getMessagePacker();
+      expect(messagePacker2.done(), isFalse);
+    });
+
+    test('handles empty instruction list', () {
+      final plan = getMessagePackerInstructionPlanFromInstructions([]);
+
+      final messagePacker = plan.getMessagePacker();
+      expect(messagePacker.done(), isTrue);
+    });
+  });
+
+  group('getLinearMessagePackerInstructionPlan', () {
+    test('creates a MessagePackerInstructionPlan', () {
+      final plan = getLinearMessagePackerInstructionPlan(
+        getInstruction: (offset, length) =>
+            createInstruction('$offset-$length'),
+        totalLength: 100,
+      );
+
+      expect(plan, isA<MessagePackerInstructionPlan>());
+      expect(plan.kind, 'messagePacker');
+    });
+
+    test('starts with done() returning false', () {
+      final plan = getLinearMessagePackerInstructionPlan(
+        getInstruction: (offset, length) =>
+            createInstruction('$offset-$length'),
+        totalLength: 100,
+      );
+
+      final messagePacker = plan.getMessagePacker();
+      expect(messagePacker.done(), isFalse);
+    });
+
+    test('throws when packer is already complete', () {
+      final plan = getLinearMessagePackerInstructionPlan(
+        getInstruction: (offset, length) =>
+            createInstruction('$offset-$length'),
+        totalLength: 1,
+      );
+
+      final messagePacker = plan.getMessagePacker();
+      final message = createMessage();
+
+      // Pack until done.
+      while (!messagePacker.done()) {
+        messagePacker.packMessageToCapacity(message);
+      }
+
+      expect(
+        () => messagePacker.packMessageToCapacity(message),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionPlansMessagePackerAlreadyComplete,
+          ),
+        ),
+      );
+    });
+
+    test('creates a new packer each time getMessagePacker is called', () {
+      final plan = getLinearMessagePackerInstructionPlan(
+        getInstruction: (offset, length) =>
+            createInstruction('$offset-$length'),
+        totalLength: 100,
+      );
+
+      final messagePacker1 = plan.getMessagePacker();
+      expect(messagePacker1.done(), isFalse);
+
+      // A new packer should start fresh.
+      final messagePacker2 = plan.getMessagePacker();
+      expect(messagePacker2.done(), isFalse);
+    });
+  });
+
+  group('getReallocMessagePackerInstructionPlan', () {
+    test('creates a MessagePackerInstructionPlan', () {
+      final plan = getReallocMessagePackerInstructionPlan(
+        getInstruction: (size) => createInstruction('Size: $size'),
+        totalSize: 15000,
+      );
+
+      expect(plan, isA<MessagePackerInstructionPlan>());
+      expect(plan.kind, 'messagePacker');
+    });
+
+    test('packs instructions chunked by realloc limit (10240 bytes)', () {
+      final sizes = <int>[];
+      final plan = getReallocMessagePackerInstructionPlan(
+        getInstruction: (size) {
+          sizes.add(size);
+          return createInstruction('Size: $size');
+        },
+        totalSize: 15000,
+      );
+
+      // The plan generates instructions during creation.
+      // 15000 / 10240 = 1 full chunk + 4760 remainder
+      expect(plan, isA<MessagePackerInstructionPlan>());
+      expect(sizes, hasLength(2));
+      expect(sizes[0], 10240);
+      expect(sizes[1], 4760);
+    });
+
+    test('handles exact multiple of realloc limit', () {
+      final sizes = <int>[];
+      getReallocMessagePackerInstructionPlan(
+        getInstruction: (size) {
+          sizes.add(size);
+          return createInstruction('Size: $size');
+        },
+        totalSize: 20480, // 2 * 10240
+      );
+
+      expect(sizes, hasLength(2));
+      expect(sizes[0], 10240);
+      expect(sizes[1], 10240);
+    });
+
+    test('handles size smaller than realloc limit', () {
+      final sizes = <int>[];
+      getReallocMessagePackerInstructionPlan(
+        getInstruction: (size) {
+          sizes.add(size);
+          return createInstruction('Size: $size');
+        },
+        totalSize: 5000,
+      );
+
+      expect(sizes, hasLength(1));
+      expect(sizes[0], 5000);
+    });
+
+    test('throws when packer is already complete', () {
+      final plan = getReallocMessagePackerInstructionPlan(
+        getInstruction: (size) => createInstruction('Size: $size'),
+        totalSize: 5000,
+      );
+
+      final messagePacker = plan.getMessagePacker();
+      final message = createMessage();
+
+      // Pack until done.
+      while (!messagePacker.done()) {
+        messagePacker.packMessageToCapacity(message);
+      }
+
+      expect(
+        () => messagePacker.packMessageToCapacity(message),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionPlansMessagePackerAlreadyComplete,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('MessagePacker', () {
+    test('can be created with custom done and packMessageToCapacity', () {
+      var isDone = false;
+      final packer = MessagePacker(
+        done: () => isDone,
+        packMessageToCapacity: (message) {
+          isDone = true;
+          return message.copyWith(
+            instructions: [
+              ...message.instructions,
+              createInstruction('custom'),
+            ],
+          );
+        },
+      );
+
+      expect(packer.done(), isFalse);
+      final result = packer.packMessageToCapacity(createMessage());
+      expect(result.instructions, hasLength(1));
+      expect(packer.done(), isTrue);
+    });
+  });
+}

--- a/packages/solana_kit_instruction_plans/test/test_helpers.dart
+++ b/packages/solana_kit_instruction_plans/test/test_helpers.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+/// Valid Solana base58-encoded addresses for testing.
+/// These are all the System Program address which is all ones (32 zero bytes).
+const _systemProgram = Address('11111111111111111111111111111111');
+
+/// A valid fee payer address for testing.
+const _feePayer = Address('E9Nykp3rSdza2moQutaJ3K3RSC8E5iFERX2SqLTsQfjJ');
+
+/// Creates a simple test instruction using the system program address.
+///
+/// The instruction has no accounts and optional data.
+Instruction createInstruction([String? _]) =>
+    const Instruction(programAddress: _systemProgram);
+
+/// Creates a simple test instruction with data of a given byte size.
+Instruction createInstructionWithData(int dataBytes) =>
+    Instruction(programAddress: _systemProgram, data: Uint8List(dataBytes));
+
+/// Creates a test [TransactionMessage] with a fee payer.
+TransactionMessage createMessage([String? _]) => const TransactionMessage(
+  version: TransactionVersion.v0,
+  feePayer: _feePayer,
+);
+
+/// Creates a test [Transaction] with a dummy signature.
+Transaction createTransaction() => Transaction(
+  messageBytes: Uint8List(32),
+  signatures: {_feePayer: SignatureBytes(Uint8List(64))},
+);

--- a/packages/solana_kit_instruction_plans/test/transaction_plan_executor_test.dart
+++ b/packages/solana_kit_instruction_plans/test/transaction_plan_executor_test.dart
@@ -1,0 +1,246 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('createTransactionPlanExecutor', () {
+    test('executes a single transaction plan successfully', () async {
+      final message = createMessage();
+      final plan = singleTransactionPlan(message);
+      final sig = Signature('test-signature'.padRight(64, '0'));
+
+      final executor = createTransactionPlanExecutor(
+        TransactionPlanExecutorConfig(
+          executeTransactionMessage: (context, msg) async => sig.toString(),
+        ),
+      );
+
+      final result = await executor(plan);
+
+      expect(result, isA<SuccessfulSingleTransactionPlanResult>());
+      final successResult = result as SuccessfulSingleTransactionPlanResult;
+      expect(successResult.plannedMessage, same(message));
+    });
+
+    test(
+      'executes a single transaction plan returning a Transaction',
+      () async {
+        final message = createMessage();
+        final plan = singleTransactionPlan(message);
+        final transaction = createTransaction();
+
+        final executor = createTransactionPlanExecutor(
+          TransactionPlanExecutorConfig(
+            executeTransactionMessage: (context, msg) async => transaction,
+          ),
+        );
+
+        final result = await executor(plan);
+
+        expect(result, isA<SuccessfulSingleTransactionPlanResult>());
+        final successResult = result as SuccessfulSingleTransactionPlanResult;
+        expect(successResult.context.containsKey('transaction'), isTrue);
+      },
+    );
+
+    test('executes a sequential transaction plan', () async {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final plan = sequentialTransactionPlan([messageA, messageB]);
+      final sig = Signature('test-signature'.padRight(64, '0'));
+
+      final executor = createTransactionPlanExecutor(
+        TransactionPlanExecutorConfig(
+          executeTransactionMessage: (context, msg) async => sig.toString(),
+        ),
+      );
+
+      final result = await executor(plan);
+
+      expect(result, isA<SequentialTransactionPlanResult>());
+      final seqResult = result as SequentialTransactionPlanResult;
+      expect(seqResult.plans, hasLength(2));
+      expect(seqResult.plans[0], isA<SuccessfulSingleTransactionPlanResult>());
+      expect(seqResult.plans[1], isA<SuccessfulSingleTransactionPlanResult>());
+    });
+
+    test('executes a parallel transaction plan', () async {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final plan = parallelTransactionPlan([messageA, messageB]);
+      final sig = Signature('test-signature'.padRight(64, '0'));
+
+      final executor = createTransactionPlanExecutor(
+        TransactionPlanExecutorConfig(
+          executeTransactionMessage: (context, msg) async => sig.toString(),
+        ),
+      );
+
+      final result = await executor(plan);
+
+      expect(result, isA<ParallelTransactionPlanResult>());
+      final parResult = result as ParallelTransactionPlanResult;
+      expect(parResult.plans, hasLength(2));
+    });
+
+    test('cancels remaining transactions on failure', () async {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final plan = sequentialTransactionPlan([messageA, messageB]);
+      var callCount = 0;
+
+      final executor = createTransactionPlanExecutor(
+        TransactionPlanExecutorConfig(
+          executeTransactionMessage: (context, msg) async {
+            callCount++;
+            if (callCount == 1) {
+              throw Exception('first transaction failed');
+            }
+            return Signature('sig'.padRight(64, '0')).toString();
+          },
+        ),
+      );
+
+      expect(
+        () => executor(plan),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionPlansFailedToExecuteTransactionPlan,
+          ),
+        ),
+      );
+    });
+
+    test('throws for non-divisible sequential transaction plans', () async {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final plan = nonDivisibleSequentialTransactionPlan([messageA, messageB]);
+
+      final executor = createTransactionPlanExecutor(
+        TransactionPlanExecutorConfig(
+          executeTransactionMessage: (context, msg) async {
+            return Signature('sig'.padRight(64, '0')).toString();
+          },
+        ),
+      );
+
+      expect(
+        () => executor(plan),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode
+                .instructionPlansNonDivisibleTransactionPlansNotSupported,
+          ),
+        ),
+      );
+    });
+
+    test('provides context to executeTransactionMessage', () async {
+      final message = createMessage();
+      final plan = singleTransactionPlan(message);
+      Map<String, Object?>? capturedContext;
+
+      final executor = createTransactionPlanExecutor(
+        TransactionPlanExecutorConfig(
+          executeTransactionMessage: (context, msg) async {
+            capturedContext = context;
+            context['myKey'] = 'myValue';
+            return Signature('sig'.padRight(64, '0')).toString();
+          },
+        ),
+      );
+
+      final result = await executor(plan);
+
+      expect(capturedContext, isNotNull);
+      expect(result, isA<SuccessfulSingleTransactionPlanResult>());
+      final successResult = result as SuccessfulSingleTransactionPlanResult;
+      expect(successResult.context['myKey'], 'myValue');
+    });
+
+    test('extracts signature from transaction in context on failure', () async {
+      final message = createMessage();
+      final plan = singleTransactionPlan(message);
+      final transaction = createTransaction();
+
+      final executor = createTransactionPlanExecutor(
+        TransactionPlanExecutorConfig(
+          executeTransactionMessage: (context, msg) async {
+            context['transaction'] = transaction;
+            throw Exception('failed after signing');
+          },
+        ),
+      );
+
+      try {
+        await executor(plan);
+        fail('Expected SolanaError');
+      } on SolanaError catch (e) {
+        expect(
+          e.code,
+          SolanaErrorCode.instructionPlansFailedToExecuteTransactionPlan,
+        );
+      }
+    });
+  });
+
+  group('TransactionPlanExecutorConfig', () {
+    test('stores the executeTransactionMessage callback', () {
+      Future<Object> callback(
+        Map<String, Object?> context,
+        dynamic msg,
+      ) async => 'result';
+
+      final config = TransactionPlanExecutorConfig(
+        executeTransactionMessage: callback,
+      );
+      expect(config.executeTransactionMessage, same(callback));
+    });
+  });
+
+  group('passthroughFailedTransactionPlanExecution', () {
+    test('returns successful result unchanged', () async {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final expectedResult = successfulSingleTransactionPlanResult(message, {
+        'signature': sig,
+      });
+
+      final result = await passthroughFailedTransactionPlanExecution(
+        Future.value(expectedResult),
+      );
+
+      expect(result, same(expectedResult));
+    });
+
+    test('rethrows non-SolanaError exceptions', () {
+      expect(
+        () => passthroughFailedTransactionPlanExecution(
+          Future<TransactionPlanResult>.error(Exception('other error')),
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('rethrows SolanaError without transactionPlanResult in context', () {
+      final error = SolanaError(
+        SolanaErrorCode.instructionPlansFailedToExecuteTransactionPlan,
+        {'cause': 'test'},
+      );
+
+      expect(
+        () => passthroughFailedTransactionPlanExecution(
+          Future<TransactionPlanResult>.error(error),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_instruction_plans/test/transaction_plan_result_test.dart
+++ b/packages/solana_kit_instruction_plans/test/transaction_plan_result_test.dart
@@ -1,0 +1,688 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('SuccessfulSingleTransactionPlanResult', () {
+    test('creates a successful result with signature', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+      final result = successfulSingleTransactionPlanResult(message, {
+        'signature': sig,
+      });
+
+      expect(result, isA<SuccessfulSingleTransactionPlanResult>());
+      expect(result.status, TransactionPlanResultStatus.successful);
+      expect(result.kind, 'single');
+      expect(result.plannedMessage, same(message));
+      expect(result.signature, sig);
+    });
+
+    test('creates a successful result from a transaction', () {
+      final message = createMessage();
+      final transaction = createTransaction();
+      final result = successfulSingleTransactionPlanResultFromTransaction(
+        message,
+        transaction,
+      );
+
+      expect(result, isA<SuccessfulSingleTransactionPlanResult>());
+      expect(result.status, TransactionPlanResultStatus.successful);
+      expect(result.context.containsKey('signature'), isTrue);
+      expect(result.context.containsKey('transaction'), isTrue);
+      expect(result.context['transaction'], same(transaction));
+    });
+
+    test('context is unmodifiable', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+      final result = successfulSingleTransactionPlanResult(message, {
+        'signature': sig,
+      });
+
+      expect(
+        () => (result.context as Map)['new_key'] = 'value',
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('FailedSingleTransactionPlanResult', () {
+    test('creates a failed result with error', () {
+      final message = createMessage();
+      final error = Exception('test error');
+      final result = failedSingleTransactionPlanResult(message, error);
+
+      expect(result, isA<FailedSingleTransactionPlanResult>());
+      expect(result.status, TransactionPlanResultStatus.failed);
+      expect(result.kind, 'single');
+      expect(result.plannedMessage, same(message));
+      expect(result.error, same(error));
+    });
+
+    test('creates a failed result with context', () {
+      final message = createMessage();
+      final error = Exception('test error');
+      final result = failedSingleTransactionPlanResult(message, error, {
+        'key': 'value',
+      });
+
+      expect(result.context['key'], 'value');
+    });
+
+    test('context defaults to empty when not provided', () {
+      final message = createMessage();
+      final result = failedSingleTransactionPlanResult(
+        message,
+        Exception('test'),
+      );
+
+      expect(result.context, isEmpty);
+    });
+  });
+
+  group('CanceledSingleTransactionPlanResult', () {
+    test('creates a canceled result', () {
+      final message = createMessage();
+      final result = canceledSingleTransactionPlanResult(message);
+
+      expect(result, isA<CanceledSingleTransactionPlanResult>());
+      expect(result.status, TransactionPlanResultStatus.canceled);
+      expect(result.kind, 'single');
+      expect(result.plannedMessage, same(message));
+    });
+
+    test('creates a canceled result with context', () {
+      final message = createMessage();
+      final result = canceledSingleTransactionPlanResult(message, {
+        'key': 'value',
+      });
+
+      expect(result.context['key'], 'value');
+    });
+  });
+
+  group('SequentialTransactionPlanResult', () {
+    test('creates a sequential result', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+      final childResult = successfulSingleTransactionPlanResult(message, {
+        'signature': sig,
+      });
+      final result = sequentialTransactionPlanResult([childResult]);
+
+      expect(result, isA<SequentialTransactionPlanResult>());
+      expect(result.kind, 'sequential');
+      expect(result.divisible, isTrue);
+      expect(result.plans, hasLength(1));
+    });
+
+    test('creates a non-divisible sequential result', () {
+      final result = nonDivisibleSequentialTransactionPlanResult([]);
+
+      expect(result, isA<SequentialTransactionPlanResult>());
+      expect(result.divisible, isFalse);
+    });
+  });
+
+  group('ParallelTransactionPlanResult', () {
+    test('creates a parallel result', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+      final childResult = successfulSingleTransactionPlanResult(message, {
+        'signature': sig,
+      });
+      final result = parallelTransactionPlanResult([childResult]);
+
+      expect(result, isA<ParallelTransactionPlanResult>());
+      expect(result.kind, 'parallel');
+      expect(result.plans, hasLength(1));
+    });
+  });
+
+  group('isTransactionPlanResult', () {
+    test('returns true for all result types', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+
+      expect(
+        isTransactionPlanResult(
+          successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        ),
+        isTrue,
+      );
+      expect(
+        isTransactionPlanResult(
+          failedSingleTransactionPlanResult(message, Exception('test')),
+        ),
+        isTrue,
+      );
+      expect(
+        isTransactionPlanResult(canceledSingleTransactionPlanResult(message)),
+        isTrue,
+      );
+      expect(
+        isTransactionPlanResult(sequentialTransactionPlanResult([])),
+        isTrue,
+      );
+      expect(
+        isTransactionPlanResult(parallelTransactionPlanResult([])),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-result values', () {
+      expect(isTransactionPlanResult(null), isFalse);
+      expect(isTransactionPlanResult('string'), isFalse);
+      expect(isTransactionPlanResult(123), isFalse);
+    });
+  });
+
+  group('isSingleTransactionPlanResult', () {
+    test('returns true for single results', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+
+      expect(
+        isSingleTransactionPlanResult(
+          successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        ),
+        isTrue,
+      );
+      expect(
+        isSingleTransactionPlanResult(
+          failedSingleTransactionPlanResult(message, Exception('test')),
+        ),
+        isTrue,
+      );
+      expect(
+        isSingleTransactionPlanResult(
+          canceledSingleTransactionPlanResult(message),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-single results', () {
+      expect(
+        isSingleTransactionPlanResult(sequentialTransactionPlanResult([])),
+        isFalse,
+      );
+      expect(
+        isSingleTransactionPlanResult(parallelTransactionPlanResult([])),
+        isFalse,
+      );
+    });
+  });
+
+  group('assertIsSingleTransactionPlanResult', () {
+    test('does nothing for single results', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+      expect(
+        () => assertIsSingleTransactionPlanResult(
+          successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError for non-single results', () {
+      expect(
+        () => assertIsSingleTransactionPlanResult(
+          sequentialTransactionPlanResult([]),
+        ),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionPlansUnexpectedTransactionPlanResult,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('isSuccessfulSingleTransactionPlanResult', () {
+    test('returns true for successful results', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+      expect(
+        isSuccessfulSingleTransactionPlanResult(
+          successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-successful results', () {
+      final message = createMessage();
+      expect(
+        isSuccessfulSingleTransactionPlanResult(
+          failedSingleTransactionPlanResult(message, Exception('test')),
+        ),
+        isFalse,
+      );
+      expect(
+        isSuccessfulSingleTransactionPlanResult(
+          canceledSingleTransactionPlanResult(message),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('isFailedSingleTransactionPlanResult', () {
+    test('returns true for failed results', () {
+      final message = createMessage();
+      expect(
+        isFailedSingleTransactionPlanResult(
+          failedSingleTransactionPlanResult(message, Exception('test')),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-failed results', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+      expect(
+        isFailedSingleTransactionPlanResult(
+          successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('isCanceledSingleTransactionPlanResult', () {
+    test('returns true for canceled results', () {
+      final message = createMessage();
+      expect(
+        isCanceledSingleTransactionPlanResult(
+          canceledSingleTransactionPlanResult(message),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-canceled results', () {
+      final message = createMessage();
+      final sig = Signature('test-signature'.padRight(64, '0'));
+      expect(
+        isCanceledSingleTransactionPlanResult(
+          successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('isSequentialTransactionPlanResult', () {
+    test('returns true for sequential results', () {
+      expect(
+        isSequentialTransactionPlanResult(sequentialTransactionPlanResult([])),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-sequential results', () {
+      expect(
+        isSequentialTransactionPlanResult(parallelTransactionPlanResult([])),
+        isFalse,
+      );
+    });
+  });
+
+  group('isNonDivisibleSequentialTransactionPlanResult', () {
+    test('returns true for non-divisible sequential results', () {
+      expect(
+        isNonDivisibleSequentialTransactionPlanResult(
+          nonDivisibleSequentialTransactionPlanResult([]),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for divisible sequential results', () {
+      expect(
+        isNonDivisibleSequentialTransactionPlanResult(
+          sequentialTransactionPlanResult([]),
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('isParallelTransactionPlanResult', () {
+    test('returns true for parallel results', () {
+      expect(
+        isParallelTransactionPlanResult(parallelTransactionPlanResult([])),
+        isTrue,
+      );
+    });
+
+    test('returns false for non-parallel results', () {
+      expect(
+        isParallelTransactionPlanResult(sequentialTransactionPlanResult([])),
+        isFalse,
+      );
+    });
+  });
+
+  group('getFirstFailedSingleTransactionPlanResult', () {
+    test('returns the first failed result', () {
+      final message = createMessage();
+      final error = Exception('test error');
+      final failedResult = failedSingleTransactionPlanResult(message, error);
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {
+          'signature': Signature('sig'.padRight(64, '0')),
+        }),
+        failedResult,
+      ]);
+
+      final found = getFirstFailedSingleTransactionPlanResult(result);
+      expect(found, same(failedResult));
+    });
+
+    test('throws SolanaError when no failed result exists', () {
+      final message = createMessage();
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {
+          'signature': Signature('sig'.padRight(64, '0')),
+        }),
+      ]);
+
+      expect(
+        () => getFirstFailedSingleTransactionPlanResult(result),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode
+                .instructionPlansFailedSingleTransactionPlanResultNotFound,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('isSuccessfulTransactionPlanResult', () {
+    test('returns true when all results are successful', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+      ]);
+
+      expect(isSuccessfulTransactionPlanResult(result), isTrue);
+    });
+
+    test('returns false when any result is failed', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        failedSingleTransactionPlanResult(message, Exception('test')),
+      ]);
+
+      expect(isSuccessfulTransactionPlanResult(result), isFalse);
+    });
+
+    test('returns false when any result is canceled', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        canceledSingleTransactionPlanResult(message),
+      ]);
+
+      expect(isSuccessfulTransactionPlanResult(result), isFalse);
+    });
+  });
+
+  group('assertIsSuccessfulTransactionPlanResult', () {
+    test('does nothing when all results are successful', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+      ]);
+
+      expect(
+        () => assertIsSuccessfulTransactionPlanResult(result),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError when any result is not successful', () {
+      final message = createMessage();
+      final result = sequentialTransactionPlanResult([
+        failedSingleTransactionPlanResult(message, Exception('test')),
+      ]);
+
+      expect(
+        () => assertIsSuccessfulTransactionPlanResult(result),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode
+                .instructionPlansExpectedSuccessfulTransactionPlanResult,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('flattenTransactionPlanResult', () {
+    test('returns a single result in a list', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = successfulSingleTransactionPlanResult(message, {
+        'signature': sig,
+      });
+
+      final flattened = flattenTransactionPlanResult(result);
+      expect(flattened, hasLength(1));
+      expect(flattened[0], same(result));
+    });
+
+    test('flattens nested results', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        parallelTransactionPlanResult([
+          failedSingleTransactionPlanResult(message, Exception('test')),
+          canceledSingleTransactionPlanResult(message),
+        ]),
+      ]);
+
+      final flattened = flattenTransactionPlanResult(result);
+      expect(flattened, hasLength(3));
+      expect(flattened[0], isA<SuccessfulSingleTransactionPlanResult>());
+      expect(flattened[1], isA<FailedSingleTransactionPlanResult>());
+      expect(flattened[2], isA<CanceledSingleTransactionPlanResult>());
+    });
+  });
+
+  group('summarizeTransactionPlanResult', () {
+    test('summarizes a fully successful result', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+      ]);
+
+      final summary = summarizeTransactionPlanResult(result);
+      expect(summary.successful, isTrue);
+      expect(summary.successfulTransactions, hasLength(2));
+      expect(summary.failedTransactions, isEmpty);
+      expect(summary.canceledTransactions, isEmpty);
+    });
+
+    test('summarizes a result with failures', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        failedSingleTransactionPlanResult(message, Exception('test')),
+        canceledSingleTransactionPlanResult(message),
+      ]);
+
+      final summary = summarizeTransactionPlanResult(result);
+      expect(summary.successful, isFalse);
+      expect(summary.successfulTransactions, hasLength(1));
+      expect(summary.failedTransactions, hasLength(1));
+      expect(summary.canceledTransactions, hasLength(1));
+    });
+
+    test('handles nested parallel and sequential results', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = parallelTransactionPlanResult([
+        sequentialTransactionPlanResult([
+          successfulSingleTransactionPlanResult(message, {'signature': sig}),
+          successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        ]),
+        failedSingleTransactionPlanResult(message, Exception('test')),
+      ]);
+
+      final summary = summarizeTransactionPlanResult(result);
+      expect(summary.successful, isFalse);
+      expect(summary.successfulTransactions, hasLength(2));
+      expect(summary.failedTransactions, hasLength(1));
+    });
+  });
+
+  group('findTransactionPlanResult', () {
+    test('returns the result itself when it matches the predicate', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = successfulSingleTransactionPlanResult(message, {
+        'signature': sig,
+      });
+      final found = findTransactionPlanResult(
+        result,
+        (r) => r is SuccessfulSingleTransactionPlanResult,
+      );
+      expect(found, same(result));
+    });
+
+    test('returns null when no result matches', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = successfulSingleTransactionPlanResult(message, {
+        'signature': sig,
+      });
+      final found = findTransactionPlanResult(
+        result,
+        (r) => r is FailedSingleTransactionPlanResult,
+      );
+      expect(found, isNull);
+    });
+
+    test('finds a nested result', () {
+      final message = createMessage();
+      final failedResult = failedSingleTransactionPlanResult(
+        message,
+        Exception('test'),
+      );
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {
+          'signature': Signature('sig'.padRight(64, '0')),
+        }),
+        failedResult,
+      ]);
+      final found = findTransactionPlanResult(
+        result,
+        (r) => r is FailedSingleTransactionPlanResult,
+      );
+      expect(found, same(failedResult));
+    });
+  });
+
+  group('everyTransactionPlanResult', () {
+    test('returns true when all results match', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+      ]);
+
+      expect(
+        everyTransactionPlanResult(
+          result,
+          (r) =>
+              r is! SingleTransactionPlanResult ||
+              r is SuccessfulSingleTransactionPlanResult,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false when any result does not match', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        failedSingleTransactionPlanResult(message, Exception('test')),
+      ]);
+
+      expect(
+        everyTransactionPlanResult(
+          result,
+          (r) =>
+              r is! SingleTransactionPlanResult ||
+              r is SuccessfulSingleTransactionPlanResult,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('transformTransactionPlanResult', () {
+    test('transforms single results', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = successfulSingleTransactionPlanResult(message, {
+        'signature': sig,
+      });
+
+      final transformed = transformTransactionPlanResult(result, (r) {
+        if (r is SuccessfulSingleTransactionPlanResult) {
+          return canceledSingleTransactionPlanResult(r.plannedMessage);
+        }
+        return r;
+      });
+
+      expect(transformed, isA<CanceledSingleTransactionPlanResult>());
+    });
+
+    test('transforms nested results bottom-up', () {
+      final message = createMessage();
+      final sig = Signature('sig'.padRight(64, '0'));
+      final result = sequentialTransactionPlanResult([
+        successfulSingleTransactionPlanResult(message, {'signature': sig}),
+        failedSingleTransactionPlanResult(message, Exception('test')),
+      ]);
+
+      final kinds = <String>[];
+      transformTransactionPlanResult(result, (r) {
+        kinds.add(r.kind);
+        return r;
+      });
+
+      // Bottom-up: first single, second single, then sequential
+      expect(kinds, hasLength(3));
+    });
+  });
+}

--- a/packages/solana_kit_instruction_plans/test/transaction_plan_test.dart
+++ b/packages/solana_kit_instruction_plans/test/transaction_plan_test.dart
@@ -1,0 +1,490 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('singleTransactionPlan', () {
+    test('creates SingleTransactionPlan objects', () {
+      final message = createMessage();
+      final plan = singleTransactionPlan(message);
+
+      expect(plan, isA<SingleTransactionPlan>());
+      expect(plan.kind, 'single');
+      expect(plan.message, same(message));
+    });
+  });
+
+  group('sequentialTransactionPlan', () {
+    test('creates divisible SequentialTransactionPlan from plans', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final plan = sequentialTransactionPlan([
+        singleTransactionPlan(messageA),
+        singleTransactionPlan(messageB),
+      ]);
+
+      expect(plan, isA<SequentialTransactionPlan>());
+      expect(plan.kind, 'sequential');
+      expect(plan.divisible, isTrue);
+      expect(plan.plans, hasLength(2));
+    });
+
+    test(
+      'accepts transaction messages directly and wraps them in single plans',
+      () {
+        final messageA = createMessage();
+        final messageB = createMessage();
+        final plan = sequentialTransactionPlan([messageA, messageB]);
+
+        expect(plan.plans, hasLength(2));
+        expect(plan.plans[0], isA<SingleTransactionPlan>());
+        expect(plan.plans[1], isA<SingleTransactionPlan>());
+      },
+    );
+
+    test('can nest other sequential plans', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final messageC = createMessage();
+      final plan = sequentialTransactionPlan([
+        messageA,
+        sequentialTransactionPlan([messageB, messageC]),
+      ]);
+
+      expect(plan.plans, hasLength(2));
+      expect(plan.plans[0], isA<SingleTransactionPlan>());
+      expect(plan.plans[1], isA<SequentialTransactionPlan>());
+    });
+
+    test('creates unmodifiable plans list', () {
+      final plan = sequentialTransactionPlan([
+        createMessage(),
+        createMessage(),
+      ]);
+      expect(
+        () => (plan.plans as List).add(singleTransactionPlan(createMessage())),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('nonDivisibleSequentialTransactionPlan', () {
+    test('creates non-divisible SequentialTransactionPlan', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final plan = nonDivisibleSequentialTransactionPlan([
+        singleTransactionPlan(messageA),
+        singleTransactionPlan(messageB),
+      ]);
+
+      expect(plan, isA<SequentialTransactionPlan>());
+      expect(plan.kind, 'sequential');
+      expect(plan.divisible, isFalse);
+      expect(plan.plans, hasLength(2));
+    });
+
+    test(
+      'accepts transaction messages directly and wraps them in single plans',
+      () {
+        final messageA = createMessage();
+        final messageB = createMessage();
+        final plan = nonDivisibleSequentialTransactionPlan([
+          messageA,
+          messageB,
+        ]);
+
+        expect(plan.plans, hasLength(2));
+        expect(plan.plans[0], isA<SingleTransactionPlan>());
+        expect(plan.plans[1], isA<SingleTransactionPlan>());
+      },
+    );
+  });
+
+  group('parallelTransactionPlan', () {
+    test('creates ParallelTransactionPlan from plans', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final plan = parallelTransactionPlan([
+        singleTransactionPlan(messageA),
+        singleTransactionPlan(messageB),
+      ]);
+
+      expect(plan, isA<ParallelTransactionPlan>());
+      expect(plan.kind, 'parallel');
+      expect(plan.plans, hasLength(2));
+    });
+
+    test(
+      'accepts transaction messages directly and wraps them in single plans',
+      () {
+        final messageA = createMessage();
+        final messageB = createMessage();
+        final plan = parallelTransactionPlan([messageA, messageB]);
+
+        expect(plan.plans, hasLength(2));
+        expect(plan.plans[0], isA<SingleTransactionPlan>());
+        expect(plan.plans[1], isA<SingleTransactionPlan>());
+      },
+    );
+
+    test('can nest other parallel plans', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final messageC = createMessage();
+      final plan = parallelTransactionPlan([
+        messageA,
+        parallelTransactionPlan([messageB, messageC]),
+      ]);
+
+      expect(plan.plans, hasLength(2));
+      expect(plan.plans[0], isA<SingleTransactionPlan>());
+      expect(plan.plans[1], isA<ParallelTransactionPlan>());
+    });
+  });
+
+  group('isSingleTransactionPlan', () {
+    test('returns true for SingleTransactionPlan', () {
+      expect(
+        isSingleTransactionPlan(singleTransactionPlan(createMessage())),
+        isTrue,
+      );
+    });
+
+    test('returns false for other plans', () {
+      expect(isSingleTransactionPlan(sequentialTransactionPlan([])), isFalse);
+      expect(
+        isSingleTransactionPlan(nonDivisibleSequentialTransactionPlan([])),
+        isFalse,
+      );
+      expect(isSingleTransactionPlan(parallelTransactionPlan([])), isFalse);
+    });
+  });
+
+  group('assertIsSingleTransactionPlan', () {
+    test('does nothing for SingleTransactionPlan', () {
+      expect(
+        () => assertIsSingleTransactionPlan(
+          singleTransactionPlan(createMessage()),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError for other plans', () {
+      expect(
+        () => assertIsSingleTransactionPlan(sequentialTransactionPlan([])),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionPlansUnexpectedTransactionPlan,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('isSequentialTransactionPlan', () {
+    test('returns true for SequentialTransactionPlan (divisible or not)', () {
+      expect(
+        isSequentialTransactionPlan(sequentialTransactionPlan([])),
+        isTrue,
+      );
+      expect(
+        isSequentialTransactionPlan(nonDivisibleSequentialTransactionPlan([])),
+        isTrue,
+      );
+    });
+
+    test('returns false for other plans', () {
+      expect(
+        isSequentialTransactionPlan(singleTransactionPlan(createMessage())),
+        isFalse,
+      );
+      expect(isSequentialTransactionPlan(parallelTransactionPlan([])), isFalse);
+    });
+  });
+
+  group('assertIsSequentialTransactionPlan', () {
+    test('does nothing for SequentialTransactionPlan', () {
+      expect(
+        () => assertIsSequentialTransactionPlan(sequentialTransactionPlan([])),
+        returnsNormally,
+      );
+      expect(
+        () => assertIsSequentialTransactionPlan(
+          nonDivisibleSequentialTransactionPlan([]),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError for other plans', () {
+      expect(
+        () => assertIsSequentialTransactionPlan(
+          singleTransactionPlan(createMessage()),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+  });
+
+  group('isNonDivisibleSequentialTransactionPlan', () {
+    test('returns true for non-divisible SequentialTransactionPlan', () {
+      expect(
+        isNonDivisibleSequentialTransactionPlan(
+          nonDivisibleSequentialTransactionPlan([]),
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false for other plans', () {
+      expect(
+        isNonDivisibleSequentialTransactionPlan(
+          singleTransactionPlan(createMessage()),
+        ),
+        isFalse,
+      );
+      expect(
+        isNonDivisibleSequentialTransactionPlan(sequentialTransactionPlan([])),
+        isFalse,
+      );
+      expect(
+        isNonDivisibleSequentialTransactionPlan(parallelTransactionPlan([])),
+        isFalse,
+      );
+    });
+  });
+
+  group('assertIsNonDivisibleSequentialTransactionPlan', () {
+    test('does nothing for non-divisible SequentialTransactionPlan', () {
+      expect(
+        () => assertIsNonDivisibleSequentialTransactionPlan(
+          nonDivisibleSequentialTransactionPlan([]),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError for divisible sequential plan', () {
+      expect(
+        () => assertIsNonDivisibleSequentialTransactionPlan(
+          sequentialTransactionPlan([]),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('throws SolanaError for other plans', () {
+      expect(
+        () => assertIsNonDivisibleSequentialTransactionPlan(
+          singleTransactionPlan(createMessage()),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+  });
+
+  group('isParallelTransactionPlan', () {
+    test('returns true for ParallelTransactionPlan', () {
+      expect(isParallelTransactionPlan(parallelTransactionPlan([])), isTrue);
+    });
+
+    test('returns false for other plans', () {
+      expect(
+        isParallelTransactionPlan(singleTransactionPlan(createMessage())),
+        isFalse,
+      );
+      expect(isParallelTransactionPlan(sequentialTransactionPlan([])), isFalse);
+    });
+  });
+
+  group('assertIsParallelTransactionPlan', () {
+    test('does nothing for ParallelTransactionPlan', () {
+      expect(
+        () => assertIsParallelTransactionPlan(parallelTransactionPlan([])),
+        returnsNormally,
+      );
+    });
+
+    test('throws SolanaError for other plans', () {
+      expect(
+        () => assertIsParallelTransactionPlan(
+          singleTransactionPlan(createMessage()),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+  });
+
+  group('flattenTransactionPlan', () {
+    test('returns the single plan when given a SingleTransactionPlan', () {
+      final message = createMessage();
+      final plan = singleTransactionPlan(message);
+      final result = flattenTransactionPlan(plan);
+      expect(result, hasLength(1));
+      expect(result[0], same(plan));
+    });
+
+    test('returns all single plans from a ParallelTransactionPlan', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final plan = parallelTransactionPlan([messageA, messageB]);
+      final result = flattenTransactionPlan(plan);
+      expect(result, hasLength(2));
+      expect(result[0], isA<SingleTransactionPlan>());
+      expect(result[1], isA<SingleTransactionPlan>());
+    });
+
+    test('returns all single plans from a SequentialTransactionPlan', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final plan = sequentialTransactionPlan([messageA, messageB]);
+      final result = flattenTransactionPlan(plan);
+      expect(result, hasLength(2));
+    });
+
+    test('returns all single plans from a complex nested structure', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final messageC = createMessage();
+      final messageD = createMessage();
+      final messageE = createMessage();
+      final plan = parallelTransactionPlan([
+        sequentialTransactionPlan([messageA, messageB]),
+        nonDivisibleSequentialTransactionPlan([messageC, messageD]),
+        messageE,
+      ]);
+      final result = flattenTransactionPlan(plan);
+      expect(result, hasLength(5));
+    });
+  });
+
+  group('findTransactionPlan', () {
+    test('returns the plan itself when it matches the predicate', () {
+      final message = createMessage();
+      final plan = singleTransactionPlan(message);
+      final result = findTransactionPlan(plan, (p) => p.kind == 'single');
+      expect(result, same(plan));
+    });
+
+    test('returns null when no plan matches the predicate', () {
+      final message = createMessage();
+      final plan = singleTransactionPlan(message);
+      final result = findTransactionPlan(plan, (p) => p.kind == 'parallel');
+      expect(result, isNull);
+    });
+
+    test('finds a nested plan in a parallel structure', () {
+      final messageA = createMessage();
+      final messageB = createMessage();
+      final nestedSequential = sequentialTransactionPlan([messageA, messageB]);
+      final plan = parallelTransactionPlan([nestedSequential]);
+      final result = findTransactionPlan(plan, (p) => p.kind == 'sequential');
+      expect(result, same(nestedSequential));
+    });
+
+    test('finds a deeply nested plan', () {
+      final message = createMessage();
+      final deepSingle = singleTransactionPlan(message);
+      final plan = parallelTransactionPlan([
+        sequentialTransactionPlan([
+          parallelTransactionPlan([deepSingle]),
+        ]),
+      ]);
+      final result = findTransactionPlan(plan, (p) => p.kind == 'single');
+      expect(result, same(deepSingle));
+    });
+  });
+
+  group('everyTransactionPlan', () {
+    test('returns true when all plans match the predicate', () {
+      final plan = sequentialTransactionPlan([
+        sequentialTransactionPlan([]),
+        sequentialTransactionPlan([]),
+      ]);
+      final result = everyTransactionPlan(plan, (p) => p.kind == 'sequential');
+      expect(result, isTrue);
+    });
+
+    test('returns false when at least one plan does not match', () {
+      final plan = sequentialTransactionPlan([
+        parallelTransactionPlan([]),
+        sequentialTransactionPlan([]),
+      ]);
+      final result = everyTransactionPlan(plan, (p) => p.kind == 'sequential');
+      expect(result, isFalse);
+    });
+  });
+
+  group('transformTransactionPlan', () {
+    test('transforms single transaction plans', () {
+      final plan = singleTransactionPlan(createMessage());
+      final newMessage = createMessage();
+      final transformedPlan = transformTransactionPlan(plan, (p) {
+        if (p is SingleTransactionPlan) {
+          return singleTransactionPlan(newMessage);
+        }
+        return p;
+      });
+
+      expect(transformedPlan, isA<SingleTransactionPlan>());
+      expect(
+        (transformedPlan as SingleTransactionPlan).message,
+        same(newMessage),
+      );
+    });
+
+    test('transforms sequential transaction plans', () {
+      final plan = sequentialTransactionPlan([
+        createMessage(),
+        createMessage(),
+      ]);
+      final transformedPlan = transformTransactionPlan(plan, (p) {
+        if (p is SequentialTransactionPlan) {
+          return SequentialTransactionPlan(
+            plans: p.plans.reversed.toList(),
+            divisible: p.divisible,
+          );
+        }
+        return p;
+      });
+
+      expect(transformedPlan, isA<SequentialTransactionPlan>());
+    });
+
+    test('can be used to remove parallelism', () {
+      final plan = parallelTransactionPlan([createMessage(), createMessage()]);
+      final transformedPlan = transformTransactionPlan(plan, (p) {
+        if (p is ParallelTransactionPlan) {
+          return sequentialTransactionPlan(p.plans);
+        }
+        return p;
+      });
+
+      expect(transformedPlan, isA<SequentialTransactionPlan>());
+    });
+  });
+
+  group('isTransactionPlan', () {
+    test('returns true for all transaction plan types', () {
+      expect(isTransactionPlan(singleTransactionPlan(createMessage())), isTrue);
+      expect(isTransactionPlan(sequentialTransactionPlan([])), isTrue);
+      expect(
+        isTransactionPlan(nonDivisibleSequentialTransactionPlan([])),
+        isTrue,
+      );
+      expect(isTransactionPlan(parallelTransactionPlan([])), isTrue);
+    });
+
+    test('returns false for non-transaction-plan values', () {
+      expect(isTransactionPlan(null), isFalse);
+      expect(isTransactionPlan('string'), isFalse);
+      expect(isTransactionPlan(123), isFalse);
+      expect(isTransactionPlan(true), isFalse);
+    });
+  });
+}

--- a/packages/solana_kit_instruction_plans/test/transaction_planner_test.dart
+++ b/packages/solana_kit_instruction_plans/test/transaction_planner_test.dart
@@ -1,0 +1,193 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('createTransactionPlanner', () {
+    late TransactionPlanner planner;
+
+    setUp(() {
+      planner = createTransactionPlanner(
+        TransactionPlannerConfig(
+          createTransactionMessage: () async => createMessage(),
+        ),
+      );
+    });
+
+    test('throws for empty instruction plan', () async {
+      final plan = sequentialInstructionPlan([]);
+
+      expect(
+        () => planner(plan),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.instructionPlansEmptyInstructionPlan,
+          ),
+        ),
+      );
+    });
+
+    test(
+      'creates a single transaction plan from a single instruction',
+      () async {
+        final instruction = createInstruction('A');
+        final plan = singleInstructionPlan(instruction);
+
+        final transactionPlan = await planner(plan);
+
+        expect(transactionPlan, isA<SingleTransactionPlan>());
+        final singlePlan = transactionPlan as SingleTransactionPlan;
+        expect(singlePlan.message.instructions, hasLength(1));
+        expect(singlePlan.message.instructions[0], same(instruction));
+      },
+    );
+
+    test(
+      'packs multiple sequential instructions into one transaction',
+      () async {
+        final instructionA = createInstruction('A');
+        final instructionB = createInstruction('B');
+        final plan = sequentialInstructionPlan([instructionA, instructionB]);
+
+        final transactionPlan = await planner(plan);
+
+        // When they fit in one transaction, they should be packed together.
+        expect(transactionPlan, isA<SingleTransactionPlan>());
+        final singlePlan = transactionPlan as SingleTransactionPlan;
+        expect(singlePlan.message.instructions, hasLength(2));
+      },
+    );
+
+    test(
+      'packs parallel instructions into one transaction when possible',
+      () async {
+        final instructionA = createInstruction('A');
+        final instructionB = createInstruction('B');
+        final plan = parallelInstructionPlan([instructionA, instructionB]);
+
+        final transactionPlan = await planner(plan);
+
+        expect(transactionPlan, isA<SingleTransactionPlan>());
+        final singlePlan = transactionPlan as SingleTransactionPlan;
+        expect(singlePlan.message.instructions, hasLength(2));
+      },
+    );
+
+    test('handles nested sequential and parallel plans', () async {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final instructionC = createInstruction('C');
+
+      final plan = sequentialInstructionPlan([
+        instructionA,
+        parallelInstructionPlan([instructionB, instructionC]),
+      ]);
+
+      final transactionPlan = await planner(plan);
+      expect(transactionPlan, isA<TransactionPlan>());
+    });
+
+    test('calls onTransactionMessageUpdated when provided', () async {
+      var updateCount = 0;
+      final updatingPlanner = createTransactionPlanner(
+        TransactionPlannerConfig(
+          createTransactionMessage: () async => createMessage(),
+          onTransactionMessageUpdated: (msg) async {
+            updateCount++;
+            return msg;
+          },
+        ),
+      );
+
+      final plan = singleInstructionPlan(createInstruction('A'));
+      await updatingPlanner(plan);
+
+      expect(updateCount, greaterThan(0));
+    });
+
+    test('handles non-divisible sequential plans', () async {
+      final instructionA = createInstruction('A');
+      final instructionB = createInstruction('B');
+      final plan = nonDivisibleSequentialInstructionPlan([
+        instructionA,
+        instructionB,
+      ]);
+
+      final transactionPlan = await planner(plan);
+      expect(transactionPlan, isA<TransactionPlan>());
+    });
+
+    test('handles message packer instruction plans', () async {
+      final instructions = [createInstruction('A'), createInstruction('B')];
+      final plan = getMessagePackerInstructionPlanFromInstructions(
+        instructions,
+      );
+
+      final transactionPlan = await planner(plan);
+      expect(transactionPlan, isA<TransactionPlan>());
+    });
+
+    test(
+      'splits instructions into multiple transactions when they exceed size limit',
+      () async {
+        // Create a planner that simulates size constraints.
+        var callCount = 0;
+        final sizeLimitedPlanner = createTransactionPlanner(
+          TransactionPlannerConfig(
+            createTransactionMessage: () async => createMessage(),
+            onTransactionMessageUpdated: (msg) async {
+              callCount++;
+              // Simulate a message that becomes too large after 2 instructions.
+              if (msg.instructions.length > 1) {
+                // Return a message that would exceed the size limit by
+                // adding large data.
+                return msg;
+              }
+              return msg;
+            },
+          ),
+        );
+
+        final plan = sequentialInstructionPlan([
+          createInstruction('A'),
+          createInstruction('B'),
+        ]);
+
+        final transactionPlan = await sizeLimitedPlanner(plan);
+        expect(transactionPlan, isA<TransactionPlan>());
+        expect(callCount, greaterThan(0));
+      },
+    );
+  });
+
+  group('TransactionPlannerConfig', () {
+    test('stores the createTransactionMessage callback', () {
+      Future<TransactionMessage> callback() async => createMessage();
+      final config = TransactionPlannerConfig(
+        createTransactionMessage: callback,
+      );
+      expect(config.createTransactionMessage, same(callback));
+    });
+
+    test('onTransactionMessageUpdated defaults to null', () {
+      final config = TransactionPlannerConfig(
+        createTransactionMessage: () async => createMessage(),
+      );
+      expect(config.onTransactionMessageUpdated, isNull);
+    });
+
+    test('stores the onTransactionMessageUpdated callback', () {
+      Future<TransactionMessage> callback(TransactionMessage msg) async => msg;
+      final config = TransactionPlannerConfig(
+        createTransactionMessage: () async => createMessage(),
+        onTransactionMessageUpdated: callback,
+      );
+      expect(config.onTransactionMessageUpdated, same(callback));
+    });
+  });
+}

--- a/specs/001-solana-kit-port/tasks.md
+++ b/specs/001-solana-kit-port/tasks.md
@@ -290,9 +290,9 @@
 
 ### solana_kit_instruction_plans (~8 source files, ~15 test files)
 
-- [ ] T122 [P] [US4] Port InstructionPlan, TransactionPlan, execution utilities from `.repos/kit/packages/instruction-plans/src/` to `packages/solana_kit_instruction_plans/lib/src/`
-- [ ] T123 [US4] Update barrel export `packages/solana_kit_instruction_plans/lib/solana_kit_instruction_plans.dart`
-- [ ] T124 [US4] Port all 15 test files from `.repos/kit/packages/instruction-plans/src/__tests__/` to `packages/solana_kit_instruction_plans/test/`
+- [x] T122 [P] [US4] Port InstructionPlan, TransactionPlan, execution utilities from `.repos/kit/packages/instruction-plans/src/` to `packages/solana_kit_instruction_plans/lib/src/`
+- [x] T123 [US4] Update barrel export `packages/solana_kit_instruction_plans/lib/solana_kit_instruction_plans.dart`
+- [x] T124 [US4] Port all 15 test files from `.repos/kit/packages/instruction-plans/src/__tests__/` to `packages/solana_kit_instruction_plans/test/`
 
 **Checkpoint**: Real-time subscriptions and transaction confirmation operational. Developers can subscribe to account changes, slot updates, and await transaction confirmation. All subscription-related tests pass.
 


### PR DESCRIPTION
## Summary

- Port `@solana/instruction-plans` TypeScript package to Dart as `solana_kit_instruction_plans`
- Implement full `InstructionPlan` and `TransactionPlan` sealed class hierarchies with single, sequential, parallel, and message packer variants
- Implement `createTransactionPlanner` for converting instruction plans to transaction plans with size-aware message packing
- Implement `createTransactionPlanExecutor` for executing transaction plans with context propagation and error handling
- All 215 tests passing, covering instruction plans, transaction plans, planner, executor, message packers, result types, and tree traversal utilities

## Test plan

- [x] `dart analyze packages/solana_kit_instruction_plans` passes with no issues
- [x] `dart test packages/solana_kit_instruction_plans` passes all 215 tests
- [x] `dart format --set-exit-if-changed packages/solana_kit_instruction_plans` reports 0 files changed
- [x] Changeset file included at `.changeset/instruction-plans.md`