### PR TITLE
📝 docs: add comprehensive readmes for all 37 packages

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -47,6 +47,11 @@ solana_kit_errors (foundation - no deps)
   └── solana_kit (umbrella - re-exports everything)
 ```
 
+## Important Rules
+
+- **Never delete files in `.changeset/`** — changeset files track release notes and versioning decisions. They are consumed by `knope release` and must not be manually removed.
+- **Always keep readme files and docs up to date** — when modifying a package's public API, behavior, or usage patterns, update its `readme.md` to reflect the changes. Documentation must stay in sync with the code.
+
 ## Coding Conventions
 
 - Modern Dart 3.10+ features: sealed classes, extension types, records, patterns

--- a/packages/solana_kit/readme.md
+++ b/packages/solana_kit/readme.md
@@ -1,0 +1,324 @@
+# solana_kit
+
+The Solana Kit Dart SDK -- a comprehensive, modular Dart port of the [Solana TypeScript SDK (`@solana/kit`)](https://github.com/anza-xyz/kit).
+
+This is the umbrella package that re-exports all 35 public packages in the SDK, giving you a single import for the entire Solana development toolkit.
+
+## Installation
+
+Add `solana_kit` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+Then import everything with a single line:
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+```
+
+## Quick start
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+Future<void> main() async {
+  // 1. Create an RPC client.
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  // 2. Generate a new Ed25519 key pair.
+  final keyPair = await generateKeyPair();
+  final signer = await createKeyPairSignerFromKeyPair(keyPair);
+  print('Address: ${signer.address}');
+
+  // 3. Check the balance.
+  final balanceResponse = await rpc.request('getBalance', [
+    signer.address.value,
+    {'commitment': 'confirmed'},
+  ]).send();
+  print('Balance: $balanceResponse');
+
+  // 4. Fetch an account.
+  final account = await fetchEncodedAccount(
+    rpc,
+    const Address('11111111111111111111111111111111'),
+  );
+  if (account.exists) {
+    print('System program account exists');
+  }
+}
+```
+
+## Usage
+
+### Addresses
+
+Create, validate, and derive Solana addresses.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+Future<void> main() async {
+  // Validate an address.
+  final addr = address('11111111111111111111111111111112');
+  print(isAddress('11111111111111111111111111111112')); // true
+
+  // Derive a program-derived address (PDA).
+  const tokenProgram = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+  final (pda, bump) = await getProgramDerivedAddress(
+    programAddress: tokenProgram,
+    seeds: ['metadata'],
+  );
+  print('PDA: ${pda.value}, bump: $bump');
+}
+```
+
+### Keys and signers
+
+Generate key pairs and create transaction signers.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+Future<void> main() async {
+  // Generate a new key pair.
+  final keyPair = await generateKeyPair();
+
+  // Create a signer from the key pair.
+  final signer = await createKeyPairSignerFromKeyPair(keyPair);
+  print('Signer address: ${signer.address}');
+
+  // Sign a message.
+  final signature = await signer.signMessages([
+    Uint8List.fromList('Hello Solana'.codeUnits),
+  ]);
+  print('Signed: ${signature.length} signature(s)');
+}
+```
+
+### RPC client
+
+Make JSON-RPC calls to a Solana node.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  // Get the latest blockhash.
+  final blockhashResponse = await rpc.request('getLatestBlockhash', [
+    {'commitment': 'confirmed'},
+  ]).send();
+  print('Blockhash: $blockhashResponse');
+
+  // Get the minimum balance for rent exemption.
+  final rentExemption = getMinimumBalanceForRentExemption(165);
+  print('Rent exemption for 165 bytes: ${rentExemption.value} lamports');
+}
+```
+
+### Accounts
+
+Fetch and decode on-chain accounts.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  // Fetch a single account.
+  final maybeAccount = await fetchEncodedAccount(
+    rpc,
+    const Address('11111111111111111111111111111111'),
+  );
+
+  switch (maybeAccount) {
+    case ExistingAccount(:final account):
+      print('Lamports: ${account.lamports}');
+      print('Data: ${account.data.length} bytes');
+      print('Owner: ${account.programAddress}');
+    case NonExistingAccount(:final address):
+      print('Account not found at $address');
+  }
+
+  // Fetch multiple accounts at once.
+  final accounts = await fetchEncodedAccounts(rpc, [
+    const Address('11111111111111111111111111111111'),
+    const Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+  ]);
+  print('Fetched ${accounts.length} accounts');
+}
+```
+
+### Codecs
+
+Encode and decode binary data for on-chain structures.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+void main() {
+  // Encode and decode addresses.
+  final addr = address('11111111111111111111111111111111');
+  final encoder = getAddressEncoder();
+  final bytes = encoder.encode(addr);
+  print('Address encoded to ${bytes.length} bytes'); // 32
+
+  // Encode and decode numbers.
+  final u64Encoder = getU64Encoder();
+  final numBytes = u64Encoder.encode(BigInt.from(1000000));
+  print('U64 encoded to ${numBytes.length} bytes'); // 8
+}
+```
+
+### Sysvars
+
+Access Solana system variables.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  // Fetch the Clock sysvar.
+  final clock = await fetchSysvarClock(rpc);
+  print('Current slot: ${clock.slot}');
+  print('Current epoch: ${clock.epoch}');
+  print('Unix timestamp: ${clock.unixTimestamp}');
+
+  // Fetch the Rent sysvar.
+  final rent = await fetchSysvarRent(rpc);
+  print('Lamports per byte-year: ${rent.lamportsPerByteYear}');
+
+  // All sysvar addresses are available as constants.
+  print('Clock: ${sysvarClockAddress.value}');
+  print('Rent: ${sysvarRentAddress.value}');
+}
+```
+
+### RPC subscriptions
+
+Subscribe to real-time notifications over WebSocket.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+Future<void> main() async {
+  final subscriptions = createSolanaRpcSubscriptions(
+    'wss://api.devnet.solana.com',
+  );
+
+  final controller = AbortController();
+
+  // Subscribe to slot notifications.
+  final pending = subscriptions.request('slotNotifications');
+  final stream = await pending.subscribe(
+    RpcSubscribeOptions(abortSignal: controller.signal),
+  );
+
+  var count = 0;
+  await for (final notification in stream) {
+    print('Slot: $notification');
+    count++;
+    if (count >= 3) {
+      controller.abort();
+    }
+  }
+}
+```
+
+### Transaction confirmation
+
+Confirm transactions using multiple strategies.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+void main() {
+  // Compare commitment levels.
+  print(commitmentComparator(Commitment.finalized, Commitment.confirmed) > 0);
+  // true -- finalized is higher than confirmed
+
+  // Calculate rent exemption without an RPC call.
+  final balance = getMinimumBalanceForRentExemption(165);
+  print('Minimum balance: ${balance.value} lamports');
+}
+```
+
+### Error handling
+
+All errors in the SDK are structured `SolanaError` instances.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+void main() {
+  try {
+    // This will throw because the string is not a valid address.
+    address('not-valid');
+  } on SolanaError catch (e) {
+    print('Error code: ${e.code}');
+    print('Message: $e');
+    if (isSolanaError(e, SolanaErrorCode.addressesInvalidBase58EncodedAddress)) {
+      print('Invalid address format');
+    }
+  }
+}
+```
+
+## Re-exported packages
+
+This umbrella package re-exports the following packages:
+
+| Package | Description |
+|---------|-------------|
+| `solana_kit_accounts` | Account fetching and decoding |
+| `solana_kit_addresses` | Base58 address utilities and PDA derivation |
+| `solana_kit_codecs` | Codec umbrella (core, numbers, strings, data structures) |
+| `solana_kit_errors` | Error codes, error class, and error conversion |
+| `solana_kit_fast_stable_stringify` | Deterministic JSON serialization |
+| `solana_kit_functional` | Functional programming utilities (pipe, compose) |
+| `solana_kit_instruction_plans` | Instruction plan composition |
+| `solana_kit_instructions` | Instruction types and account meta |
+| `solana_kit_keys` | Key pair generation and signature types |
+| `solana_kit_offchain_messages` | Off-chain message signing |
+| `solana_kit_options` | Borsh-compatible Option codec |
+| `solana_kit_program_client_core` | Program client building blocks |
+| `solana_kit_programs` | Program error identification |
+| `solana_kit_rpc` | RPC client factory |
+| `solana_kit_rpc_parsed_types` | Parsed RPC response types |
+| `solana_kit_rpc_spec_types` | RPC specification types |
+| `solana_kit_rpc_subscriptions` | WebSocket subscription client |
+| `solana_kit_rpc_transport_http` | HTTP transport for RPC |
+| `solana_kit_rpc_types` | RPC type definitions (Commitment, Lamports, etc.) |
+| `solana_kit_signers` | Transaction signer abstractions |
+| `solana_kit_subscribable` | Pub/sub event patterns |
+| `solana_kit_sysvars` | System variable account access |
+| `solana_kit_transaction_confirmation` | Transaction confirmation strategies |
+| `solana_kit_transaction_messages` | Transaction message building |
+| `solana_kit_transactions` | Transaction types and serialization |
+
+### Umbrella-specific helpers
+
+| Function | Description |
+|----------|-------------|
+| `getMinimumBalanceForRentExemption(int space)` | Calculates the minimum lamports for rent exemption without an RPC call. Uses on-chain rent parameters from the Solana runtime. |
+
+## API Reference
+
+Since this is an umbrella package, the complete API is the union of all re-exported packages. Refer to each package's readme for detailed API documentation:
+
+- [solana_kit_errors](../solana_kit_errors/readme.md)
+- [solana_kit_addresses](../solana_kit_addresses/readme.md)
+- [solana_kit_accounts](../solana_kit_accounts/readme.md)
+- [solana_kit_sysvars](../solana_kit_sysvars/readme.md)
+- [solana_kit_rpc_subscriptions](../solana_kit_rpc_subscriptions/readme.md)
+- [solana_kit_subscribable](../solana_kit_subscribable/readme.md)
+- [solana_kit_programs](../solana_kit_programs/readme.md)
+- [solana_kit_program_client_core](../solana_kit_program_client_core/readme.md)
+- [solana_kit_transaction_confirmation](../solana_kit_transaction_confirmation/readme.md)

--- a/packages/solana_kit_accounts/readme.md
+++ b/packages/solana_kit_accounts/readme.md
@@ -1,0 +1,384 @@
+# solana_kit_accounts
+
+Account fetching, decoding, and assertion utilities for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/accounts`](https://github.com/anza-xyz/kit/tree/main/packages/accounts) from the Solana TypeScript SDK.
+
+## Installation
+
+Add `solana_kit_accounts` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_accounts:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### The Account type
+
+The `Account<TData>` class contains all the information relevant to a Solana account: its address, data, and on-chain metadata.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+void main() {
+  // An encoded account stores its data as raw bytes.
+  final encodedAccount = Account<Uint8List>(
+    address: const Address('11111111111111111111111111111111'),
+    data: Uint8List.fromList([1, 2, 3, 4]),
+    executable: false,
+    lamports: Lamports(BigInt.from(1000000000)),
+    programAddress: const Address('11111111111111111111111111111111'),
+    space: BigInt.from(4),
+  );
+
+  print(encodedAccount.address); // Address('11111111111111111111111111111111')
+  print(encodedAccount.lamports); // Lamports(1000000000)
+  print(encodedAccount.executable); // false
+  print(encodedAccount.data.length); // 4
+
+  // The EncodedAccount type alias is Account<Uint8List>.
+  final EncodedAccount sameType = encodedAccount;
+}
+```
+
+### MaybeAccount -- handling accounts that may not exist
+
+`MaybeAccount<TData>` is a sealed class hierarchy that represents an account that may or may not exist on-chain. Pattern matching is the idiomatic way to handle both cases.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+void handleAccount(MaybeAccount<Uint8List> maybeAccount) {
+  switch (maybeAccount) {
+    case ExistingAccount<Uint8List>(:final account):
+      print('Account exists with ${account.data.length} bytes');
+      print('Lamports: ${account.lamports}');
+    case NonExistingAccount():
+      print('Account does not exist at ${maybeAccount.address}');
+  }
+
+  // Or use the exists flag.
+  if (maybeAccount.exists) {
+    print('Found at ${maybeAccount.address}');
+  }
+}
+```
+
+### Fetching accounts from the RPC
+
+Use `fetchEncodedAccount` and `fetchEncodedAccounts` to retrieve accounts from a Solana RPC node. These functions use the `getAccountInfo` and `getMultipleAccounts` RPC methods with base64 encoding.
+
+```dart
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  // Fetch a single account.
+  final maybeAccount = await fetchEncodedAccount(
+    rpc,
+    const Address('11111111111111111111111111111111'),
+  );
+
+  if (maybeAccount.exists) {
+    print('Account found at ${maybeAccount.address}');
+  }
+
+  // Fetch with a specific commitment level.
+  final confirmedAccount = await fetchEncodedAccount(
+    rpc,
+    const Address('11111111111111111111111111111111'),
+    config: FetchAccountConfig(commitment: Commitment.confirmed),
+  );
+
+  // Fetch multiple accounts at once.
+  final accounts = await fetchEncodedAccounts(
+    rpc,
+    [
+      const Address('11111111111111111111111111111111'),
+      const Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+    ],
+  );
+  print('Fetched ${accounts.length} accounts');
+}
+```
+
+### Fetching JSON-parsed accounts
+
+The `fetchJsonParsedAccount` and `fetchJsonParsedAccounts` functions use the `jsonParsed` encoding, which returns human-readable data for well-known program accounts (e.g. SPL Token accounts).
+
+```dart
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+  const tokenAccountAddress = Address(
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+  );
+
+  // Fetch a single JSON-parsed account.
+  final account = await fetchJsonParsedAccount(rpc, tokenAccountAddress);
+  if (account case ExistingAccount<Object>(:final account)) {
+    if (account.data case JsonParsedAccountData<Map<String, Object?>>(:final parsedAccountMeta, :final data)) {
+      print('Program: ${parsedAccountMeta?.program}');
+      print('Type: ${parsedAccountMeta?.type}');
+      print('Parsed data: $data');
+    }
+  }
+}
+```
+
+### Decoding accounts
+
+Transform an `EncodedAccount` into an `Account<TData>` using a `Decoder`.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// A simple data type for demonstration.
+class MyData {
+  const MyData(this.value);
+  final int value;
+}
+
+// A decoder that reads a little-endian u32 from the account data.
+class MyDataDecoder implements Decoder<MyData> {
+  const MyDataDecoder();
+
+  @override
+  MyData decode(Uint8List bytes, [int offset = 0]) => read(bytes, offset).$1;
+
+  @override
+  (MyData, int) read(Uint8List bytes, int offset) {
+    final byteData = ByteData.sublistView(bytes);
+    final value = byteData.getUint32(offset, Endian.little);
+    return (MyData(value), offset + 4);
+  }
+
+  @override
+  int get fixedSize => 4;
+
+  @override
+  int? get maxSize => 4;
+}
+
+void main() {
+  // Create an encoded account.
+  final encodedAccount = Account<Uint8List>(
+    address: const Address('11111111111111111111111111111111'),
+    data: Uint8List.fromList([42, 0, 0, 0]),
+    executable: false,
+    lamports: Lamports(BigInt.from(1000000)),
+    programAddress: const Address('11111111111111111111111111111111'),
+    space: BigInt.from(4),
+  );
+
+  // Decode the account using a custom decoder.
+  const decoder = MyDataDecoder();
+  final decodedAccount = decodeAccount<MyData>(encodedAccount, decoder);
+  print(decodedAccount.data.value); // 42
+}
+```
+
+For `MaybeAccount`, use `decodeMaybeAccount`:
+
+```dart
+Future<void> fetchAndDecode() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+  const decoder = MyDataDecoder();
+
+  final maybeFetched = await fetchEncodedAccount(
+    rpc,
+    const Address('11111111111111111111111111111111'),
+  );
+  final maybeDecoded = decodeMaybeAccount<MyData>(maybeFetched, decoder);
+
+  switch (maybeDecoded) {
+    case ExistingAccount<MyData>(:final account):
+      print('Decoded value: ${account.data.value}');
+    case NonExistingAccount():
+      print('Account not found');
+  }
+}
+```
+
+### Asserting account state
+
+Use assertion functions to validate account existence and decoding state.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  // Assert that a MaybeAccount exists.
+  // Throws SolanaError with code accountsAccountNotFound if it does not.
+  final maybeAccount = await fetchEncodedAccount(
+    rpc,
+    const Address('11111111111111111111111111111111'),
+  );
+  assertAccountExists(maybeAccount);
+
+  // Assert multiple accounts all exist.
+  // Throws SolanaError with code accountsOneOrMoreAccountsNotFound.
+  final accounts = await fetchEncodedAccounts(rpc, [
+    const Address('11111111111111111111111111111111'),
+    const Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+  ]);
+  assertAccountsExist(accounts);
+
+  // Assert that an account stores decoded data (not Uint8List).
+  // Throws SolanaError with code accountsExpectedDecodedAccount
+  // if the data field is still a Uint8List (i.e. not yet decoded).
+  // assertAccountDecoded(decodedAccount);
+
+  // Assert all accounts in a list are decoded.
+  // Throws SolanaError with code accountsExpectedAllAccountsToBeDecoded.
+  // assertAccountsDecoded(decodedAccounts);
+}
+```
+
+### Parsing raw RPC account data
+
+Convert raw JSON-RPC account maps into typed `MaybeAccount` instances.
+
+```dart
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+void main() {
+  const addr = Address('11111111111111111111111111111111');
+
+  // Parse a base64-encoded RPC response.
+  final account = parseBase64RpcAccount(addr, {
+    'data': ['AQAAAA==', 'base64'],
+    'executable': false,
+    'lamports': 1000000000,
+    'owner': '11111111111111111111111111111111',
+    'space': 4,
+  });
+
+  if (account case ExistingAccount(:final data)) {
+    print('Data length: ${data.length}');
+  }
+
+  // Parse a null response (account not found).
+  final missing = parseBase64RpcAccount(addr, null);
+  print(missing.exists); // false
+
+  // Parse a jsonParsed-encoded RPC response.
+  final jsonParsed = parseJsonRpcAccount(addr, {
+    'data': {
+      'parsed': {
+        'info': {'balance': 1000},
+        'type': 'account',
+      },
+      'program': 'system',
+      'space': 4,
+    },
+    'executable': false,
+    'lamports': 1000000000,
+    'owner': '11111111111111111111111111111111',
+    'space': 4,
+  });
+}
+```
+
+## API Reference
+
+### Classes
+
+| Class                          | Description                                                              |
+| ------------------------------ | ------------------------------------------------------------------------ |
+| `BaseAccount`                  | Base properties: `executable`, `lamports`, `programAddress`, `space`.    |
+| `Account<TData>`               | Extends `BaseAccount` with `address` and `data` of type `TData`.         |
+| `MaybeAccount<TData>`          | Sealed class: account that may or may not exist.                         |
+| `ExistingAccount<TData>`       | Extends `MaybeAccount`. Wraps an `Account<TData>` with `exists == true`. |
+| `NonExistingAccount<TData>`    | Extends `MaybeAccount`. Only has `address` with `exists == false`.       |
+| `FetchAccountConfig`           | Optional config: `commitment`, `minContextSlot`.                         |
+| `JsonParsedAccountData<TData>` | Parsed account data with optional `ParsedAccountMeta`.                   |
+| `ParsedAccountMeta`            | Metadata from jsonParsed responses: `program`, `type`.                   |
+
+### Type aliases
+
+| Type                  | Description                                                      |
+| --------------------- | ---------------------------------------------------------------- |
+| `EncodedAccount`      | `Account<Uint8List>` -- an account with raw byte data.           |
+| `MaybeEncodedAccount` | `MaybeAccount<Uint8List>` -- a maybe-account with raw byte data. |
+
+### Fetch functions
+
+| Function                                             | Description                                                                         |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `fetchEncodedAccount(rpc, address, {config?})`       | Fetches a single `MaybeEncodedAccount` using `getAccountInfo` with base64 encoding. |
+| `fetchEncodedAccounts(rpc, addresses, {config?})`    | Fetches multiple `MaybeEncodedAccount`s using `getMultipleAccounts`.                |
+| `fetchJsonParsedAccount(rpc, address, {config?})`    | Fetches a single `MaybeAccount<Object>` using `jsonParsed` encoding.                |
+| `fetchJsonParsedAccounts(rpc, addresses, {config?})` | Fetches multiple `MaybeAccount<Object>`s using `jsonParsed` encoding.               |
+
+### Decode functions
+
+| Function                                       | Description                                               |
+| ---------------------------------------------- | --------------------------------------------------------- |
+| `decodeAccount<T>(encodedAccount, decoder)`    | Decodes an `EncodedAccount` into an `Account<T>`.         |
+| `decodeMaybeAccount<T>(maybeEncoded, decoder)` | Decodes a `MaybeEncodedAccount` into a `MaybeAccount<T>`. |
+
+### Assertion functions
+
+| Function                                  | Description                                             |
+| ----------------------------------------- | ------------------------------------------------------- |
+| `assertAccountExists<T>(maybeAccount)`    | Throws if the account does not exist.                   |
+| `assertAccountsExist<T>(accounts)`        | Throws if any account does not exist.                   |
+| `assertAccountDecoded<T>(account)`        | Throws if the account data is still a `Uint8List`.      |
+| `assertMaybeAccountDecoded<T>(account)`   | Throws if an existing account's data is still encoded.  |
+| `assertAccountsDecoded<T>(accounts)`      | Throws if any account's data is still encoded.          |
+| `assertMaybeAccountsDecoded<T>(accounts)` | Throws if any existing account's data is still encoded. |
+
+### Parse functions
+
+| Function                                      | Description                                                                       |
+| --------------------------------------------- | --------------------------------------------------------------------------------- |
+| `parseBase64RpcAccount(address, rpcAccount?)` | Parses a base64-encoded RPC account map into a `MaybeEncodedAccount`.             |
+| `parseBase58RpcAccount(address, rpcAccount?)` | Parses a base58-encoded RPC account map into a `MaybeEncodedAccount`.             |
+| `parseJsonRpcAccount(address, rpcAccount?)`   | Parses a jsonParsed RPC account map into a `MaybeAccount<JsonParsedAccountData>`. |
+| `parseBaseAccount(rpcAccount)`                | Extracts `BaseAccount` properties from a raw RPC account map.                     |
+
+### Constants
+
+| Constant          | Description                                                         |
+| ----------------- | ------------------------------------------------------------------- |
+| `baseAccountSize` | `128` -- the number of bytes for account metadata (excluding data). |

--- a/packages/solana_kit_addresses/readme.md
+++ b/packages/solana_kit_addresses/readme.md
@@ -1,0 +1,255 @@
+# solana_kit_addresses
+
+Base58-encoded Solana address utilities for the Solana Kit Dart SDK -- a Dart port of [`@solana/addresses`](https://github.com/anza-xyz/kit/tree/main/packages/addresses).
+
+## Installation
+
+Add `solana_kit_addresses` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_addresses:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Creating and validating addresses
+
+The `Address` type is a zero-overhead extension type wrapping a `String`. Use the `address()` factory function to create a validated address from an untrusted string, or the `Address()` constructor directly when you know the string is valid.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+void main() {
+  // Create a validated address from an untrusted string.
+  // Throws SolanaError if the string is not a valid base58-encoded 32-byte address.
+  final myAddress = address('11111111111111111111111111111112');
+
+  // For known-good strings you can use the constructor directly (no validation).
+  const systemProgram = Address('11111111111111111111111111111111');
+
+  // Check whether a string is a valid Solana address without throwing.
+  final valid = isAddress('11111111111111111111111111111112'); // true
+  final invalid = isAddress('not-a-valid-address'); // false
+
+  // Assert validity -- throws SolanaError on failure.
+  assertIsAddress('11111111111111111111111111111112');
+}
+```
+
+### Converting between addresses and public keys
+
+Convert between a raw 32-byte Ed25519 public key (`Uint8List`) and a base58-encoded `Address`.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+void main() {
+  // Suppose you have a 32-byte public key from an Ed25519 key pair.
+  final publicKeyBytes = Uint8List(32); // replace with real bytes
+
+  // Convert raw public key bytes to an Address.
+  final addr = getAddressFromPublicKey(publicKeyBytes);
+  print(addr.value); // base58-encoded string
+
+  // Convert an Address back to raw 32-byte public key bytes.
+  final bytesAgain = getPublicKeyFromAddress(addr);
+  print(bytesAgain.length); // 32
+}
+```
+
+### Encoding and decoding addresses
+
+The address codec encodes and decodes `Address` values as fixed-size 32-byte binary representations. This is useful for serializing addresses in on-chain data structures.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+void main() {
+  final addr = address('11111111111111111111111111111112');
+
+  // Get a fixed-size encoder (Address -> 32 bytes).
+  final encoder = getAddressEncoder();
+  final bytes = encoder.encode(addr);
+  print(bytes.length); // 32
+
+  // Get a fixed-size decoder (32 bytes -> Address).
+  final decoder = getAddressDecoder();
+  final decoded = decoder.decode(bytes);
+  print(decoded.value); // '11111111111111111111111111111112'
+
+  // Or use the combined codec.
+  final codec = getAddressCodec();
+  final roundTripped = codec.decode(codec.encode(addr));
+  print(roundTripped.value == addr.value); // true
+}
+```
+
+### Comparing addresses
+
+The `getAddressComparator()` function returns a comparator that sorts addresses using base58 collation rules, matching the ordering used by the Solana runtime.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+void main() {
+  final addresses = [
+    address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+    address('11111111111111111111111111111111'),
+    address('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'),
+  ];
+
+  final comparator = getAddressComparator();
+  addresses.sort(comparator);
+
+  // Addresses are now in base58 collation order.
+  for (final addr in addresses) {
+    print(addr.value);
+  }
+}
+```
+
+### Checking if an address is on/off the Ed25519 curve
+
+Solana program-derived addresses (PDAs) must NOT fall on the Ed25519 curve. Use these utilities to verify curve membership.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+void main() {
+  // Check raw compressed point bytes (32 bytes).
+  final pointBytes = Uint8List(32); // replace with real bytes
+  final onCurve = compressedPointBytesAreOnCurve(pointBytes);
+  print('On curve: $onCurve');
+
+  // Check an address directly.
+  final addr = address('11111111111111111111111111111112');
+  print('Is on curve: ${isOnCurveAddress(addr)}');
+  print('Is off curve: ${isOffCurveAddress(addr)}');
+
+  // Assert curve membership -- throws SolanaError on failure.
+  assertIsOnCurveAddress(addr);
+
+  // Assert off-curve (useful for validating PDAs).
+  // assertIsOffCurveAddress(somePda);
+}
+```
+
+### Deriving program-derived addresses (PDAs)
+
+Program-derived addresses are deterministic addresses derived from a program address and a set of seeds. The runtime guarantees that no private key exists for a PDA.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+Future<void> main() async {
+  const programAddress = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+  // Derive a PDA with string and byte seeds.
+  // Seeds can be String values (UTF-8 encoded) or Uint8List byte arrays.
+  // Maximum 16 seeds, each at most 32 bytes.
+  final (pda, bump) = await getProgramDerivedAddress(
+    programAddress: programAddress,
+    seeds: ['metadata', Uint8List.fromList([1, 2, 3])],
+  );
+
+  print('PDA: ${pda.value}');
+  print('Bump seed: $bump'); // 0-255
+
+  // The PDA is guaranteed to be off the Ed25519 curve.
+  print('Off curve: ${isOffCurveAddress(pda)}'); // true
+}
+```
+
+### Creating addresses with a seed (SHA-256 based)
+
+This is the older `createAccountWithSeed` style derivation, which differs from PDA derivation. It concatenates the base address, seed, and program address and takes their SHA-256 hash.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+Future<void> main() async {
+  const baseAddress = Address('11111111111111111111111111111111');
+  const programAddress = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+  // Create an address derived from a base address, seed, and program address.
+  // The seed can be a String (UTF-8 encoded) or Uint8List, at most 32 bytes.
+  final derived = await createAddressWithSeed(
+    baseAddress: baseAddress,
+    programAddress: programAddress,
+    seed: 'my-seed',
+  );
+
+  print('Derived address: ${derived.value}');
+}
+```
+
+## API Reference
+
+### Types
+
+| Export | Description |
+|--------|-------------|
+| `Address` | Extension type wrapping `String` -- a validated base58-encoded 32-byte Solana address. Zero runtime overhead. |
+| `ProgramDerivedAddress` | Type alias for `(Address pda, int bump)` -- a derived address paired with its bump seed. |
+
+### Address creation and validation
+
+| Function | Description |
+|----------|-------------|
+| `address(String)` | Creates a validated `Address` from an untrusted string. Throws on invalid input. |
+| `assertIsAddress(String)` | Asserts that a string is a valid base58 Solana address. Throws `SolanaError` on failure. |
+| `isAddress(String)` | Returns `true` if the string is a valid base58 Solana address. |
+
+### Public key conversion
+
+| Function | Description |
+|----------|-------------|
+| `getAddressFromPublicKey(Uint8List)` | Converts a 32-byte Ed25519 public key to an `Address`. |
+| `getPublicKeyFromAddress(Address)` | Converts an `Address` to its 32-byte Ed25519 public key. |
+
+### Codecs
+
+| Function | Description |
+|----------|-------------|
+| `getAddressEncoder()` | Returns a `FixedSizeEncoder<Address>` that encodes an address into exactly 32 bytes. |
+| `getAddressDecoder()` | Returns a `FixedSizeDecoder<Address>` that decodes exactly 32 bytes into an address. |
+| `getAddressCodec()` | Returns a `FixedSizeCodec<Address, Address>` combining encoder and decoder. |
+
+### Comparator
+
+| Function | Description |
+|----------|-------------|
+| `getAddressComparator()` | Returns a `Comparator<Address>` using base58 collation rules. |
+
+### Curve checks
+
+| Function | Description |
+|----------|-------------|
+| `compressedPointBytesAreOnCurve(Uint8List)` | Returns `true` if the 32-byte compressed point is on the Ed25519 curve. |
+| `isOnCurveAddress(Address)` | Returns `true` if the address decodes to a point on the Ed25519 curve. |
+| `isOffCurveAddress(Address)` | Returns `true` if the address is NOT on the Ed25519 curve. |
+| `assertIsOnCurveAddress(Address)` | Asserts the address is on curve. Throws `SolanaError` on failure. |
+| `assertIsOffCurveAddress(Address)` | Asserts the address is off curve. Throws `SolanaError` on failure. |
+
+### Program-derived addresses
+
+| Function | Description |
+|----------|-------------|
+| `getProgramDerivedAddress({required Address programAddress, required List<Object> seeds})` | Derives a PDA by searching for a valid bump seed (255 down to 0). Returns `Future<ProgramDerivedAddress>`. |
+| `createAddressWithSeed({required Address baseAddress, required Address programAddress, required Object seed})` | Creates a SHA-256-based derived address. Returns `Future<Address>`. |

--- a/packages/solana_kit_codecs/readme.md
+++ b/packages/solana_kit_codecs/readme.md
@@ -1,0 +1,125 @@
+# solana_kit_codecs
+
+Umbrella package that re-exports all Solana Kit codec sub-packages through a single import.
+
+This is a Dart port of [`@solana/codecs`](https://github.com/anza-xyz/kit/tree/main/packages/codecs) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_codecs:
+```
+
+Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+
+## Usage
+
+Instead of importing each codec sub-package individually, import `solana_kit_codecs` to get everything at once:
+
+```dart
+import 'package:solana_kit_codecs/solana_kit_codecs.dart';
+```
+
+This single import gives you access to all codec functionality from:
+
+- **solana_kit_codecs_core** -- Core interfaces (`Encoder`, `Decoder`, `Codec`) and composition utilities (`combineCodec`, `transformCodec`, `fixCodecSize`, `addCodecSizePrefix`, `addCodecSentinel`, `offsetCodec`, `padLeftCodec`, `padRightCodec`, `reverseCodec`, etc.)
+- **solana_kit_codecs_numbers** -- Numeric codecs for integers and floats (`getU8Codec`, `getU16Codec`, `getU32Codec`, `getU64Codec`, `getU128Codec`, `getI8Codec`, ..., `getF32Codec`, `getF64Codec`, `getShortU16Codec`)
+- **solana_kit_codecs_strings** -- String codecs (`getUtf8Codec`, `getBase58Codec`, `getBase16Codec`, `getBase64Codec`, `getBase10Codec`, `getBaseXCodec`, `getBaseXResliceCodec`)
+- **solana_kit_codecs_data_structures** -- Composite data structure codecs (`getStructCodec`, `getArrayCodec`, `getTupleCodec`, `getBooleanCodec`, `getNullableCodec`, `getMapCodec`, `getSetCodec`, `getDiscriminatedUnionCodec`, `getLiteralUnionCodec`, `getBitArrayCodec`, `getBytesCodec`, `getConstantCodec`, `getUnitCodec`, `getHiddenPrefixCodec`, `getHiddenSuffixCodec`)
+- **solana_kit_options** -- Rust-like `Option<T>` type and codec (`some`, `none`, `getOptionCodec`, `unwrapOption`, `unwrapOptionRecursively`)
+
+### Example: encoding a Solana account layout
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs/solana_kit_codecs.dart';
+
+// Define an account data layout (similar to a Borsh schema).
+final accountCodec = getStructCodec([
+  ('isInitialized', getBooleanCodec()),
+  ('authority', fixCodecSize(getBase58Codec(), 32)),
+  ('balance', getU64Codec()),
+  ('label', addCodecSizePrefix(getUtf8Codec(), getU32Codec())),
+  ('tags', getArrayCodec(
+    addCodecSizePrefix(getUtf8Codec(), getU32Codec()),
+    size: PrefixedArraySize(getU16Codec()),
+  )),
+]);
+
+// Encode account data.
+final encoded = accountCodec.encode({
+  'isInitialized': true,
+  'authority': '11111111111111111111111111111111',
+  'balance': BigInt.from(1000000000),
+  'label': 'My Account',
+  'tags': ['defi', 'staking'],
+});
+
+// Decode account data.
+final decoded = accountCodec.decode(encoded);
+// decoded['isInitialized'] == true
+// decoded['balance'] == BigInt.from(1000000000)
+// decoded['label'] == 'My Account'
+// decoded['tags'] == ['defi', 'staking']
+```
+
+### Example: encoding a Rust-like enum
+
+```dart
+import 'package:solana_kit_codecs/solana_kit_codecs.dart';
+
+// Define an instruction enum.
+final instructionCodec = getDiscriminatedUnionCodec([
+  ('initialize', getStructCodec([
+    ('authority', fixCodecSize(getBase58Codec(), 32)),
+    ('amount', getU64Codec()),
+  ])),
+  ('transfer', getStructCodec([
+    ('amount', getU64Codec()),
+  ])),
+  ('close', getUnitCodec()),
+]);
+
+// Encode a 'transfer' instruction.
+final bytes = instructionCodec.encode({
+  '__kind': 'transfer',
+  'amount': BigInt.from(500),
+});
+
+// Decode.
+final decoded = instructionCodec.decode(bytes);
+// decoded['__kind'] == 'transfer'
+// decoded['amount'] == BigInt.from(500)
+```
+
+### Example: working with Option types
+
+```dart
+import 'package:solana_kit_codecs/solana_kit_codecs.dart';
+
+// Encode an optional u64 field.
+final optionalBalance = getOptionCodec(getU64Codec());
+
+optionalBalance.encode(some(BigInt.from(42)));  // [0x01, ...8 bytes...]
+optionalBalance.encode(none<BigInt>());          // [0x00]
+
+// Decode and pattern match.
+final result = optionalBalance.decode(bytes);
+switch (result) {
+  case Some(:final value):
+    print('Balance: $value');
+  case None():
+    print('No balance set');
+}
+```
+
+## Re-exported packages
+
+| Package | Description |
+|---------|-------------|
+| [`solana_kit_codecs_core`](../solana_kit_codecs_core/) | Core interfaces and composition utilities |
+| [`solana_kit_codecs_numbers`](../solana_kit_codecs_numbers/) | Integer and float codecs |
+| [`solana_kit_codecs_strings`](../solana_kit_codecs_strings/) | String and base encoding codecs |
+| [`solana_kit_codecs_data_structures`](../solana_kit_codecs_data_structures/) | Struct, array, enum, and other composite codecs |
+| [`solana_kit_options`](../solana_kit_options/) | Rust-like `Option<T>` type and codec |

--- a/packages/solana_kit_codecs_core/readme.md
+++ b/packages/solana_kit_codecs_core/readme.md
@@ -1,0 +1,325 @@
+# solana_kit_codecs_core
+
+Core codec interfaces and composition utilities for encoding and decoding Solana data structures in Dart.
+
+This is a Dart port of [`@solana/codecs-core`](https://github.com/anza-xyz/kit/tree/main/packages/codecs-core) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_codecs_core:
+```
+
+Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+
+## Usage
+
+### Core types: Encoder, Decoder, and Codec
+
+The package provides three sealed class hierarchies for working with binary data:
+
+- **`Encoder<T>`** -- Encodes a value of type `T` into a `Uint8List`.
+- **`Decoder<T>`** -- Decodes a `Uint8List` into a value of type `T`.
+- **`Codec<TFrom, TTo>`** -- Combines both encoding and decoding. `TFrom` is the type accepted for encoding (may be looser), while `TTo` is the type returned when decoding.
+
+Each hierarchy has two concrete subtypes:
+
+- **`FixedSizeEncoder<T>`** / **`FixedSizeDecoder<T>`** / **`FixedSizeCodec<TFrom, TTo>`** -- Always operates on a fixed number of bytes (`fixedSize`).
+- **`VariableSizeEncoder<T>`** / **`VariableSizeDecoder<T>`** / **`VariableSizeCodec<TFrom, TTo>`** -- The byte length depends on the value.
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+// Create a simple fixed-size encoder for a single byte.
+final myEncoder = FixedSizeEncoder<int>(
+  fixedSize: 1,
+  write: (value, bytes, offset) {
+    bytes[offset] = value;
+    return offset + 1;
+  },
+);
+
+final encoded = myEncoder.encode(42);
+// encoded == Uint8List.fromList([42])
+
+// Create a matching decoder.
+final myDecoder = FixedSizeDecoder<int>(
+  fixedSize: 1,
+  read: (bytes, offset) => (bytes[offset], offset + 1),
+);
+
+final decoded = myDecoder.decode(Uint8List.fromList([42]));
+// decoded == 42
+```
+
+### Combining encoders and decoders
+
+Use `combineCodec` to pair an `Encoder` and a `Decoder` into a `Codec`. Both must have compatible sizes (both fixed or both variable, with matching sizes).
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+final encoder = FixedSizeEncoder<int>(
+  fixedSize: 1,
+  write: (value, bytes, offset) {
+    bytes[offset] = value;
+    return offset + 1;
+  },
+);
+
+final decoder = FixedSizeDecoder<int>(
+  fixedSize: 1,
+  read: (bytes, offset) => (bytes[offset], offset + 1),
+);
+
+final codec = combineCodec(encoder, decoder);
+// codec is a FixedSizeCodec<int, int>
+
+final bytes = codec.encode(255); // Uint8List [0xff]
+final value = codec.decode(bytes); // 255
+```
+
+### Extracting encoders and decoders from codecs
+
+Since `Codec` does not extend `Encoder` or `Decoder` (Dart does not support multiple inheritance of sealed classes), use `encoderFromCodec` and `decoderFromCodec` to extract them:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+// Given some codec...
+final codec = combineCodec(myEncoder, myDecoder);
+
+// Extract an Encoder view.
+final enc = encoderFromCodec(codec);
+final encoded = enc.encode(42);
+
+// Extract a Decoder view.
+final dec = decoderFromCodec(codec);
+final decoded = dec.decode(encoded);
+```
+
+### Transforming codecs
+
+Use `transformEncoder`, `transformDecoder`, and `transformCodec` to map between types:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+// Suppose we have a u8 encoder that encodes num values.
+// We can transform it to accept bool values instead.
+final boolEncoder = transformEncoder<num, bool>(
+  u8Encoder,
+  (bool value) => value ? 1 : 0,
+);
+
+final bytes = boolEncoder.encode(true); // Uint8List [0x01]
+
+// Transform a decoder to map its output.
+final boolDecoder = transformDecoder<int, bool>(
+  u8Decoder,
+  (int value, _, __) => value != 0,
+);
+
+final decoded = boolDecoder.decode(Uint8List.fromList([1])); // true
+```
+
+### Fixing codec size
+
+Convert a variable-size codec into a fixed-size one with `fixEncoderSize`, `fixDecoderSize`, and `fixCodecSize`:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+// Fix a variable-size encoder to always produce 32 bytes.
+final fixed = fixEncoderSize(myVariableEncoder, 32);
+// fixed.fixedSize == 32
+// Shorter values are zero-padded, longer values are truncated.
+```
+
+### Adding size prefixes
+
+Prefix the encoded data with its byte length using `addEncoderSizePrefix`, `addDecoderSizePrefix`, and `addCodecSizePrefix`:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+// Add a u32 size prefix to a variable-size encoder.
+final prefixed = addEncoderSizePrefix(myEncoder, u32Encoder);
+// When encoding, the byte length of the encoded value is written first,
+// followed by the encoded value itself.
+```
+
+### Adding sentinels
+
+Delimit encoded values with a sentinel byte sequence using `addEncoderSentinel`, `addDecoderSentinel`, and `addCodecSentinel`:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+final sentinel = Uint8List.fromList([0xff, 0xff]);
+
+// The encoder appends the sentinel after the encoded value.
+final sentineled = addEncoderSentinel(myEncoder, sentinel);
+
+// The decoder reads until the sentinel is found.
+final sentineledDecoder = addDecoderSentinel(myDecoder, sentinel);
+```
+
+### Reversing bytes
+
+Reverse the byte order of a fixed-size encoder, decoder, or codec:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+// Reverse a fixed-size encoder (e.g., to switch endianness).
+final reversed = reverseEncoder(myFixedEncoder);
+```
+
+### Offsetting and padding
+
+Adjust the read/write offset before and after encoding/decoding:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+// Add 4 bytes of left padding (zeroes before the encoded value).
+final padded = padLeftEncoder(myEncoder, 4);
+
+// Add 4 bytes of right padding (zeroes after the encoded value).
+final paddedRight = padRightEncoder(myEncoder, 4);
+
+// Use offsetEncoder for fine-grained control.
+final offset = offsetEncoder(
+  myEncoder,
+  OffsetConfig(
+    preOffset: (scope) => scope.preOffset + 2,
+  ),
+);
+```
+
+### Resizing codecs
+
+Change the reported size of a codec without altering its read/write behavior:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+// Increase the reported size by 8 bytes.
+final resized = resizeEncoder(myEncoder, (size) => size + 8);
+```
+
+### Checking codec size
+
+Use utility functions to inspect whether a codec is fixed-size or variable-size:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+
+isFixedSize(myCodec);    // true if fixed-size
+isVariableSize(myCodec); // true if variable-size
+
+// Assert and throw if the expectation is not met.
+assertIsFixedSize(myCodec);
+assertIsVariableSize(myCodec);
+
+// Get the encoded size of a specific value.
+final size = getEncodedSize(myValue, myEncoder);
+```
+
+## API Reference
+
+### Core types
+
+| Type | Description |
+|------|-------------|
+| `Encoder<T>` | Sealed class for encoding values to bytes |
+| `FixedSizeEncoder<T>` | Encoder with a fixed `fixedSize` |
+| `VariableSizeEncoder<T>` | Encoder with dynamic size via `getSizeFromValue` |
+| `Decoder<T>` | Sealed class for decoding bytes to values |
+| `FixedSizeDecoder<T>` | Decoder with a fixed `fixedSize` |
+| `VariableSizeDecoder<T>` | Decoder with dynamic size |
+| `Codec<TFrom, TTo>` | Sealed class combining encoding and decoding |
+| `FixedSizeCodec<TFrom, TTo>` | Codec with a fixed `fixedSize` |
+| `VariableSizeCodec<TFrom, TTo>` | Codec with dynamic size |
+
+### Composition functions
+
+| Function | Description |
+|----------|-------------|
+| `combineCodec(encoder, decoder)` | Combine an `Encoder` and `Decoder` into a `Codec` |
+| `encoderFromCodec(codec)` | Extract an `Encoder` from a `Codec` |
+| `decoderFromCodec(codec)` | Extract a `Decoder` from a `Codec` |
+
+### Transform functions
+
+| Function | Description |
+|----------|-------------|
+| `transformEncoder(encoder, unmap)` | Map input type before encoding |
+| `transformDecoder(decoder, map)` | Map output type after decoding |
+| `transformCodec(codec, unmap, [map])` | Map both input and output types |
+
+### Size manipulation
+
+| Function | Description |
+|----------|-------------|
+| `fixEncoderSize(encoder, fixedBytes)` | Fix an encoder to a constant byte size |
+| `fixDecoderSize(decoder, fixedBytes)` | Fix a decoder to a constant byte size |
+| `fixCodecSize(codec, fixedBytes)` | Fix a codec to a constant byte size |
+| `resizeEncoder(encoder, resize)` | Change the reported size of an encoder |
+| `resizeDecoder(decoder, resize)` | Change the reported size of a decoder |
+| `resizeCodec(codec, resize)` | Change the reported size of a codec |
+
+### Size prefix
+
+| Function | Description |
+|----------|-------------|
+| `addEncoderSizePrefix(encoder, prefix)` | Prefix encoded data with its byte length |
+| `addDecoderSizePrefix(decoder, prefix)` | Read a size prefix before decoding |
+| `addCodecSizePrefix(codec, prefix)` | Add size prefix to both encode and decode |
+
+### Sentinel
+
+| Function | Description |
+|----------|-------------|
+| `addEncoderSentinel(encoder, sentinel)` | Append a sentinel after encoding |
+| `addDecoderSentinel(decoder, sentinel)` | Read until a sentinel when decoding |
+| `addCodecSentinel(codec, sentinel)` | Add sentinel to both encode and decode |
+
+### Offset and padding
+
+| Function | Description |
+|----------|-------------|
+| `offsetEncoder(encoder, config)` | Adjust pre/post offset of an encoder |
+| `offsetDecoder(decoder, config)` | Adjust pre/post offset of a decoder |
+| `offsetCodec(codec, config)` | Adjust pre/post offset of a codec |
+| `padLeftEncoder(encoder, offset)` | Add left (leading) zero padding |
+| `padRightEncoder(encoder, offset)` | Add right (trailing) zero padding |
+| `padLeftDecoder(decoder, offset)` | Skip left padding when decoding |
+| `padRightDecoder(decoder, offset)` | Skip right padding when decoding |
+| `padLeftCodec(codec, offset)` | Add left padding to both encode and decode |
+| `padRightCodec(codec, offset)` | Add right padding to both encode and decode |
+
+### Byte reversal
+
+| Function | Description |
+|----------|-------------|
+| `reverseEncoder(encoder)` | Reverse bytes of a fixed-size encoder |
+| `reverseDecoder(decoder)` | Reverse bytes of a fixed-size decoder |
+| `reverseCodec(codec)` | Reverse bytes of a fixed-size codec |
+
+### Utility functions
+
+| Function | Description |
+|----------|-------------|
+| `getEncodedSize(value, encoder)` | Get the byte size of an encoded value |
+| `isFixedSize(object)` | Check if a codec/encoder/decoder is fixed-size |
+| `isVariableSize(object)` | Check if a codec/encoder/decoder is variable-size |
+| `assertIsFixedSize(object)` | Assert fixed-size or throw |
+| `assertIsVariableSize(object)` | Assert variable-size or throw |
+| `createDecoderThatConsumesEntireByteArray(decoder)` | Ensure all bytes are consumed |
+| `containsBytes(bytes, target, offset)` | Check if bytes contain a subsequence |
+| `fixBytes(bytes, length)` | Pad or truncate bytes to a fixed length |

--- a/packages/solana_kit_codecs_data_structures/readme.md
+++ b/packages/solana_kit_codecs_data_structures/readme.md
@@ -1,0 +1,529 @@
+# solana_kit_codecs_data_structures
+
+Codecs for encoding and decoding composite data structures -- structs, arrays, tuples, maps, sets, enums, booleans, and more -- for Solana on-chain data.
+
+This is a Dart port of [`@solana/codecs-data-structures`](https://github.com/anza-xyz/kit/tree/main/packages/codecs-data-structures) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_codecs_data_structures:
+```
+
+Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+
+## Usage
+
+### Structs
+
+Encode and decode named field structures (similar to Rust structs or C structs). Fields are serialized sequentially in the order they are declared.
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+// Define a struct with named fields.
+final personCodec = getStructCodec([
+  ('age', getU8Codec()),
+  ('name', addCodecSizePrefix(getUtf8Codec(), getU32Codec())),
+]);
+
+// Encode a struct as a Map.
+final bytes = personCodec.encode({
+  'age': 30,
+  'name': 'Alice',
+});
+// bytes == [30, 5, 0, 0, 0, 65, 108, 105, 99, 101]
+//          ^age ^--name len--^ ^----name UTF-8----^
+
+// Decode back to a Map.
+final person = personCodec.decode(bytes);
+// person == {'age': 30, 'name': 'Alice'}
+```
+
+### Arrays
+
+Encode and decode lists of homogeneous values. By default, the array length is prefixed with a `u32` value.
+
+```dart
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+// Default: u32-prefixed array of u8 values.
+final arrayCodec = getArrayCodec(getU8Codec());
+final bytes = arrayCodec.encode([10, 20, 30]);
+// bytes == [3, 0, 0, 0, 10, 20, 30]
+//          ^--u32 len--^ ^-items-^
+
+final decoded = arrayCodec.decode(bytes);
+// decoded == [10, 20, 30]
+```
+
+#### Array size options
+
+Control how the array length is determined using `ArrayLikeCodecSize`:
+
+```dart
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+// Fixed-size array (always exactly 3 items, no prefix).
+final fixed = getArrayCodec(
+  getU8Codec(),
+  size: FixedArraySize(3),
+);
+fixed.encode([1, 2, 3]); // Uint8List [1, 2, 3] -- no length prefix
+
+// Custom prefix (e.g., u16 instead of u32).
+final u16Prefixed = getArrayCodec(
+  getU8Codec(),
+  size: PrefixedArraySize(getU16Codec()),
+);
+u16Prefixed.encode([1, 2, 3]); // Uint8List [3, 0, 1, 2, 3]
+
+// Remainder: infer count from remaining bytes (fixed-size items only).
+final remainder = getArrayCodec(
+  getU8Codec(),
+  size: RemainderArraySize(),
+);
+remainder.encode([1, 2, 3]); // Uint8List [1, 2, 3] -- no prefix
+```
+
+### Tuples
+
+Encode and decode fixed-length heterogeneous lists. Unlike arrays, each position has its own codec:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+// A tuple of (u8, u32, bool).
+final tupleCodec = getTupleCodec([
+  getU8Codec(),
+  getU32Codec(),
+  getBooleanCodec(),
+]);
+
+final bytes = tupleCodec.encode([255, 1000, true]);
+// Encodes each item sequentially: [0xff, 0xe8, 0x03, 0x00, 0x00, 0x01]
+
+final decoded = tupleCodec.decode(bytes);
+// decoded == [255, 1000, true]
+```
+
+### Booleans
+
+Encode `true` as `1` and `false` as `0`. By default, stored as a single `u8` byte:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+final boolCodec = getBooleanCodec();
+
+boolCodec.encode(true);  // Uint8List [0x01]
+boolCodec.encode(false); // Uint8List [0x00]
+
+boolCodec.decode(Uint8List.fromList([1])); // true
+boolCodec.decode(Uint8List.fromList([0])); // false
+```
+
+You can customize the underlying number codec:
+
+```dart
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+// Store booleans as u32 (4 bytes).
+final wideBool = getBooleanCodec(size: getU32Codec());
+wideBool.encode(true); // Uint8List [0x01, 0x00, 0x00, 0x00]
+```
+
+### Nullable values
+
+Encode optional values with a boolean prefix (0 = null, 1 = present):
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+final nullableU16 = getNullableCodec(getU16Codec());
+
+// Encoding a present value.
+nullableU16.encode(42);   // Uint8List [0x01, 0x2a, 0x00]
+//                                     ^prefix ^--value--^
+
+// Encoding null.
+nullableU16.encode(null);  // Uint8List [0x00]
+//                                      ^prefix (0 = null)
+
+// Decoding.
+nullableU16.decode(Uint8List.fromList([0x01, 0x2a, 0x00])); // 42
+nullableU16.decode(Uint8List.fromList([0x00]));              // null
+```
+
+#### Zeroes none value
+
+Use zeroes to represent null instead of omitting the value. This keeps the encoded size constant for fixed-size items:
+
+```dart
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+final nullableU16 = getNullableCodec(
+  getU16Codec(),
+  noneValue: ZeroesNoneValue(),
+);
+
+nullableU16.encode(42);   // Uint8List [0x01, 0x2a, 0x00]
+nullableU16.encode(null);  // Uint8List [0x00, 0x00, 0x00]
+//                          prefix=0, then 2 bytes of zeroes
+```
+
+### Maps
+
+Encode and decode `Map<K, V>` values as arrays of key-value pairs:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+// Map<String, int> with u32-prefixed size.
+final mapCodec = getMapCodec(
+  addCodecSizePrefix(getUtf8Codec(), getU32Codec()),
+  getU8Codec(),
+);
+
+final bytes = mapCodec.encode({'a': 1, 'b': 2});
+final decoded = mapCodec.decode(bytes);
+// decoded == {'a': 1, 'b': 2}
+```
+
+### Sets
+
+Encode and decode `Set<T>` values as arrays with deduplication:
+
+```dart
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+final setCodec = getSetCodec(getU8Codec());
+
+final bytes = setCodec.encode({10, 20, 30});
+final decoded = setCodec.decode(bytes);
+// decoded == {10, 20, 30}
+```
+
+### Discriminated unions
+
+Encode Rust-like enums where each variant is distinguished by a discriminator field (default: `'__kind'`):
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+// Define an enum with two variants.
+final messageCodec = getDiscriminatedUnionCodec([
+  // Variant 0: 'quit' -- no additional data.
+  ('quit', getUnitCodec()),
+  // Variant 1: 'move' -- has x and y fields.
+  ('move', getStructCodec([
+    ('x', getI32Codec()),
+    ('y', getI32Codec()),
+  ])),
+]);
+
+// Encode the 'quit' variant.
+final quitBytes = messageCodec.encode({'__kind': 'quit'});
+// quitBytes == [0x00]
+
+// Encode the 'move' variant.
+final moveBytes = messageCodec.encode({
+  '__kind': 'move',
+  'x': 10,
+  'y': -5,
+});
+// moveBytes == [0x01, 0x0a, 0x00, 0x00, 0x00, 0xfb, 0xff, 0xff, 0xff]
+//              ^disc ^-------x--------^ ^-------y--------^
+
+// Decode.
+final decoded = messageCodec.decode(moveBytes);
+// decoded == {'__kind': 'move', 'x': 10, 'y': -5}
+```
+
+### Literal unions
+
+Encode a value from a fixed set of variants as its index:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+final directionCodec = getLiteralUnionCodec(['north', 'south', 'east', 'west']);
+
+directionCodec.encode('south'); // Uint8List [0x01] -- index 1
+directionCodec.encode('west');  // Uint8List [0x03] -- index 3
+
+directionCodec.decode(Uint8List.fromList([0x02])); // 'east'
+```
+
+### Raw unions
+
+For cases where you need full control over variant selection (without a stored discriminator):
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+final unionCodec = getUnionCodec(
+  [getU8Codec(), getU32Codec()],
+  // Encode: select variant by value type.
+  (Object? value) => (value as num) > 255 ? 1 : 0,
+  // Decode: select variant by inspecting the byte array.
+  (Uint8List bytes, int offset) => bytes.length - offset >= 4 ? 1 : 0,
+);
+```
+
+### Bit arrays
+
+Pack boolean arrays into compact bit representations (8 booleans per byte):
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+// 1 byte = 8 booleans.
+final bitCodec = getBitArrayCodec(1);
+
+final bytes = bitCodec.encode([true, false, true, false, false, false, false, true]);
+// bytes == [0xa1] (10100001 in binary, MSB-first)
+
+final decoded = bitCodec.decode(Uint8List.fromList([0xa1]));
+// decoded == [true, false, true, false, false, false, false, true]
+
+// Use backward mode for LSB-first ordering.
+final bitCodecLsb = getBitArrayCodec(1, backward: true);
+```
+
+### Raw bytes
+
+Encode and decode raw `Uint8List` data without transformation:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+final bytesCodec = getBytesCodec();
+
+final data = Uint8List.fromList([1, 2, 3, 4, 5]);
+final encoded = bytesCodec.encode(data);
+// encoded == Uint8List [1, 2, 3, 4, 5]
+
+final decoded = bytesCodec.decode(encoded);
+// decoded == Uint8List [1, 2, 3, 4, 5]
+```
+
+### Constants
+
+Encode a fixed byte sequence (ignores the input value) and verify it when decoding:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+final magicCodec = getConstantCodec(Uint8List.fromList([0xCA, 0xFE]));
+
+// Always writes [0xCA, 0xFE].
+final bytes = magicCodec.encode(null);
+
+// Decoding verifies the bytes match. Throws if they don't.
+magicCodec.decode(Uint8List.fromList([0xCA, 0xFE])); // OK
+```
+
+### Unit codec
+
+A zero-size codec that encodes and decodes `void`. Useful for empty enum variants:
+
+```dart
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+final unitCodec = getUnitCodec();
+unitCodec.encode(null); // Uint8List [] (empty)
+unitCodec.decode(Uint8List(0)); // null
+```
+
+### Hidden prefix and suffix
+
+Embed hidden constant data before or after the main encoded value, without exposing it in the API:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+
+// Prepend a 2-byte magic number before the actual value.
+final codec = getHiddenPrefixCodec(
+  getU8Codec(),
+  [getConstantCodec(Uint8List.fromList([0xCA, 0xFE]))],
+);
+
+final bytes = codec.encode(42);
+// bytes == [0xCA, 0xFE, 0x2a]
+//          ^--hidden--^ ^val^
+
+final decoded = codec.decode(bytes);
+// decoded == 42 (the hidden prefix is consumed but not returned)
+
+// Similarly, getHiddenSuffixCodec appends hidden data after the value.
+```
+
+## API Reference
+
+### Struct codecs
+
+| Function | Description |
+|----------|-------------|
+| `getStructEncoder(fields)` | Encode a `Map<String, Object?>` from named field encoders |
+| `getStructDecoder(fields)` | Decode a `Map<String, Object?>` using named field decoders |
+| `getStructCodec(fields)` | Combined struct codec |
+
+### Array codecs
+
+| Function | Description |
+|----------|-------------|
+| `getArrayEncoder(item, {size})` | Encode a `List<T>` with configurable size |
+| `getArrayDecoder(item, {size})` | Decode a `List<T>` with configurable size |
+| `getArrayCodec(item, {size})` | Combined array codec |
+
+### Array size types
+
+| Type | Description |
+|------|-------------|
+| `PrefixedArraySize(prefix)` | Length stored as a number prefix (default: u32) |
+| `FixedArraySize(n)` | Fixed number of items, no prefix |
+| `RemainderArraySize()` | Infer count from remaining bytes |
+
+### Tuple codecs
+
+| Function | Description |
+|----------|-------------|
+| `getTupleEncoder(items)` | Encode a `List<Object?>` with heterogeneous item encoders |
+| `getTupleDecoder(items)` | Decode a `List<Object?>` with heterogeneous item decoders |
+| `getTupleCodec(items)` | Combined tuple codec |
+
+### Boolean codecs
+
+| Function | Description |
+|----------|-------------|
+| `getBooleanEncoder({size})` | Encode `bool` as a number (default: u8) |
+| `getBooleanDecoder({size})` | Decode a number as `bool` |
+| `getBooleanCodec({size})` | Combined boolean codec |
+
+### Nullable codecs
+
+| Function | Description |
+|----------|-------------|
+| `getNullableEncoder(item, {prefix, hasPrefix, noneValue})` | Encode nullable values with an optional prefix |
+| `getNullableDecoder(item, {prefix, hasPrefix, noneValue})` | Decode nullable values |
+| `getNullableCodec(item, {prefix, hasPrefix, noneValue})` | Combined nullable codec |
+
+### None value types
+
+| Type | Description |
+|------|-------------|
+| `OmitNoneValue()` | Null values are omitted (default) |
+| `ZeroesNoneValue()` | Null values are encoded as zeroes (fixed-size items only) |
+| `ConstantNoneValue(bytes)` | Null values are encoded as a specific byte sequence |
+
+### Map codecs
+
+| Function | Description |
+|----------|-------------|
+| `getMapEncoder(key, value, {size})` | Encode `Map<K, V>` as key-value pairs |
+| `getMapDecoder(key, value, {size})` | Decode key-value pairs into `Map<K, V>` |
+| `getMapCodec(key, value, {size})` | Combined map codec |
+
+### Set codecs
+
+| Function | Description |
+|----------|-------------|
+| `getSetEncoder(item, {size})` | Encode `Set<T>` as an array |
+| `getSetDecoder(item, {size})` | Decode an array into `Set<T>` |
+| `getSetCodec(item, {size})` | Combined set codec |
+
+### Discriminated union codecs
+
+| Function | Description |
+|----------|-------------|
+| `getDiscriminatedUnionEncoder(variants, {discriminator, size})` | Encode a map with a `'__kind'` discriminator |
+| `getDiscriminatedUnionDecoder(variants, {discriminator, size})` | Decode a discriminated union |
+| `getDiscriminatedUnionCodec(variants, {discriminator, size})` | Combined discriminated union codec |
+
+### Literal union codecs
+
+| Function | Description |
+|----------|-------------|
+| `getLiteralUnionEncoder(variants, {size})` | Encode a value as its index in a list |
+| `getLiteralUnionDecoder(variants, {size})` | Decode an index into a variant value |
+| `getLiteralUnionCodec(variants, {size})` | Combined literal union codec |
+
+### Raw union codecs
+
+| Function | Description |
+|----------|-------------|
+| `getUnionEncoder(variants, getIndexFromValue)` | Encode using a user-defined variant selector |
+| `getUnionDecoder(variants, getIndexFromBytes)` | Decode using a user-defined variant selector |
+| `getUnionCodec(variants, getIndexFromValue, getIndexFromBytes)` | Combined union codec |
+
+### Bit array codecs
+
+| Function | Description |
+|----------|-------------|
+| `getBitArrayEncoder(size, {backward})` | Encode `List<bool>` into packed bits |
+| `getBitArrayDecoder(size, {backward})` | Decode packed bits into `List<bool>` |
+| `getBitArrayCodec(size, {backward})` | Combined bit array codec |
+
+### Bytes codecs
+
+| Function | Description |
+|----------|-------------|
+| `getBytesEncoder()` | Encode raw `Uint8List` as-is |
+| `getBytesDecoder()` | Decode raw `Uint8List` as-is |
+| `getBytesCodec()` | Combined bytes codec |
+
+### Constant codecs
+
+| Function | Description |
+|----------|-------------|
+| `getConstantEncoder(bytes)` | Always writes a fixed byte sequence |
+| `getConstantDecoder(bytes)` | Verifies and consumes a fixed byte sequence |
+| `getConstantCodec(bytes)` | Combined constant codec |
+
+### Unit codecs
+
+| Function | Description |
+|----------|-------------|
+| `getUnitEncoder()` | Zero-size encoder for `void` |
+| `getUnitDecoder()` | Zero-size decoder for `void` |
+| `getUnitCodec()` | Combined unit codec |
+
+### Hidden prefix/suffix codecs
+
+| Function | Description |
+|----------|-------------|
+| `getHiddenPrefixEncoder(encoder, prefixedEncoders)` | Prepend hidden data before encoding |
+| `getHiddenPrefixDecoder(decoder, prefixedDecoders)` | Skip hidden prefix when decoding |
+| `getHiddenPrefixCodec(codec, prefixedCodecs)` | Combined hidden prefix codec |
+| `getHiddenSuffixEncoder(encoder, suffixedEncoders)` | Append hidden data after encoding |
+| `getHiddenSuffixDecoder(decoder, suffixedDecoders)` | Skip hidden suffix when decoding |
+| `getHiddenSuffixCodec(codec, suffixedCodecs)` | Combined hidden suffix codec |

--- a/packages/solana_kit_codecs_numbers/readme.md
+++ b/packages/solana_kit_codecs_numbers/readme.md
@@ -1,0 +1,218 @@
+# solana_kit_codecs_numbers
+
+Numeric codecs for encoding and decoding integers and floats in Solana data structures.
+
+This is a Dart port of [`@solana/codecs-numbers`](https://github.com/anza-xyz/kit/tree/main/packages/codecs-numbers) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_codecs_numbers:
+```
+
+Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+
+## Usage
+
+### Unsigned integers
+
+All integer codecs default to **little-endian** byte order, matching Solana's on-chain data layout.
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+// u8: unsigned 8-bit integer (1 byte)
+final u8 = getU8Codec();
+u8.encode(42);                              // Uint8List [0x2a]
+u8.decode(Uint8List.fromList([0x2a]));      // 42
+
+// u16: unsigned 16-bit integer (2 bytes, little-endian)
+final u16 = getU16Codec();
+u16.encode(512);                            // Uint8List [0x00, 0x02]
+u16.decode(Uint8List.fromList([0x00, 0x02])); // 512
+
+// u32: unsigned 32-bit integer (4 bytes, little-endian)
+final u32 = getU32Codec();
+u32.encode(42);                             // Uint8List [0x2a, 0x00, 0x00, 0x00]
+u32.decode(Uint8List.fromList([0x2a, 0x00, 0x00, 0x00])); // 42
+```
+
+### Large unsigned integers (BigInt)
+
+For 64-bit and 128-bit values, `BigInt` is used instead of `int` to avoid precision loss:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+// u64: unsigned 64-bit integer (8 bytes)
+final u64 = getU64Codec();
+u64.encode(BigInt.from(1000000));
+// Uint8List [0x40, 0x42, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00]
+
+final decoded = u64.decode(
+  Uint8List.fromList([0x40, 0x42, 0x0f, 0x00, 0x00, 0x00, 0x00, 0x00]),
+);
+// decoded == BigInt.from(1000000)
+
+// u128: unsigned 128-bit integer (16 bytes)
+final u128 = getU128Codec();
+u128.encode(BigInt.parse('340282366920938463463374607431768211455'));
+```
+
+### Signed integers
+
+Signed integers use two's complement representation:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+// i8: signed 8-bit integer (1 byte, range -128 to 127)
+final i8 = getI8Codec();
+i8.encode(-1);                              // Uint8List [0xff]
+i8.decode(Uint8List.fromList([0xff]));      // -1
+
+// i16: signed 16-bit integer (2 bytes)
+final i16 = getI16Codec();
+i16.encode(-256);                           // little-endian encoding
+
+// i32: signed 32-bit integer (4 bytes)
+final i32 = getI32Codec();
+i32.encode(-42);
+
+// i64 and i128 use BigInt
+final i64 = getI64Codec();
+i64.encode(BigInt.from(-1000000));
+
+final i128 = getI128Codec();
+i128.encode(BigInt.from(-1));
+```
+
+### Floating-point numbers
+
+IEEE 754 floating-point codecs for 32-bit and 64-bit floats:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+// f32: 32-bit float (4 bytes)
+final f32 = getF32Codec();
+f32.encode(1.5);
+final float = f32.decode(Uint8List.fromList([0x00, 0x00, 0xc0, 0x3f]));
+// float == 1.5
+
+// f64: 64-bit float (8 bytes)
+final f64Codec = getF64Codec();
+f64Codec.encode(3.141592653589793);
+```
+
+### Solana shortU16 compact encoding
+
+The `shortU16` encoding is Solana's variable-length compact encoding for unsigned 16-bit values. It uses 1 to 3 bytes depending on the magnitude:
+
+- Values 0-127: 1 byte
+- Values 128-16383: 2 bytes
+- Values 16384-65535: 3 bytes
+
+Each byte stores 7 bits of data; bit 7 is a continuation flag.
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+final shortU16 = getShortU16Codec();
+
+// Small values use 1 byte.
+shortU16.encode(42);    // Uint8List [0x2a]
+
+// Medium values use 2 bytes.
+shortU16.encode(128);   // Uint8List [0x80, 0x01]
+
+// Large values use 3 bytes.
+shortU16.encode(16384); // Uint8List [0x80, 0x80, 0x01]
+
+// Decoding
+shortU16.decode(Uint8List.fromList([0x80, 0x01])); // 128
+```
+
+### Using individual encoders and decoders
+
+Each codec function has corresponding encoder-only and decoder-only variants. This is useful when you only need one direction, or when composing with other codec utilities:
+
+```dart
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+// Encoder only
+final encoder = getU32Encoder();
+final bytes = encoder.encode(100);
+
+// Decoder only
+final decoder = getU32Decoder();
+final value = decoder.decode(bytes);
+
+// Read with offset tracking
+final (decoded, nextOffset) = decoder.read(bytes, 0);
+// decoded == 100, nextOffset == 4
+```
+
+### Configuring endianness
+
+Multi-byte number codecs accept an optional `NumberCodecConfig` to override the default little-endian byte order:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+// Big-endian u32
+final bigEndianU32 = getU32Codec(NumberCodecConfig(endian: Endian.big));
+bigEndianU32.encode(42); // Uint8List [0x00, 0x00, 0x00, 0x2a]
+
+// Little-endian (default)
+final littleEndianU32 = getU32Codec();
+littleEndianU32.encode(42); // Uint8List [0x2a, 0x00, 0x00, 0x00]
+```
+
+## API Reference
+
+### Unsigned integer codecs
+
+| Function | Size | Dart Type | Range |
+|----------|------|-----------|-------|
+| `getU8Encoder()` / `getU8Decoder()` / `getU8Codec()` | 1 byte | `num` / `int` | 0 to 255 |
+| `getU16Encoder()` / `getU16Decoder()` / `getU16Codec()` | 2 bytes | `num` / `int` | 0 to 65,535 |
+| `getU32Encoder()` / `getU32Decoder()` / `getU32Codec()` | 4 bytes | `num` / `int` | 0 to 4,294,967,295 |
+| `getU64Encoder()` / `getU64Decoder()` / `getU64Codec()` | 8 bytes | `BigInt` | 0 to 2^64-1 |
+| `getU128Encoder()` / `getU128Decoder()` / `getU128Codec()` | 16 bytes | `BigInt` | 0 to 2^128-1 |
+
+### Signed integer codecs
+
+| Function | Size | Dart Type | Range |
+|----------|------|-----------|-------|
+| `getI8Encoder()` / `getI8Decoder()` / `getI8Codec()` | 1 byte | `num` / `int` | -128 to 127 |
+| `getI16Encoder()` / `getI16Decoder()` / `getI16Codec()` | 2 bytes | `num` / `int` | -32,768 to 32,767 |
+| `getI32Encoder()` / `getI32Decoder()` / `getI32Codec()` | 4 bytes | `num` / `int` | -2^31 to 2^31-1 |
+| `getI64Encoder()` / `getI64Decoder()` / `getI64Codec()` | 8 bytes | `BigInt` | -2^63 to 2^63-1 |
+| `getI128Encoder()` / `getI128Decoder()` / `getI128Codec()` | 16 bytes | `BigInt` | -2^127 to 2^127-1 |
+
+### Floating-point codecs
+
+| Function | Size | Dart Type |
+|----------|------|-----------|
+| `getF32Encoder()` / `getF32Decoder()` / `getF32Codec()` | 4 bytes | `num` / `double` |
+| `getF64Encoder()` / `getF64Decoder()` / `getF64Codec()` | 8 bytes | `num` / `double` |
+
+### Special codecs
+
+| Function | Size | Description |
+|----------|------|-------------|
+| `getShortU16Encoder()` / `getShortU16Decoder()` / `getShortU16Codec()` | 1-3 bytes | Solana compact u16 encoding |
+
+### Configuration
+
+| Type | Description |
+|------|-------------|
+| `NumberCodecConfig` | Configuration with `endian` parameter (defaults to `Endian.little`) |

--- a/packages/solana_kit_codecs_strings/readme.md
+++ b/packages/solana_kit_codecs_strings/readme.md
@@ -1,0 +1,212 @@
+# solana_kit_codecs_strings
+
+String codecs for encoding and decoding string data in various bases (base-10, base-16, base-58, base-64, UTF-8) for Solana data structures.
+
+This is a Dart port of [`@solana/codecs-strings`](https://github.com/anza-xyz/kit/tree/main/packages/codecs-strings) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_codecs_strings:
+```
+
+Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+
+## Usage
+
+### Base-58 encoding
+
+Base-58 is the primary encoding used for Solana addresses, public keys, and signatures. It uses the Bitcoin alphabet (`123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz`), which omits visually ambiguous characters (0, O, I, l).
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+// Encode a base-58 string to bytes.
+final encoder = getBase58Encoder();
+final bytes = encoder.encode('4wBqpZM9xaSheZzJSMawUHDgZ7miWfSsxmfVF5jJpYP');
+
+// Decode bytes back to a base-58 string.
+final decoder = getBase58Decoder();
+final address = decoder.decode(bytes);
+// address == '4wBqpZM9xaSheZzJSMawUHDgZ7miWfSsxmfVF5jJpYP'
+
+// Or use the combined codec.
+final codec = getBase58Codec();
+final roundTripped = codec.decode(codec.encode('hello'));
+// roundTripped == 'hello'
+```
+
+### Base-16 (hexadecimal) encoding
+
+Encode and decode hexadecimal strings:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+final codec = getBase16Codec();
+
+// Encode hex string to bytes.
+final bytes = codec.encode('deadbeef');
+// bytes == Uint8List [0xde, 0xad, 0xbe, 0xef]
+
+// Decode bytes to hex string.
+final hex = codec.decode(Uint8List.fromList([0xde, 0xad, 0xbe, 0xef]));
+// hex == 'deadbeef'
+```
+
+### Base-64 encoding
+
+Encode and decode base-64 strings, commonly used in Solana RPC responses:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+final codec = getBase64Codec();
+
+// Encode a base-64 string to bytes.
+final bytes = codec.encode('SGVsbG8gV29ybGQ=');
+// bytes contains the decoded binary data
+
+// Decode bytes to a base-64 string.
+final encoded = codec.decode(Uint8List.fromList([72, 101, 108, 108, 111]));
+// encoded == 'SGVsbG8='
+```
+
+### Base-10 encoding
+
+Encode and decode base-10 (decimal) strings:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+final codec = getBase10Codec();
+
+final bytes = codec.encode('12345');
+final decoded = codec.decode(bytes);
+// decoded == '12345'
+```
+
+### UTF-8 encoding
+
+Encode and decode UTF-8 strings. This is a variable-size codec since the byte length depends on the string content:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+final codec = getUtf8Codec();
+
+// Encode a string to UTF-8 bytes.
+final bytes = codec.encode('Hello, Solana!');
+// bytes == [72, 101, 108, 108, 111, 44, 32, 83, 111, 108, 97, 110, 97, 33]
+
+// Decode UTF-8 bytes back to a string.
+final text = codec.decode(Uint8List.fromList([72, 101, 108, 108, 111]));
+// text == 'Hello'
+
+// Multi-byte characters are handled correctly.
+final emoji = codec.encode('\u{1F680}'); // Rocket emoji
+// emoji.length == 4 (UTF-8 encoding of a 4-byte character)
+```
+
+### Custom base-X encoding
+
+Create codecs for arbitrary alphabets using `getBaseXCodec`:
+
+```dart
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+// Create a base-2 (binary) codec.
+final binaryCodec = getBaseXCodec('01');
+final bytes = binaryCodec.encode('11111111'); // Uint8List [0xff]
+final decoded = binaryCodec.decode(bytes);    // '11111111'
+
+// Create a custom base-36 codec.
+final base36Codec = getBaseXCodec('0123456789abcdefghijklmnopqrstuvwxyz');
+```
+
+### Custom base-X reslice encoding
+
+For alphabets whose length is a power of 2, `getBaseXResliceCodec` is more efficient because it uses bit-slicing instead of BigInt arithmetic:
+
+```dart
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+// Base-8 (octal) using reslice -- alphabet length is 8 = 2^3, bits = 3.
+final octalCodec = getBaseXResliceCodec('01234567', 3);
+final bytes = octalCodec.encode('777');
+final decoded = octalCodec.decode(bytes);
+```
+
+### Null character utilities
+
+Fixed-size string encodings often use null characters (`\u0000`) as padding. This package provides helpers:
+
+```dart
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+// Remove null characters from a decoded string.
+final cleaned = removeNullCharacters('hello\u0000\u0000\u0000');
+// cleaned == 'hello'
+
+// Pad a string with null characters to a fixed length.
+final padded = padNullCharacters('hello', 10);
+// padded == 'hello\u0000\u0000\u0000\u0000\u0000'
+```
+
+### Using with codec composition
+
+String codecs are commonly combined with size prefixes or fixed-size constraints from `solana_kit_codecs_core`:
+
+```dart
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+// Create a length-prefixed UTF-8 string codec.
+// The string's byte length is encoded as a u32 prefix.
+final prefixedUtf8 = addCodecSizePrefix(getUtf8Codec(), getU32Codec());
+
+final bytes = prefixedUtf8.encode('Hello');
+// bytes == [5, 0, 0, 0, 72, 101, 108, 108, 111]
+//          ^--u32 len--^ ^---UTF-8 bytes---^
+
+// Create a fixed-size UTF-8 string codec (always 32 bytes).
+final fixedUtf8 = fixCodecSize(getUtf8Codec(), 32);
+```
+
+## API Reference
+
+### Base encoders/decoders/codecs
+
+| Function | Description |
+|----------|-------------|
+| `getBase10Encoder()` / `getBase10Decoder()` / `getBase10Codec()` | Base-10 (decimal) encoding |
+| `getBase16Encoder()` / `getBase16Decoder()` / `getBase16Codec()` | Base-16 (hexadecimal) encoding |
+| `getBase58Encoder()` / `getBase58Decoder()` / `getBase58Codec()` | Base-58 (Bitcoin alphabet) encoding |
+| `getBase64Encoder()` / `getBase64Decoder()` / `getBase64Codec()` | Base-64 encoding |
+
+### UTF-8
+
+| Function | Description |
+|----------|-------------|
+| `getUtf8Encoder()` / `getUtf8Decoder()` / `getUtf8Codec()` | UTF-8 string encoding |
+
+### Generic base-X
+
+| Function | Description |
+|----------|-------------|
+| `getBaseXEncoder(alphabet)` / `getBaseXDecoder(alphabet)` / `getBaseXCodec(alphabet)` | Custom base-X encoding using BigInt arithmetic |
+| `getBaseXResliceEncoder(alphabet, bits)` / `getBaseXResliceDecoder(alphabet, bits)` / `getBaseXResliceCodec(alphabet, bits)` | Custom base-X encoding using bit reslicing (for power-of-2 alphabet sizes) |
+
+### Null character utilities
+
+| Function | Description |
+|----------|-------------|
+| `removeNullCharacters(string)` | Remove all `\u0000` characters from a string |
+| `padNullCharacters(string, length)` | Pad a string with `\u0000` to reach a target length |

--- a/packages/solana_kit_errors/readme.md
+++ b/packages/solana_kit_errors/readme.md
@@ -1,0 +1,321 @@
+# solana_kit_errors
+
+Error codes, structured error class, and error conversion utilities for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/errors`](https://github.com/anza-xyz/kit/tree/main/packages/errors) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_errors:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+### Creating errors
+
+Every error in the Solana Kit SDK is a `SolanaError` carrying a numeric code from `SolanaErrorCode` and an optional context map. The context map provides structured data that is interpolated into the human-readable error message.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+// Simple error with no context.
+final error = SolanaError(SolanaErrorCode.blockHeightExceeded);
+print(error);
+// SolanaError#1: The network has progressed past the last block for which
+// this transaction could have been committed.
+
+// Error with context variables interpolated into the message.
+final notFoundError = SolanaError(
+  SolanaErrorCode.accountsAccountNotFound,
+  {'address': '11111111111111111111111111111111'},
+);
+print(notFoundError);
+// SolanaError#3230000: Account not found at address: 11111111111111111111111111111111
+```
+
+`SolanaError` implements `Exception`, so it can be thrown and caught like any Dart exception:
+
+```dart
+try {
+  throw SolanaError(SolanaErrorCode.transactionFeePayerMissing);
+} on SolanaError catch (e) {
+  print('Code: ${e.code}');
+  print('Context: ${e.context}');
+  print('Message: $e');
+}
+```
+
+The context map is made unmodifiable at construction time, so it cannot be accidentally mutated after creation.
+
+### Checking errors with `isSolanaError`
+
+The `isSolanaError` function acts as a type guard. It checks whether a value is a `SolanaError` and optionally whether it matches a specific error code.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+void handleError(Object? error) {
+  // Check if it is any SolanaError.
+  if (isSolanaError(error)) {
+    print('Got a Solana error with code: ${(error as SolanaError).code}');
+  }
+
+  // Check for a specific error code.
+  if (isSolanaError(error, SolanaErrorCode.transactionFeePayerMissing)) {
+    print('Transaction is missing a fee payer!');
+  }
+
+  // Returns false for non-SolanaError values.
+  print(isSolanaError('not an error'));  // false
+  print(isSolanaError(null));            // false
+}
+```
+
+### Error codes (`SolanaErrorCode`)
+
+`SolanaErrorCode` is an abstract final class containing 100+ `static const int` codes organized by category. The numeric values are kept in sync with the upstream TypeScript package for cross-implementation interoperability.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+// General errors (1 - 10)
+SolanaErrorCode.blockHeightExceeded;          // 1
+SolanaErrorCode.invalidNonce;                  // 2
+SolanaErrorCode.lamportsOutOfRange;            // 6
+
+// JSON-RPC errors (-32768 to -32000)
+SolanaErrorCode.jsonRpcParseError;             // -32700
+SolanaErrorCode.jsonRpcInternalError;          // -32603
+SolanaErrorCode.jsonRpcServerErrorNodeUnhealthy; // -32005
+
+// Address errors (2800000 - 2800999)
+SolanaErrorCode.addressesInvalidByteLength;    // 2800000
+SolanaErrorCode.addressesInvalidBase58EncodedAddress; // 2800002
+
+// Account errors (3230000 - 3230999)
+SolanaErrorCode.accountsAccountNotFound;       // 3230000
+SolanaErrorCode.accountsFailedToDecodeAccount; // 3230002
+
+// Key errors (3704000 - 3704999)
+SolanaErrorCode.keysInvalidKeyPairByteLength;  // 3704000
+SolanaErrorCode.keysInvalidSignatureByteLength; // 3704002
+
+// Instruction errors (4128000 - 4128999)
+SolanaErrorCode.instructionExpectedToHaveAccounts; // 4128000
+
+// Instruction runtime errors (4615000 - 4615999)
+SolanaErrorCode.instructionErrorInsufficientFunds; // 4615006
+SolanaErrorCode.instructionErrorCustom;        // 4615026
+
+// Signer errors (5508000 - 5508999)
+SolanaErrorCode.signerExpectedKeyPairSigner;   // 5508001
+
+// Transaction errors (5663000 - 5663999)
+SolanaErrorCode.transactionFeePayerMissing;    // 5663011
+SolanaErrorCode.transactionSignaturesMissing;  // 5663009
+
+// Transaction runtime errors (7050000 - 7050999)
+SolanaErrorCode.transactionErrorBlockhashNotFound; // 7050008
+
+// Codec errors (8078000 - 8078999)
+SolanaErrorCode.codecsCannotDecodeEmptyByteArray; // 8078000
+SolanaErrorCode.codecsNumberOutOfRange;        // 8078011
+
+// RPC errors (8100000 - 8100999)
+SolanaErrorCode.rpcIntegerOverflow;            // 8100000
+SolanaErrorCode.rpcTransportHttpError;         // 8100002
+```
+
+### Error message interpolation
+
+Error messages are templates with `$variable` placeholders that are filled from the context map. The `getErrorMessage` function performs this interpolation.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+// Get an interpolated message directly.
+final message = getErrorMessage(
+  SolanaErrorCode.addressesInvalidByteLength,
+  {'actualLength': 28},
+);
+print(message);
+// Expected base58 encoded address to decode to a byte array of length 32.
+// Actual length: 28.
+
+// Missing context values leave the placeholder as-is.
+final partial = getErrorMessage(SolanaErrorCode.addressesInvalidByteLength);
+print(partial);
+// Expected base58 encoded address to decode to a byte array of length 32.
+// Actual length: $actualLength.
+
+// Unknown error codes produce a fallback message.
+final unknown = getErrorMessage(999999);
+print(unknown);
+// Solana error #999999
+```
+
+### Converting JSON-RPC errors
+
+When you receive an error response from a Solana JSON-RPC endpoint, use `getSolanaErrorFromJsonRpcError` to convert it into a `SolanaError`.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+// Typical JSON-RPC error response from a Solana node.
+final rpcError = {
+  'code': -32005,
+  'message': 'Node is unhealthy',
+  'data': <String, Object?>{},
+};
+
+final solanaError = getSolanaErrorFromJsonRpcError(rpcError);
+print(solanaError.code == SolanaErrorCode.jsonRpcServerErrorNodeUnhealthy);
+// true
+
+// Preflight failure errors automatically extract the nested transaction error.
+final preflightError = {
+  'code': -32002,
+  'message': 'Transaction simulation failed',
+  'data': {
+    'err': 'BlockhashNotFound',
+    'logs': <String>[],
+  },
+};
+
+final preflightSolanaError = getSolanaErrorFromJsonRpcError(preflightError);
+print(preflightSolanaError.code ==
+    SolanaErrorCode.jsonRpcServerErrorSendTransactionPreflightFailure);
+// true
+
+// The nested cause is available in the context.
+final cause = preflightSolanaError.context['cause'] as SolanaError;
+print(cause.code == SolanaErrorCode.transactionErrorBlockhashNotFound);
+// true
+
+// Malformed responses (missing required fields) produce a malformedJsonRpcError.
+final malformed = getSolanaErrorFromJsonRpcError({'unexpected': 'data'});
+print(malformed.code == SolanaErrorCode.malformedJsonRpcError);
+// true
+```
+
+### Converting transaction errors
+
+Transaction errors from RPC responses use a Rust enum-like format. The `getSolanaErrorFromTransactionError` function handles both string and map forms.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+// Simple string error.
+final error = getSolanaErrorFromTransactionError('BlockhashNotFound');
+print(error.code == SolanaErrorCode.transactionErrorBlockhashNotFound);
+// true
+
+// Error with nested context.
+final rentError = getSolanaErrorFromTransactionError({
+  'InsufficientFundsForRent': {'account_index': 2},
+});
+print(rentError.code == SolanaErrorCode.transactionErrorInsufficientFundsForRent);
+// true
+print(rentError.context['accountIndex']); // 2
+```
+
+### Converting instruction errors
+
+Instruction errors come nested within transaction errors, typically as `{'InstructionError': [index, error]}`. Use `getSolanaErrorFromInstructionError` to convert them directly.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+// Simple instruction error.
+final error = getSolanaErrorFromInstructionError(0, 'InsufficientFunds');
+print(error.code == SolanaErrorCode.instructionErrorInsufficientFunds);
+// true
+print(error.context['index']); // 0
+
+// Custom program error with an error code.
+final customError = getSolanaErrorFromInstructionError(1, {'Custom': 42});
+print(customError.code == SolanaErrorCode.instructionErrorCustom);
+// true
+print(customError.context['code']);  // 42
+print(customError.context['index']); // 1
+
+// Transaction errors containing InstructionError are automatically delegated.
+final txError = getSolanaErrorFromTransactionError({
+  'InstructionError': [0, 'InvalidAccountData'],
+});
+print(txError.code == SolanaErrorCode.instructionErrorInvalidAccountData);
+// true
+```
+
+### Unwrapping simulation errors
+
+When a transaction simulation fails, the actual error is wrapped in a simulation error. Use `unwrapSimulationError` to get at the underlying cause.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+final simulationError = SolanaError(
+  SolanaErrorCode.jsonRpcServerErrorSendTransactionPreflightFailure,
+  {
+    'cause': SolanaError(SolanaErrorCode.transactionErrorBlockhashNotFound),
+    'logs': <String>[],
+  },
+);
+
+final underlying = unwrapSimulationError(simulationError);
+print(underlying is SolanaError); // true
+print((underlying! as SolanaError).code ==
+    SolanaErrorCode.transactionErrorBlockhashNotFound); // true
+
+// Non-simulation errors are returned as-is.
+final regularError = SolanaError(SolanaErrorCode.blockHeightExceeded);
+print(identical(unwrapSimulationError(regularError), regularError)); // true
+```
+
+### Context encoding and decoding
+
+The `encodeContextObject` and `decodeEncodedContext` functions serialize error context maps to and from compact base64 strings, useful for transmitting error details.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+
+final context = {'address': '11111111111111111111111111111111', 'index': 0};
+
+// Encode to a compact base64 string.
+final encoded = encodeContextObject(context);
+print(encoded); // base64 string
+
+// Decode back to the original map.
+final decoded = decodeEncodedContext(encoded);
+print(decoded['address']); // 11111111111111111111111111111111
+```
+
+## API Reference
+
+### Classes
+
+- **`SolanaError`** -- Core error class implementing `Exception`. Carries an `int code` and an unmodifiable `Map<String, Object?> context`.
+- **`SolanaErrorCode`** -- Abstract final class with 100+ `static const int` error codes grouped by category (general, JSON-RPC, addresses, accounts, keys, instructions, instruction errors, signers, transactions, transaction errors, codecs, RPC, RPC subscriptions, program clients, invariant violations).
+- **`RpcEnumErrorConfig`** -- Configuration class for mapping Solana RPC enum-style errors to `SolanaError` instances.
+
+### Functions
+
+- **`isSolanaError(Object? e, [int? code])`** -- Type guard that checks whether a value is a `SolanaError`, optionally matching a specific code.
+- **`getErrorMessage(int code, [Map<String, Object?> context])`** -- Returns the interpolated error message for a given error code and context.
+- **`getSolanaErrorFromJsonRpcError(Object?)`** -- Converts a JSON-RPC error response map into a `SolanaError`.
+- **`getSolanaErrorFromTransactionError(Object)`** -- Converts a Solana RPC transaction error into a `SolanaError`.
+- **`getSolanaErrorFromInstructionError(num index, Object)`** -- Converts a Solana RPC instruction error into a `SolanaError`.
+- **`getSolanaErrorFromRpcError(RpcEnumErrorConfig, Object)`** -- Low-level converter for RPC enum-style errors.
+- **`unwrapSimulationError(Object?)`** -- Extracts the underlying cause from simulation-related errors.
+- **`encodeContextObject(Map<String, Object?>)`** -- Encodes a context map to a compact base64 string.
+- **`decodeEncodedContext(String)`** -- Decodes a base64-encoded context string back into a map.
+
+### Constants
+
+- **`solanaErrorMessages`** -- `Map<int, String>` mapping every `SolanaErrorCode` to its human-readable message template.

--- a/packages/solana_kit_fast_stable_stringify/readme.md
+++ b/packages/solana_kit_fast_stable_stringify/readme.md
@@ -1,0 +1,179 @@
+# solana_kit_fast_stable_stringify
+
+Deterministic JSON serialization with sorted keys for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/fast-stable-stringify`](https://github.com/anza-xyz/kit/tree/main/packages/fast-stable-stringify) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_fast_stable_stringify:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+### Basic stringification
+
+`fastStableStringify` works like `jsonEncode` but sorts object keys alphabetically, producing deterministic output regardless of insertion order.
+
+```dart
+import 'package:solana_kit_fast_stable_stringify/solana_kit_fast_stable_stringify.dart';
+
+final json = fastStableStringify({
+  'zebra': 1,
+  'apple': 2,
+  'mango': 3,
+});
+print(json); // {"apple":2,"mango":3,"zebra":1}
+```
+
+Compare with standard `jsonEncode`, which preserves insertion order:
+
+```dart
+import 'dart:convert';
+
+// jsonEncode preserves insertion order -- non-deterministic.
+print(jsonEncode({'zebra': 1, 'apple': 2, 'mango': 3}));
+// {"zebra":1,"apple":2,"mango":3}
+```
+
+### Supported types
+
+The function handles all common Dart types:
+
+```dart
+import 'package:solana_kit_fast_stable_stringify/solana_kit_fast_stable_stringify.dart';
+
+// null
+fastStableStringify(null);          // 'null'
+
+// Booleans
+fastStableStringify(true);          // 'true'
+fastStableStringify(false);         // 'false'
+
+// Integers
+fastStableStringify(42);            // '42'
+fastStableStringify(-1);            // '-1'
+
+// Doubles
+fastStableStringify(3.14);          // '3.14'
+fastStableStringify(double.nan);    // 'null'  (non-finite becomes null)
+fastStableStringify(double.infinity); // 'null'
+
+// Strings (JSON-escaped)
+fastStableStringify('hello');       // '"hello"'
+fastStableStringify('line\nbreak'); // '"line\\nbreak"'
+
+// BigInt (appends 'n' suffix, matching JavaScript BigInt convention)
+fastStableStringify(BigInt.from(200)); // '200n'
+
+// Lists (recursively stringified)
+fastStableStringify([1, 'two', null]); // '[1,"two",null]'
+
+// Maps with sorted keys (recursively stringified)
+fastStableStringify({'b': 2, 'a': 1}); // '{"a":1,"b":2}'
+```
+
+### Nested structures
+
+Keys are sorted at every level of nesting:
+
+```dart
+import 'package:solana_kit_fast_stable_stringify/solana_kit_fast_stable_stringify.dart';
+
+final result = fastStableStringify({
+  'users': [
+    {'name': 'Alice', 'age': 30},
+    {'name': 'Bob', 'age': 25},
+  ],
+  'count': 2,
+});
+print(result);
+// {"count":2,"users":[{"age":30,"name":"Alice"},{"age":25,"name":"Bob"}]}
+```
+
+### BigInt handling
+
+BigInt values are serialized with a trailing `n` suffix to match the JavaScript BigInt serialization convention. This is important for interoperability with the TypeScript SDK.
+
+```dart
+import 'package:solana_kit_fast_stable_stringify/solana_kit_fast_stable_stringify.dart';
+
+final result = fastStableStringify({
+  'age': BigInt.from(100),
+  'name': 'Hrushi',
+});
+print(result); // {"age":100n,"name":"Hrushi"}
+
+// BigInt values in arrays
+final arrayResult = fastStableStringify({
+  'values': [BigInt.from(100), BigInt.from(200), BigInt.from(300)],
+});
+print(arrayResult); // {"values":[100n,200n,300n]}
+```
+
+### Custom objects with `ToJsonable`
+
+Classes that mix in `ToJsonable` and implement `toJson()` are automatically stringified by recursively processing the return value:
+
+```dart
+import 'package:solana_kit_fast_stable_stringify/solana_kit_fast_stable_stringify.dart';
+
+class User with ToJsonable {
+  User(this.name, this.age);
+
+  final String name;
+  final int age;
+
+  @override
+  Object? toJson() => {'name': name, 'age': age};
+}
+
+final result = fastStableStringify(User('Alice', 30));
+print(result); // {"age":30,"name":"Alice"}
+```
+
+### Return value
+
+`fastStableStringify` returns `String?`. It returns `null` for values that have no JSON representation (such as functions or objects without a `toJson()` method that cannot be encoded by `jsonEncode`).
+
+```dart
+import 'package:solana_kit_fast_stable_stringify/solana_kit_fast_stable_stringify.dart';
+
+// Returns null for non-serializable top-level values.
+final result = fastStableStringify(Object());
+print(result); // null (if Object has no toJson and jsonEncode fails)
+
+// Inside arrays, non-serializable values become 'null'.
+final arrayResult = fastStableStringify([1, Object(), 3]);
+print(arrayResult); // [1,null,3]
+```
+
+### Use case: request deduplication
+
+The primary use of this function in the Solana Kit SDK is to produce stable cache keys for RPC request deduplication. Because the output is deterministic, two requests with the same parameters but different key ordering will produce the same string, allowing them to be correctly identified as duplicates.
+
+```dart
+import 'package:solana_kit_fast_stable_stringify/solana_kit_fast_stable_stringify.dart';
+
+// These produce the same output regardless of key order.
+final key1 = fastStableStringify({'method': 'getBalance', 'params': ['abc']});
+final key2 = fastStableStringify({'params': ['abc'], 'method': 'getBalance'});
+print(key1 == key2); // true
+// Both: {"method":"getBalance","params":["abc"]}
+```
+
+## API Reference
+
+### Functions
+
+- **`fastStableStringify(Object? value)`** -- Returns a deterministic JSON string with sorted keys, or `null` if the value cannot be serialized.
+
+### Mixins
+
+- **`ToJsonable`** -- Mixin for classes that implement `Object? toJson()`. When an object with this mixin is passed to `fastStableStringify`, its `toJson()` return value is recursively stringified.

--- a/packages/solana_kit_functional/readme.md
+++ b/packages/solana_kit_functional/readme.md
@@ -1,0 +1,175 @@
+# solana_kit_functional
+
+Pipe and compose utilities for the Solana Kit Dart SDK, enabling functional pipeline composition on any value.
+
+This is the Dart port of [`@solana/functional`](https://github.com/anza-xyz/kit/tree/main/packages/functional) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_functional:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+### The `pipe` extension
+
+The `Pipe<T>` extension adds a `.pipe()` method to every Dart value. It takes a function `R Function(T)` and returns the result, allowing you to chain transformations in a readable left-to-right pipeline.
+
+```dart
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+
+final result = 'hello'
+    .pipe((value) => value.toUpperCase())
+    .pipe((value) => '$value!');
+print(result); // HELLO!
+```
+
+### Chaining multiple transforms
+
+Pipes can be chained indefinitely. Each step receives the output of the previous step:
+
+```dart
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+
+final result = 1
+    .pipe((value) => value + 1)   // 2
+    .pipe((value) => value * 2)   // 4
+    .pipe((value) => value - 1);  // 3
+print(result); // 3
+```
+
+### Type-changing pipelines
+
+The type can change at each step in the pipeline. Dart infers the types automatically:
+
+```dart
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+
+final result = 42
+    .pipe((value) => value + 8)           // int: 50
+    .pipe((value) => value.toString())    // String: '50'
+    .pipe((value) => '$value items');     // String: '50 items'
+print(result); // 50 items
+```
+
+### Building immutable objects
+
+Pipe is especially useful for building up immutable data structures step by step:
+
+```dart
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+
+final config = <String, Object?>{'version': 1}
+    .pipe((c) => {...c, 'name': 'my-app'})
+    .pipe((c) => {...c, 'debug': false})
+    .pipe((c) => {...c, 'maxRetries': 3});
+print(config);
+// {version: 1, name: my-app, debug: false, maxRetries: 3}
+```
+
+### Building Solana transaction messages
+
+The primary use case for `pipe` in the Solana Kit SDK is constructing transaction messages through a series of transformations. Each SDK function returns a new message, and `pipe` chains them together fluently:
+
+```dart
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+
+// Illustrative example showing the intended usage pattern.
+// The actual transaction builder functions come from other solana_kit packages.
+final message = createTransactionMessage(version: 0)
+    .pipe(setTransactionMessageFeePayer(myAddress))
+    .pipe(setTransactionMessageLifetimeUsingBlockhash(blockhash))
+    .pipe(appendTransactionMessageInstruction(transferInstruction))
+    .pipe(appendTransactionMessageInstruction(memoInstruction));
+```
+
+This pattern mirrors the TypeScript SDK, where the `pipe()` function from `@solana/functional` is used throughout to build transaction messages:
+
+```typescript
+// TypeScript equivalent from @solana/kit
+const message = pipe(
+  createTransactionMessage({ version: 0 }),
+  tx => setTransactionMessageFeePayer(myAddress, tx),
+  tx => setTransactionMessageLifetimeUsingBlockhash(blockhash, tx),
+  tx => appendTransactionMessageInstruction(transferInstruction, tx),
+);
+```
+
+### Combining lists
+
+```dart
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+
+final combined = [1]
+    .pipe((list) => [...list, 2])
+    .pipe((list) => [...list, 3])
+    .pipe((list) => [...list, 4]);
+print(combined); // [1, 2, 3, 4]
+```
+
+### Nested pipes
+
+Pipes can be nested within other pipes for complex transformations:
+
+```dart
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+
+final result = 1
+    .pipe((value) => value + 1)
+    .pipe((value) => value * 2)
+    .pipe((value) => value - 1)
+    .pipe(
+      (value) => value
+          .pipe((v) => v.toString())
+          .pipe((v) => '$v!'),
+    )
+    .pipe((value) => '$value##')
+    .pipe((value) => '$value$value');
+print(result); // 3!##3!##
+```
+
+### Passing named functions
+
+You can pass any function reference directly to `pipe`, not just lambdas:
+
+```dart
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+
+Map<String, Object?> dropNulls(Map<String, Object?> map) {
+  return Map.fromEntries(map.entries.where((e) => e.value != null));
+}
+
+final cleaned = <String, Object?>{'a': 1, 'b': null, 'c': 3}
+    .pipe(dropNulls);
+print(cleaned); // {a: 1, c: 3}
+```
+
+### Error propagation
+
+Errors thrown inside a pipe step propagate naturally:
+
+```dart
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+
+try {
+  'start'
+      .pipe((value) => value.toUpperCase())
+      .pipe((value) => throw Exception('Something went wrong'))
+      .pipe((value) => '$value!'); // never reached
+} on Exception catch (e) {
+  print(e); // Exception: Something went wrong
+}
+```
+
+## API Reference
+
+### Extensions
+
+- **`Pipe<T>` on `T`** -- Adds the `pipe` method to every Dart value.
+  - `R pipe<R>(R Function(T value) transform)` -- Applies the given transform function to this value and returns the result.

--- a/packages/solana_kit_instruction_plans/readme.md
+++ b/packages/solana_kit_instruction_plans/readme.md
@@ -1,0 +1,412 @@
+# solana_kit_instruction_plans
+
+Plan, organize, and execute complex multi-instruction and multi-transaction operations on Solana.
+
+This is the Dart port of [`@solana/instruction-plans`](https://github.com/anza-xyz/kit/tree/main/packages/instruction-plans) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_instruction_plans:
+```
+
+Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Overview
+
+Instruction plans describe operations that may go beyond a single instruction and can span multiple transactions. They define a tree of instructions with constraints on execution order:
+
+- **Sequential** -- Instructions that must run in order.
+- **Parallel** -- Instructions that can run concurrently.
+- **Single** -- A leaf node wrapping one instruction.
+- **MessagePacker** -- A dynamic node that packs instructions into transaction messages to fill available space.
+
+The workflow has three stages:
+
+1. **Instruction Plan** -- Describe what needs to happen.
+2. **Transaction Planner** -- Convert instruction plans into transaction plans (decides how instructions are grouped into transactions).
+3. **Transaction Plan Executor** -- Compile, sign, send, and report results.
+
+## Usage
+
+### Creating instruction plans
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+
+final systemProgram = Address('11111111111111111111111111111111');
+final alice = Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu');
+final bob = Address('GDhQoTpNbYUaCAjFKBMCPCdrCaKaLiSqhx5M7r4SrEFy');
+
+final depositFromAlice = singleInstructionPlan(Instruction(
+  programAddress: systemProgram,
+  accounts: [
+    AccountMeta(address: alice, role: AccountRole.writableSigner),
+  ],
+  data: Uint8List.fromList([2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0]),
+));
+
+final depositFromBob = singleInstructionPlan(Instruction(
+  programAddress: systemProgram,
+  accounts: [
+    AccountMeta(address: bob, role: AccountRole.writableSigner),
+  ],
+  data: Uint8List.fromList([2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0]),
+));
+
+final activateVault = singleInstructionPlan(Instruction(
+  programAddress: systemProgram,
+));
+
+final withdrawToAlice = singleInstructionPlan(Instruction(
+  programAddress: systemProgram,
+  accounts: [
+    AccountMeta(address: alice, role: AccountRole.writable),
+  ],
+));
+
+final withdrawToBob = singleInstructionPlan(Instruction(
+  programAddress: systemProgram,
+  accounts: [
+    AccountMeta(address: bob, role: AccountRole.writable),
+  ],
+));
+```
+
+### Composing plans
+
+Combine instruction plans using sequential and parallel composition:
+
+```dart
+// Both deposits can happen in parallel, then activate, then both
+// withdrawals can happen in parallel.
+final plan = sequentialInstructionPlan([
+  parallelInstructionPlan([depositFromAlice, depositFromBob]),
+  activateVault,
+  parallelInstructionPlan([withdrawToAlice, withdrawToBob]),
+]);
+```
+
+You can pass `Instruction` objects directly to the factory functions -- they are automatically wrapped in `SingleInstructionPlan`:
+
+```dart
+final simplePlan = sequentialInstructionPlan([
+  Instruction(programAddress: systemProgram),
+  Instruction(programAddress: systemProgram),
+]);
+```
+
+### Non-divisible plans
+
+When instructions must execute atomically (in a single transaction or bundle), use a non-divisible sequential plan:
+
+```dart
+final atomicPlan = nonDivisibleSequentialInstructionPlan([
+  Instruction(programAddress: systemProgram),
+  Instruction(programAddress: systemProgram),
+]);
+
+print(atomicPlan.divisible); // false
+```
+
+### Message packer plans
+
+For operations that need to write large amounts of data across multiple transactions, use message packer plans. They dynamically fill each transaction to capacity:
+
+```dart
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+
+// Pack data linearly, writing `totalLength` bytes across multiple
+// transactions.
+final linearPlan = getLinearMessagePackerInstructionPlan(
+  getInstruction: (offset, length) => Instruction(
+    programAddress: Address('11111111111111111111111111111111'),
+    // Build your instruction using the offset and length.
+  ),
+  totalLength: 50000, // 50 KB of data to write.
+);
+
+// Pack a pre-built list of instructions, filling each transaction.
+final listPlan = getMessagePackerInstructionPlanFromInstructions([
+  Instruction(programAddress: Address('11111111111111111111111111111111')),
+  Instruction(programAddress: Address('11111111111111111111111111111111')),
+  Instruction(programAddress: Address('11111111111111111111111111111111')),
+]);
+
+// Pack realloc instructions in chunks of 10,240 bytes.
+final reallocPlan = getReallocMessagePackerInstructionPlan(
+  getInstruction: (size) => Instruction(
+    programAddress: Address('11111111111111111111111111111111'),
+    // Build a realloc instruction for `size` bytes.
+  ),
+  totalSize: 40960, // 40 KB to reallocate.
+);
+```
+
+### Planning transactions
+
+A `TransactionPlanner` converts an instruction plan into a `TransactionPlan` -- a tree of transaction messages ready to be compiled and sent:
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+final planner = createTransactionPlanner(
+  TransactionPlannerConfig(
+    createTransactionMessage: () async {
+      // Create a new transaction message with fee payer and lifetime.
+      return TransactionMessage(
+        version: TransactionVersion.v0,
+        feePayer: Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu'),
+        lifetimeConstraint: BlockhashLifetimeConstraint(
+          blockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N',
+          lastValidBlockHeight: BigInt.from(300000),
+        ),
+      );
+    },
+  ),
+);
+
+// Convert the instruction plan to a transaction plan.
+final transactionPlan = await planner(plan);
+```
+
+### Transaction plans
+
+Transaction plans mirror the instruction plan tree structure, but contain `TransactionMessage` objects instead of instructions:
+
+```dart
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+// Create transaction plans directly.
+final msg = TransactionMessage(version: TransactionVersion.v0);
+final singlePlan = singleTransactionPlan(msg);
+final seqPlan = sequentialTransactionPlan([singlePlan, singlePlan]);
+final parPlan = parallelTransactionPlan([singlePlan, singlePlan]);
+final nonDivPlan = nonDivisibleSequentialTransactionPlan([
+  singlePlan,
+  singlePlan,
+]);
+```
+
+### Traversing transaction plan trees
+
+```dart
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+
+void main() {
+  // Flatten a plan tree into a list of SingleTransactionPlans.
+  final allSinglePlans = flattenTransactionPlan(transactionPlan);
+  print('Total transactions: ${allSinglePlans.length}');
+
+  // Find the first plan matching a predicate.
+  final found = findTransactionPlan(
+    transactionPlan,
+    (p) => p is SingleTransactionPlan,
+  );
+
+  // Check if all plans match a predicate.
+  final allSingle = everyTransactionPlan(
+    transactionPlan,
+    (p) => p is SingleTransactionPlan,
+  );
+
+  // Transform plans (bottom-up).
+  final transformed = transformTransactionPlan(
+    transactionPlan,
+    (p) => p, // identity transform
+  );
+}
+```
+
+### Executing transaction plans
+
+A `TransactionPlanExecutor` traverses the transaction plan tree, compiling, signing, and sending each transaction:
+
+```dart
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+final executor = createTransactionPlanExecutor(
+  TransactionPlanExecutorConfig(
+    executeTransactionMessage: (context, message) async {
+      // Compile, sign, and send the transaction message.
+      // Return a Signature string or a Transaction object.
+      // The `context` map can be used to store intermediate data.
+      return 'signature-base58-string';
+    },
+  ),
+);
+
+// Execute the transaction plan.
+final result = await executor(transactionPlan);
+```
+
+### Inspecting execution results
+
+The execution returns a `TransactionPlanResult` tree that mirrors the plan structure:
+
+```dart
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+
+void inspectResults(TransactionPlanResult result) {
+  // Summarize results into successful, failed, and canceled lists.
+  final summary = summarizeTransactionPlanResult(result);
+  print(summary.successful);              // true if all succeeded
+  print(summary.successfulTransactions);   // List of successful results
+  print(summary.failedTransactions);       // List of failed results
+  print(summary.canceledTransactions);     // List of canceled results
+
+  // Check if all results are successful.
+  print(isSuccessfulTransactionPlanResult(result));
+
+  // Flatten results into a list.
+  final allResults = flattenTransactionPlanResult(result);
+  print('Total results: ${allResults.length}');
+}
+```
+
+### Appending instruction plans to transaction messages
+
+You can directly append all instructions from an instruction plan to a transaction message:
+
+```dart
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+void main() {
+  final message = TransactionMessage(version: TransactionVersion.v0);
+
+  final updatedMessage = appendTransactionMessageInstructionPlan(
+    plan,
+    message,
+  );
+  print(updatedMessage.instructions.length);
+}
+```
+
+### Parsing flexible inputs
+
+The package provides helpers that accept `Instruction`, `InstructionPlan`, `TransactionMessage`, or `TransactionPlan` objects and automatically wrap them:
+
+```dart
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+final instruction = Instruction(
+  programAddress: Address('11111111111111111111111111111111'),
+);
+
+// Automatically wraps in SingleInstructionPlan.
+final parsed = parseInstructionPlanInput(instruction);
+print(parsed is SingleInstructionPlan); // true
+
+// A list is wrapped in a SequentialInstructionPlan.
+final parsedList = parseInstructionPlanInput([instruction, instruction]);
+print(parsedList is SequentialInstructionPlan); // true
+```
+
+## API Reference
+
+### Sealed classes
+
+- **`InstructionPlan`** -- The base sealed class for instruction plans.
+  - **`SingleInstructionPlan`** -- Wraps a single `Instruction`.
+  - **`SequentialInstructionPlan`** -- Contains ordered `plans` with a `divisible` flag.
+  - **`ParallelInstructionPlan`** -- Contains `plans` that can execute concurrently.
+  - **`MessagePackerInstructionPlan`** -- Provides a `getMessagePacker` factory for dynamic packing.
+
+- **`TransactionPlan`** -- The base sealed class for transaction plans.
+  - **`SingleTransactionPlan`** -- Wraps a single `TransactionMessage`.
+  - **`SequentialTransactionPlan`** -- Contains ordered `plans` with a `divisible` flag.
+  - **`ParallelTransactionPlan`** -- Contains `plans` that can execute concurrently.
+
+- **`TransactionPlanResult`** -- The base sealed class for execution results.
+  - **`SingleTransactionPlanResult`** -- Base for single transaction results.
+    - **`SuccessfulSingleTransactionPlanResult`** -- Contains `signature`.
+    - **`FailedSingleTransactionPlanResult`** -- Contains `error`.
+    - **`CanceledSingleTransactionPlanResult`** -- Canceled due to earlier failure.
+  - **`SequentialTransactionPlanResult`** -- Contains `plans` results list.
+  - **`ParallelTransactionPlanResult`** -- Contains `plans` results list.
+
+### Classes
+
+- **`MessagePacker`** -- Returned by `MessagePackerInstructionPlan.getMessagePacker()`, with `done()` and `packMessageToCapacity(message)`.
+- **`TransactionPlannerConfig`** -- Configuration with `createTransactionMessage` and optional `onTransactionMessageUpdated`.
+- **`TransactionPlanExecutorConfig`** -- Configuration with `executeTransactionMessage`.
+- **`TransactionPlanResultSummary`** -- Summary with `successful`, `successfulTransactions`, `failedTransactions`, `canceledTransactions`.
+
+### Type aliases
+
+- **`TransactionPlanner`** -- `Future<TransactionPlan> Function(InstructionPlan)`.
+- **`TransactionPlanExecutor`** -- `Future<TransactionPlanResult> Function(TransactionPlan)`.
+- **`CreateTransactionMessage`** -- `Future<TransactionMessage> Function()`.
+- **`ExecuteTransactionMessage`** -- `Future<Object> Function(Map<String, Object?>, TransactionMessage)`.
+
+### Factory functions
+
+| Function                                | Description                                                |
+| --------------------------------------- | ---------------------------------------------------------- |
+| `singleInstructionPlan`                 | Wraps an `Instruction` in a `SingleInstructionPlan`.       |
+| `sequentialInstructionPlan`             | Creates a divisible sequential plan from a list.           |
+| `nonDivisibleSequentialInstructionPlan` | Creates a non-divisible sequential plan.                   |
+| `parallelInstructionPlan`               | Creates a parallel plan from a list.                       |
+| `singleTransactionPlan`                 | Wraps a `TransactionMessage` in a `SingleTransactionPlan`. |
+| `sequentialTransactionPlan`             | Creates a divisible sequential transaction plan.           |
+| `nonDivisibleSequentialTransactionPlan` | Creates a non-divisible sequential transaction plan.       |
+| `parallelTransactionPlan`               | Creates a parallel transaction plan.                       |
+
+### Tree helpers
+
+| Function                         | Description                                                         |
+| -------------------------------- | ------------------------------------------------------------------- |
+| `flattenInstructionPlan`         | Flattens an instruction plan tree into leaf plans.                  |
+| `findInstructionPlan`            | Depth-first search for the first matching plan.                     |
+| `everyInstructionPlan`           | Returns `true` if all plans satisfy a predicate.                    |
+| `transformInstructionPlan`       | Bottom-up transformation of the plan tree.                          |
+| `flattenTransactionPlan`         | Flattens a transaction plan tree into `SingleTransactionPlan` list. |
+| `findTransactionPlan`            | Depth-first search for the first matching transaction plan.         |
+| `everyTransactionPlan`           | Returns `true` if all transaction plans satisfy a predicate.        |
+| `transformTransactionPlan`       | Bottom-up transformation of the transaction plan tree.              |
+| `flattenTransactionPlanResult`   | Flattens results into `SingleTransactionPlanResult` list.           |
+| `findTransactionPlanResult`      | Depth-first search for the first matching result.                   |
+| `everyTransactionPlanResult`     | Returns `true` if all results satisfy a predicate.                  |
+| `transformTransactionPlanResult` | Bottom-up transformation of the result tree.                        |
+
+### Message packer factories
+
+| Function                                          | Description                                                 |
+| ------------------------------------------------- | ----------------------------------------------------------- |
+| `getLinearMessagePackerInstructionPlan`           | Packs data linearly with offset/length across transactions. |
+| `getMessagePackerInstructionPlanFromInstructions` | Packs a list of instructions, filling each transaction.     |
+| `getReallocMessagePackerInstructionPlan`          | Packs realloc instructions in 10,240-byte chunks.           |
+
+### Planner and executor
+
+| Function                                    | Description                                                         |
+| ------------------------------------------- | ------------------------------------------------------------------- |
+| `createTransactionPlanner`                  | Creates a `TransactionPlanner` from config.                         |
+| `createTransactionPlanExecutor`             | Creates a `TransactionPlanExecutor` from config.                    |
+| `passthroughFailedTransactionPlanExecution` | Catches executor errors and returns the result instead of throwing. |
+| `summarizeTransactionPlanResult`            | Categorizes results into successful, failed, and canceled.          |
+| `getFirstFailedSingleTransactionPlanResult` | Finds the first failed result in a tree.                            |
+
+### Other functions
+
+| Function                                  | Description                                                    |
+| ----------------------------------------- | -------------------------------------------------------------- |
+| `appendTransactionMessageInstructionPlan` | Appends all instructions from a plan to a transaction message. |
+| `parseInstructionPlanInput`               | Parses flexible input into an `InstructionPlan`.               |
+| `parseTransactionPlanInput`               | Parses flexible input into a `TransactionPlan`.                |

--- a/packages/solana_kit_instructions/readme.md
+++ b/packages/solana_kit_instructions/readme.md
@@ -1,0 +1,163 @@
+# solana_kit_instructions
+
+Types and helpers for creating Solana transaction instructions.
+
+This is the Dart port of [`@solana/instructions`](https://github.com/anza-xyz/kit/tree/main/packages/instructions) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_instructions:
+```
+
+Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Creating instructions
+
+An `Instruction` describes a call to a Solana program. It includes the program address, an optional list of account metadata, and optional opaque data bytes.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+// A simple instruction with no accounts or data.
+final instruction = Instruction(
+  programAddress: Address('11111111111111111111111111111111'),
+);
+
+// An instruction with accounts and data.
+final transferInstruction = Instruction(
+  programAddress: Address('11111111111111111111111111111111'),
+  accounts: [
+    AccountMeta(
+      address: Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu'),
+      role: AccountRole.writableSigner,
+    ),
+    AccountMeta(
+      address: Address('GDhQoTpNbYUaCAjFKBMCPCdrCaKaLiSqhx5M7r4SrEFy'),
+      role: AccountRole.writable,
+    ),
+  ],
+  data: Uint8List.fromList([2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0]),
+);
+```
+
+### Account roles
+
+Every account that participates in a transaction is assigned a role via `AccountRole`. Roles are encoded as a two-bit bitmask:
+
+| Role             | Signer | Writable | Value |
+| ---------------- | ------ | -------- | ----- |
+| `readonly`       | No     | No       | 0b00  |
+| `writable`       | No     | Yes      | 0b01  |
+| `readonlySigner` | Yes    | No       | 0b10  |
+| `writableSigner` | Yes    | Yes      | 0b11  |
+
+```dart
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+// Check whether a role is a signer or writable.
+final role = AccountRole.writableSigner;
+print(isSignerRole(role));   // true
+print(isWritableRole(role)); // true
+
+// Upgrade / downgrade roles.
+final upgraded = upgradeRoleToSigner(AccountRole.writable);
+print(upgraded); // AccountRole.writableSigner
+
+final downgraded = downgradeRoleToNonSigner(AccountRole.writableSigner);
+print(downgraded); // AccountRole.writable
+
+// Merge two roles, taking the highest privilege of each.
+final merged = mergeRoles(AccountRole.readonlySigner, AccountRole.writable);
+print(merged); // AccountRole.writableSigner
+```
+
+### Address lookup table accounts
+
+For versioned transactions (v0), accounts can be referenced via address lookup tables. Use `AccountLookupMeta` for this:
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+final lookupAccount = AccountLookupMeta(
+  address: Address('GDhQoTpNbYUaCAjFKBMCPCdrCaKaLiSqhx5M7r4SrEFy'),
+  addressIndex: 3,
+  lookupTableAddress: Address('4wBqpZM9msxygPoFDEBSm7BKZRXBT6DzChAZ87UMVGim'),
+  role: AccountRole.writable,
+);
+
+// AccountLookupMeta extends AccountMeta, so it fits anywhere
+// an AccountMeta is accepted.
+final instruction = Instruction(
+  programAddress: Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+  accounts: [lookupAccount],
+);
+```
+
+### Asserting instruction properties
+
+The package provides guard functions that throw a `SolanaError` when an assertion fails:
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+final systemProgram = Address('11111111111111111111111111111111');
+final instruction = Instruction(programAddress: systemProgram);
+
+// Returns true if the instruction targets the given program.
+print(isInstructionForProgram(instruction, systemProgram)); // true
+
+// Throws SolanaError if the program addresses do not match.
+assertIsInstructionForProgram(instruction, systemProgram);
+
+// Check that accounts or data are present.
+print(isInstructionWithAccounts(instruction)); // false
+print(isInstructionWithData(instruction));     // false
+
+// These will throw because accounts and data are null.
+// assertIsInstructionWithAccounts(instruction);
+// assertIsInstructionWithData(instruction);
+```
+
+## API Reference
+
+### Classes
+
+- **`Instruction`** -- An instruction destined for a given program, with `programAddress`, optional `accounts`, and optional `data`.
+- **`AccountMeta`** -- An account's address and its role in the transaction.
+- **`AccountLookupMeta`** -- Extends `AccountMeta` with lookup table address and index for versioned transactions.
+
+### Enums
+
+- **`AccountRole`** -- `readonly`, `writable`, `readonlySigner`, `writableSigner`.
+
+### Functions
+
+| Function | Description |
+| --- | --- |
+| `isInstructionForProgram` | Returns `true` if the instruction targets the given program address. |
+| `assertIsInstructionForProgram` | Throws `SolanaError` if the instruction does not target the given program. |
+| `isInstructionWithAccounts` | Returns `true` if the instruction has an accounts list. |
+| `assertIsInstructionWithAccounts` | Throws `SolanaError` if the instruction has no accounts. |
+| `isInstructionWithData` | Returns `true` if the instruction has data. |
+| `assertIsInstructionWithData` | Throws `SolanaError` if the instruction has no data. |
+| `isSignerRole` | Returns `true` if the role represents a signer. |
+| `isWritableRole` | Returns `true` if the role represents a writable account. |
+| `upgradeRoleToSigner` | Returns the signer variant of the given role. |
+| `upgradeRoleToWritable` | Returns the writable variant of the given role. |
+| `downgradeRoleToNonSigner` | Returns the non-signer variant of the given role. |
+| `downgradeRoleToReadonly` | Returns the read-only variant of the given role. |
+| `mergeRoles` | Returns the role with the highest privileges of both inputs. |

--- a/packages/solana_kit_keys/readme.md
+++ b/packages/solana_kit_keys/readme.md
@@ -1,0 +1,276 @@
+# solana_kit_keys
+
+Ed25519 key pair generation, signing, and signature verification for the Solana Kit Dart SDK -- a Dart port of [`@solana/keys`](https://github.com/anza-xyz/kit/tree/main/packages/keys).
+
+## Installation
+
+Add `solana_kit_keys` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_keys:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Generating a key pair
+
+Generate a random Ed25519 key pair containing a 32-byte private key (seed) and its corresponding 32-byte public key.
+
+```dart
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  final keyPair = generateKeyPair();
+
+  print('Private key length: ${keyPair.privateKey.length}'); // 32
+  print('Public key length: ${keyPair.publicKey.length}'); // 32
+}
+```
+
+### Creating a key pair from bytes
+
+Restore a key pair from a 64-byte array where the first 32 bytes are the private key and the last 32 bytes are the public key. The function verifies that the public key matches the private key.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  // A 64-byte array: [32 bytes private key | 32 bytes public key]
+  final bytes = Uint8List(64); // replace with real key bytes
+
+  // Throws SolanaError if:
+  // - bytes is not exactly 64 bytes
+  // - public key does not match the private key
+  final keyPair = createKeyPairFromBytes(bytes);
+  print(keyPair.privateKey.length); // 32
+  print(keyPair.publicKey.length); // 32
+}
+```
+
+### Creating a key pair from a private key
+
+If you only have the 32-byte private key (seed), derive the corresponding public key automatically.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  // A 32-byte private key (seed).
+  final privateKeyBytes = Uint8List(32); // replace with real bytes
+
+  // Derives the public key from the private key.
+  // Throws SolanaError if privateKeyBytes is not exactly 32 bytes.
+  final keyPair = createKeyPairFromPrivateKeyBytes(privateKeyBytes);
+  print(keyPair.publicKey.length); // 32
+}
+```
+
+### Deriving a public key from a private key
+
+If you need just the public key bytes without constructing a full `KeyPair`:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  final privateKeyBytes = Uint8List(32); // replace with real bytes
+
+  // Returns the 32-byte Ed25519 public key corresponding to the private key.
+  final publicKeyBytes = getPublicKeyFromPrivateKey(privateKeyBytes);
+  print(publicKeyBytes.length); // 32
+}
+```
+
+### Signing data
+
+Sign arbitrary byte data with a 32-byte private key. Returns a 64-byte Ed25519 signature.
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  final keyPair = generateKeyPair();
+  final message = Uint8List.fromList(utf8.encode('Hello, Solana!'));
+
+  // Sign the message with the private key.
+  final sig = signBytes(keyPair.privateKey, message);
+  print('Signature length: ${sig.value.length}'); // 64
+}
+```
+
+### Verifying signatures
+
+Verify that a signature was produced by the holder of a given public key.
+
+```dart
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  final keyPair = generateKeyPair();
+  final message = Uint8List.fromList(utf8.encode('Hello, Solana!'));
+
+  // Sign the message.
+  final sig = signBytes(keyPair.privateKey, message);
+
+  // Verify the signature with the public key.
+  final isValid = verifySignature(keyPair.publicKey, sig, message);
+  print('Signature valid: $isValid'); // true
+
+  // Verification fails with a wrong public key.
+  final otherKeyPair = generateKeyPair();
+  final isInvalid = verifySignature(otherKeyPair.publicKey, sig, message);
+  print('Signature valid with wrong key: $isInvalid'); // false
+}
+```
+
+### Working with base58-encoded signatures
+
+The `Signature` extension type wraps a base58-encoded string representation of a 64-byte Ed25519 signature. Use the `signature()` factory to create a validated instance.
+
+```dart
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  const rawSigString =
+      '5cFvJAqcyB5VGjkzvcTxUKwcirYvJrBWLQEjRCBXhDrGi'
+      'JLbDDQfpnEhcACxNLEBjcDjSbGNpGSmSCXtHRpzKNG';
+
+  // Validate and wrap a base58-encoded signature string.
+  final sig = signature(rawSigString);
+  print(sig.value); // the base58-encoded string
+
+  // Check without throwing.
+  final valid = isSignature(rawSigString); // true
+  final invalid = isSignature('too-short'); // false
+}
+```
+
+### Working with raw signature bytes
+
+The `SignatureBytes` extension type wraps a `Uint8List` that is exactly 64 bytes. Use the `signatureBytes()` factory for validation.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  final rawBytes = Uint8List(64); // replace with real signature bytes
+
+  // Validate and wrap raw signature bytes.
+  final sig = signatureBytes(rawBytes);
+  print(sig.value.length); // 64
+
+  // Check without throwing.
+  final valid = isSignatureBytes(rawBytes); // true
+  final invalid = isSignatureBytes(Uint8List(32)); // false
+}
+```
+
+### Validating private keys
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  final validKey = Uint8List(32);
+  final invalidKey = Uint8List(16);
+
+  // Assert that bytes represent a valid 32-byte Ed25519 private key.
+  assertIsPrivateKey(validKey); // OK
+
+  // Throws SolanaError with keysInvalidPrivateKeyByteLength.
+  // assertIsPrivateKey(invalidKey);
+}
+```
+
+### Connecting addresses and key pairs
+
+Use `solana_kit_addresses` together with `solana_kit_keys` to convert between key pairs and Solana addresses.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+
+void main() {
+  final keyPair = generateKeyPair();
+
+  // Convert the public key to a Solana address.
+  final addr = getAddressFromPublicKey(keyPair.publicKey);
+  print('Address: ${addr.value}');
+
+  // Convert the address back to public key bytes.
+  final publicKeyBytes = getPublicKeyFromAddress(addr);
+  print('Public key length: ${publicKeyBytes.length}'); // 32
+}
+```
+
+## API Reference
+
+### Types
+
+| Export | Description |
+|--------|-------------|
+| `KeyPair` | Class holding a 32-byte `privateKey` and a 32-byte `publicKey` (`Uint8List` fields). |
+| `Signature` | Extension type wrapping `String` -- a validated base58-encoded 64-byte Ed25519 signature. Zero runtime overhead. |
+| `SignatureBytes` | Extension type wrapping `Uint8List` -- a validated 64-byte Ed25519 signature in raw bytes. Zero runtime overhead. |
+
+### Key pair generation
+
+| Function | Description |
+|----------|-------------|
+| `generateKeyPair()` | Generates a new random Ed25519 `KeyPair`. |
+| `createKeyPairFromBytes(Uint8List)` | Creates a `KeyPair` from a 64-byte array (32 private + 32 public). Validates the key pair. |
+| `createKeyPairFromPrivateKeyBytes(Uint8List)` | Creates a `KeyPair` from a 32-byte private key, deriving the public key. |
+
+### Public key derivation
+
+| Function | Description |
+|----------|-------------|
+| `getPublicKeyFromPrivateKey(Uint8List)` | Derives the 32-byte Ed25519 public key from a 32-byte private key. |
+
+### Signing and verification
+
+| Function | Description |
+|----------|-------------|
+| `signBytes(Uint8List privateKey, Uint8List data)` | Signs data with a 32-byte private key. Returns `SignatureBytes` (64 bytes). |
+| `verifySignature(Uint8List publicKey, SignatureBytes sig, Uint8List data)` | Returns `true` if the signature is valid for the given public key and data. |
+
+### Signature creation and validation
+
+| Function | Description |
+|----------|-------------|
+| `signature(String)` | Creates a validated `Signature` from a base58-encoded string. Throws on invalid input. |
+| `signatureBytes(Uint8List)` | Creates validated `SignatureBytes` from a 64-byte array. Throws on invalid input. |
+| `isSignature(String)` | Returns `true` if the string is a valid base58-encoded 64-byte signature. |
+| `isSignatureBytes(Uint8List)` | Returns `true` if the byte array is exactly 64 bytes. |
+| `assertIsSignature(String)` | Asserts the string is a valid base58 signature. Throws `SolanaError` on failure. |
+| `assertIsSignatureBytes(Uint8List)` | Asserts the byte array is exactly 64 bytes. Throws `SolanaError` on failure. |
+
+### Private key validation
+
+| Function | Description |
+|----------|-------------|
+| `assertIsPrivateKey(Uint8List)` | Asserts the byte array is exactly 32 bytes. Throws `SolanaError` on failure. |

--- a/packages/solana_kit_lints/readme.md
+++ b/packages/solana_kit_lints/readme.md
@@ -1,0 +1,100 @@
+# solana_kit_lints
+
+Shared lint rules for all packages in the Solana Kit Dart SDK.
+
+This is an internal package (`publish_to: none`) that centralizes the analysis configuration for the monorepo. It is not published to pub.dev.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dev_dependencies:
+  solana_kit_lints:
+```
+
+Within the `solana_kit` monorepo, the package resolves through the Dart workspace. This package is not intended for use outside the monorepo.
+
+## Usage
+
+### Including the lint rules
+
+Create or update your package's `analysis_options.yaml` to include the shared rules:
+
+```yaml
+include: package:solana_kit_lints/analysis_options.yaml
+```
+
+This single line gives your package the full set of lint rules used across the Solana Kit SDK. No additional configuration is needed in most cases.
+
+### Adding package-specific overrides
+
+If a specific package needs to adjust a rule, add overrides after the include:
+
+```yaml
+include: package:solana_kit_lints/analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false  # Allow print in example/CLI packages
+```
+
+## Configuration
+
+The shared `analysis_options.yaml` provided by this package includes [`very_good_analysis`](https://pub.dev/packages/very_good_analysis) as its base and applies the following customizations:
+
+### Base
+
+```yaml
+include: package:very_good_analysis/analysis_options.yaml
+```
+
+### Analyzer error severity
+
+The following diagnostics are promoted to errors to catch problems early:
+
+| Diagnostic              | Severity |
+| ----------------------- | -------- |
+| `missing_return`        | error    |
+| `dead_code`             | error    |
+| `unused_element`        | error    |
+| `unused_import`         | error    |
+| `unused_local_variable` | error    |
+| `todo`                  | ignore   |
+
+### Disabled lint rules
+
+The following rules from `very_good_analysis` are disabled for this project:
+
+| Rule                          | Reason                                                                                             |
+| ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| `public_member_api_docs`      | Disabled to reduce friction during initial development. Public API docs are encouraged but not enforced. |
+| `lines_longer_than_80_chars`  | Disabled because many error messages, type signatures, and constant names in the SDK naturally exceed 80 characters. |
+
+### Full configuration
+
+For reference, the complete shared analysis options file:
+
+```yaml
+include: package:very_good_analysis/analysis_options.yaml
+
+analyzer:
+  errors:
+    missing_return: error
+    dead_code: error
+    unused_element: error
+    unused_import: error
+    unused_local_variable: error
+    todo: ignore
+
+linter:
+  rules:
+    public_member_api_docs: false
+    lines_longer_than_80_chars: false
+```
+
+## API Reference
+
+### Provided files
+
+- **`lib/analysis_options.yaml`** -- The shared analysis options file that all packages include. Built on top of `very_good_analysis` with project-specific customizations.

--- a/packages/solana_kit_offchain_messages/readme.md
+++ b/packages/solana_kit_offchain_messages/readme.md
@@ -1,0 +1,259 @@
+# solana_kit_offchain_messages
+
+Create, compile, sign, and verify Solana offchain messages.
+
+Offchain messages allow wallets and applications to sign structured messages that are never submitted to the Solana network. This is the Dart implementation of the [Solana offchain message signing specification](https://github.com/solana-labs/solana/blob/master/docs/src/proposals/off-chain-message-signing.md), related to the signing capabilities in [`@solana/keys`](https://github.com/anza-xyz/kit/tree/main/packages/keys) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_offchain_messages:
+```
+
+Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Creating offchain messages
+
+There are two versions of offchain messages:
+
+**Version 0** messages include an application domain, formatted content, and required signatories.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_offchain_messages/solana_kit_offchain_messages.dart';
+
+// The application domain is a 32-byte identifier (same format as a Solana
+// address) that uniquely identifies the requesting application.
+final appDomain = offchainMessageApplicationDomain(
+  '11111111111111111111111111111111',
+);
+
+final messageV0 = OffchainMessageV0(
+  applicationDomain: appDomain,
+  content: OffchainMessageContent(
+    format: OffchainMessageContentFormat.restrictedAscii1232BytesMax,
+    text: 'Sign this message to verify your identity.',
+  ),
+  requiredSignatories: [
+    OffchainMessageSignatory(
+      address: Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu'),
+    ),
+  ],
+);
+```
+
+**Version 1** messages have simpler UTF-8 text content with no application domain:
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_offchain_messages/solana_kit_offchain_messages.dart';
+
+final messageV1 = OffchainMessageV1(
+  content: 'I agree to the terms and conditions of Acme Corp.',
+  requiredSignatories: [
+    OffchainMessageSignatory(
+      address: Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu'),
+    ),
+  ],
+);
+```
+
+### Content formats (v0)
+
+Version 0 messages support three content formats, each with different constraints:
+
+| Format                        | Characters           | Max bytes |
+| ----------------------------- | -------------------- | --------- |
+| `restrictedAscii1232BytesMax` | ASCII 0x20-0x7E only | 1232      |
+| `utf81232BytesMax`            | Any UTF-8            | 1232      |
+| `utf865535BytesMax`           | Any UTF-8            | 65535     |
+
+The first two formats are signable by hardware wallets, while the third is not.
+
+```dart
+import 'package:solana_kit_offchain_messages/solana_kit_offchain_messages.dart';
+
+final content = OffchainMessageContent(
+  format: OffchainMessageContentFormat.utf81232BytesMax,
+  text: 'Hello, world!',
+);
+
+// Validate content against its declared format.
+print(isOffchainMessageContentUtf8Of1232BytesMax(content)); // true
+
+// Throws SolanaError if validation fails.
+assertIsOffchainMessageContentUtf8Of1232BytesMax(content);
+```
+
+### Application domains
+
+An application domain is a 32-byte value encoded as a base58 string (the same format as a Solana address). It uniquely identifies the application requesting the signature.
+
+```dart
+import 'package:solana_kit_offchain_messages/solana_kit_offchain_messages.dart';
+
+// Validate and create an application domain.
+final domain = offchainMessageApplicationDomain(
+  '11111111111111111111111111111111',
+);
+
+// Check validity.
+print(isOffchainMessageApplicationDomain(
+  '11111111111111111111111111111111',
+)); // true
+
+// Throws SolanaError if invalid.
+assertIsOffchainMessageApplicationDomain(
+  '11111111111111111111111111111111',
+);
+```
+
+### Compiling offchain message envelopes
+
+An `OffchainMessageEnvelope` bundles the encoded message bytes with a signatures map. Compiling a message creates an envelope with `null` signatures for each required signatory:
+
+```dart
+import 'package:solana_kit_offchain_messages/solana_kit_offchain_messages.dart';
+
+// Compile a v0 message.
+final envelopeV0 = compileOffchainMessageEnvelope(messageV0);
+print(envelopeV0.content.length); // Size of the encoded message bytes.
+print(envelopeV0.signatures);     // {Address('mpngs...'): null}
+
+// Compile a v1 message.
+final envelopeV1 = compileOffchainMessageEnvelope(messageV1);
+
+// You can also compile specific versions directly.
+final envelopeV0Direct = compileOffchainMessageV0Envelope(messageV0);
+final envelopeV1Direct = compileOffchainMessageV1Envelope(messageV1);
+```
+
+### Signing offchain message envelopes
+
+Sign envelopes with Ed25519 key pairs:
+
+```dart
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_offchain_messages/solana_kit_offchain_messages.dart';
+
+Future<void> main() async {
+  final keyPair = await generateKeyPair();
+
+  // Sign and assert all signatures are present.
+  final signedEnvelope = signOffchainMessageEnvelope(
+    [keyPair],
+    envelopeV1,
+  );
+
+  // Or partially sign when you don't have all signers yet.
+  final partialEnvelope = partiallySignOffchainMessageEnvelope(
+    [keyPair],
+    envelopeV1,
+  );
+
+  // Check if fully signed.
+  print(isFullySignedOffchainMessageEnvelope(signedEnvelope)); // true
+}
+```
+
+### Verifying offchain message envelopes
+
+After collecting all signatures, verify that every required signatory provided a valid Ed25519 signature:
+
+```dart
+import 'package:solana_kit_offchain_messages/solana_kit_offchain_messages.dart';
+
+void main() {
+  // Throws SolanaError if any signature is missing or invalid.
+  verifyOffchainMessageEnvelope(signedEnvelope);
+}
+```
+
+### Message codecs
+
+The package provides encoders, decoders, and codecs for serializing offchain messages:
+
+```dart
+import 'package:solana_kit_offchain_messages/solana_kit_offchain_messages.dart';
+
+// V0 message codec.
+final v0Encoder = getOffchainMessageV0Encoder();
+final v0Decoder = getOffchainMessageV0Decoder();
+final v0Codec = getOffchainMessageV0Codec();
+
+// V1 message codec.
+final v1Encoder = getOffchainMessageV1Encoder();
+final v1Decoder = getOffchainMessageV1Decoder();
+final v1Codec = getOffchainMessageV1Codec();
+
+// Generic message codec (dispatches on version).
+final encoder = getOffchainMessageEncoder();
+final decoder = getOffchainMessageDecoder();
+final codec = getOffchainMessageCodec();
+
+// Envelope codec (message + signatures).
+final envelopeEncoder = getOffchainMessageEnvelopeEncoder();
+final envelopeDecoder = getOffchainMessageEnvelopeDecoder();
+final envelopeCodec = getOffchainMessageEnvelopeCodec();
+```
+
+## API Reference
+
+### Sealed classes
+
+- **`OffchainMessage`** -- Sealed base class for offchain messages.
+  - **`OffchainMessageV0`** -- Version 0 message with `applicationDomain`, `content` (an `OffchainMessageContent`), and `requiredSignatories`.
+  - **`OffchainMessageV1`** -- Version 1 message with `content` (a `String`) and `requiredSignatories`.
+
+### Classes
+
+- **`OffchainMessageEnvelope`** -- Compiled envelope with `content` bytes and `signatures` map.
+- **`OffchainMessageSignatory`** -- A required signatory with an `address`.
+- **`OffchainMessageContent`** -- V0 content with `format` and `text`.
+
+### Enums
+
+- **`OffchainMessageContentFormat`** -- `restrictedAscii1232BytesMax`, `utf81232BytesMax`, `utf865535BytesMax`.
+
+### Type aliases
+
+- **`OffchainMessageApplicationDomain`** -- Alias for `Address` (32-byte base58 domain).
+- **`OffchainMessageVersion`** -- Alias for `int` (0 or 1).
+
+### Functions
+
+| Function                                                       | Description                                                         |
+| -------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `compileOffchainMessageEnvelope`                               | Compiles an offchain message into an envelope with null signatures. |
+| `compileOffchainMessageV0Envelope`                             | Compiles a v0 message into an envelope.                             |
+| `compileOffchainMessageV1Envelope`                             | Compiles a v1 message into an envelope.                             |
+| `signOffchainMessageEnvelope`                                  | Signs an envelope and asserts all signatures are present.           |
+| `partiallySignOffchainMessageEnvelope`                         | Signs an envelope with a subset of required signers.                |
+| `isFullySignedOffchainMessageEnvelope`                         | Returns `true` if all signatures are present.                       |
+| `assertIsFullySignedOffchainMessageEnvelope`                   | Throws if any signature is missing.                                 |
+| `verifyOffchainMessageEnvelope`                                | Verifies all signatures are valid Ed25519 signatures.               |
+| `offchainMessageApplicationDomain`                             | Validates and returns an application domain.                        |
+| `isOffchainMessageApplicationDomain`                           | Returns `true` if the string is a valid application domain.         |
+| `assertIsOffchainMessageApplicationDomain`                     | Throws if the string is not a valid application domain.             |
+| `isOffchainMessageContentRestrictedAsciiOf1232BytesMax`        | Validates restricted ASCII content.                                 |
+| `isOffchainMessageContentUtf8Of1232BytesMax`                   | Validates UTF-8 content up to 1232 bytes.                           |
+| `isOffchainMessageContentUtf8Of65535BytesMax`                  | Validates UTF-8 content up to 65535 bytes.                          |
+| `getOffchainMessageV0Encoder` / `Decoder` / `Codec`            | V0 message serialization.                                           |
+| `getOffchainMessageV1Encoder` / `Decoder` / `Codec`            | V1 message serialization.                                           |
+| `getOffchainMessageEncoder` / `Decoder` / `Codec`              | Generic message serialization.                                      |
+| `getOffchainMessageEnvelopeEncoder` / `Decoder` / `Codec`      | Envelope serialization.                                             |
+| `getOffchainMessageSigningDomainEncoder` / `Decoder` / `Codec` | The 16-byte `\xffsolana offchain` signing domain prefix.            |
+
+### Constants
+
+- **`maxBodyBytes`** -- Maximum body bytes for any v0 message: `65535`.
+- **`maxBodyBytesHardwareWalletSignable`** -- Maximum body bytes for hardware-wallet-signable messages: `1232`.
+- **`offchainMessageSigningDomainBytes`** -- The 16-byte signing domain prefix (`\xffsolana offchain`).

--- a/packages/solana_kit_options/readme.md
+++ b/packages/solana_kit_options/readme.md
@@ -1,0 +1,273 @@
+# solana_kit_options
+
+A Rust-like `Option<T>` type and corresponding codec for encoding and decoding optional values in Solana on-chain data.
+
+This is a Dart port of [`@solana/options`](https://github.com/anza-xyz/kit/tree/main/packages/options) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_options:
+```
+
+Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+
+## Usage
+
+### The Option type
+
+Dart has nullable types (`T?`), but they cannot represent nested optionality. For example, `Option<Option<int>>` cannot be expressed as `int??` because there is no way to distinguish `Some(None)` from `None`. This package provides a sealed class hierarchy that mirrors Rust's `Option<T>`.
+
+```dart
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+// Create a Some value.
+final present = some(42);         // Some<int>(42)
+final alsoPresent = Some(42);     // Same thing using the constructor
+
+// Create a None value.
+final absent = none<int>();       // None<int>()
+final alsoAbsent = None<int>();   // Same thing using the constructor
+
+// Pattern matching with Dart's sealed class support.
+final message = switch (present) {
+  Some(:final value) => 'Got $value',
+  None() => 'Nothing',
+};
+// message == 'Got 42'
+```
+
+### Checking option variants
+
+```dart
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+final opt = some(42);
+
+isSome(opt);      // true
+isNone(opt);      // false
+
+isOption(opt);    // true
+isOption(42);     // false
+isOption(null);   // false
+```
+
+### Unwrapping options
+
+Extract the contained value, or get `null` / a fallback:
+
+```dart
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+// Unwrap to nullable.
+unwrapOption(some(42));         // 42
+unwrapOption(none<int>());      // null
+
+// Unwrap with a fallback.
+unwrapOptionOr(some(42), () => 0);     // 42
+unwrapOptionOr(none<int>(), () => 0);  // 0
+
+// Wrap a nullable value into an Option.
+wrapNullable(42);           // Some(42)
+wrapNullable<int>(null);    // None<int>()
+```
+
+### Recursive unwrapping
+
+Deeply unwrap nested options within complex data structures:
+
+```dart
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+// Nested options are fully unwrapped.
+unwrapOptionRecursively(some(some('Hello')));      // 'Hello'
+unwrapOptionRecursively(some(none<String>()));      // null
+
+// Works with maps and lists too.
+final data = {
+  'name': 'Alice',
+  'age': some(30),
+  'nickname': none<String>(),
+  'scores': [some(100), none<int>(), some(85)],
+};
+
+final unwrapped = unwrapOptionRecursively(data);
+// unwrapped == {
+//   'name': 'Alice',
+//   'age': 30,
+//   'nickname': null,
+//   'scores': [100, null, 85],
+// }
+
+// With a fallback for None values.
+unwrapOptionRecursively(some(none<int>()), () => -1); // -1
+```
+
+### Encoding and decoding options
+
+The `getOptionCodec` function creates a codec that encodes `Option<T>` values with a configurable prefix byte (default: `u8`, where `0 = None` and `1 = Some`).
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+final optionU16 = getOptionCodec(getU16Codec());
+
+// Encode Some(42).
+final someBytes = optionU16.encode(some(42));
+// someBytes == [0x01, 0x2a, 0x00]
+//              ^prefix=1^ ^-u16-^
+
+// Encode None.
+final noneBytes = optionU16.encode(none<int>());
+// noneBytes == [0x00]
+//              ^prefix=0^
+
+// You can also pass raw values or null for convenience.
+optionU16.encode(42);    // Same as encoding some(42)
+optionU16.encode(null);  // Same as encoding none()
+
+// Decode back to Option<int>.
+final decoded = optionU16.decode(Uint8List.fromList([0x01, 0x2a, 0x00]));
+// decoded == Some(42)
+
+final decodedNone = optionU16.decode(Uint8List.fromList([0x00]));
+// decodedNone == None<int>()
+```
+
+### Zeroes none value
+
+Use zeroes to represent `None` instead of omitting the value. This keeps the total encoded size constant for fixed-size items, which is useful in account data layouts where field offsets must be predictable:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+final optionU16 = getOptionCodec(
+  getU16Codec(),
+  noneValue: ZeroesOptionNoneValue(),
+);
+
+// Some(42): prefix + value.
+optionU16.encode(some(42));   // [0x01, 0x2a, 0x00]
+
+// None: prefix + zeroed bytes (same total size as Some).
+optionU16.encode(none<int>()); // [0x00, 0x00, 0x00]
+```
+
+### Constant none value
+
+Use a specific byte sequence to represent `None`:
+
+```dart
+import 'dart:typed_data';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+final optionU16 = getOptionCodec(
+  getU16Codec(),
+  noneValue: ConstantOptionNoneValue(Uint8List.fromList([0xff, 0xff])),
+);
+
+optionU16.encode(none<int>()); // [0x00, 0xff, 0xff]
+```
+
+### No prefix
+
+Omit the boolean prefix entirely. Useful when the presence of data can be inferred from context (e.g., remaining bytes or the none value itself):
+
+```dart
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+final optionU16 = getOptionCodec(
+  getU16Codec(),
+  hasPrefix: false,
+  noneValue: ZeroesOptionNoneValue(),
+);
+
+// Some(42): just the value, no prefix.
+optionU16.encode(some(42));    // [0x2a, 0x00]
+
+// None: zeroed bytes, no prefix.
+optionU16.encode(none<int>()); // [0x00, 0x00]
+```
+
+### Custom prefix codec
+
+Use a different number codec for the prefix:
+
+```dart
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+// Use u32 instead of u8 for the prefix.
+final optionU8 = getOptionCodec(
+  getU8Codec(),
+  prefix: getU32Codec(),
+);
+
+optionU8.encode(some(42)); // [0x01, 0x00, 0x00, 0x00, 0x2a]
+//                          ^------u32 prefix------^ ^-u8-^
+```
+
+### Using separate encoders and decoders
+
+For composition with other codec utilities, use the encoder-only and decoder-only variants:
+
+```dart
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_options/solana_kit_options.dart';
+
+// Encoder only.
+final encoder = getOptionEncoder(getU16Encoder());
+final bytes = encoder.encode(some(42));
+
+// Decoder only.
+final decoder = getOptionDecoder(getU16Decoder());
+final option = decoder.decode(bytes);
+// option == Some(42)
+```
+
+## API Reference
+
+### Option type
+
+| Type / Function | Description |
+|-----------------|-------------|
+| `Option<T>` | Sealed class: either `Some<T>` or `None<T>` |
+| `Some<T>(T value)` | Contains a present value |
+| `None<T>()` | Contains no value |
+| `some<T>(T value)` | Factory function for `Some<T>` |
+| `none<T>()` | Factory function for `None<T>` |
+| `isOption(input)` | Returns `true` if the input is an `Option` |
+| `isSome(option)` | Returns `true` if the option is `Some` |
+| `isNone(option)` | Returns `true` if the option is `None` |
+
+### Unwrap utilities
+
+| Function | Description |
+|----------|-------------|
+| `unwrapOption<T>(option)` | Returns the contained value or `null` |
+| `unwrapOptionOr<T>(option, fallback)` | Returns the contained value or calls `fallback()` |
+| `wrapNullable<T>(nullable)` | Converts `T?` into `Option<T>` |
+| `unwrapOptionRecursively(input, [fallback])` | Deep-unwraps nested options in maps, lists, and values |
+
+### Option codecs
+
+| Function | Description |
+|----------|-------------|
+| `getOptionEncoder<T>(item, {prefix, hasPrefix, noneValue})` | Encode `Option<T>` or `T?` values |
+| `getOptionDecoder<T>(item, {prefix, hasPrefix, noneValue})` | Decode bytes into `Option<T>` |
+| `getOptionCodec<TFrom, TTo>(item, {prefix, hasPrefix, noneValue})` | Combined option codec |
+
+### None value types
+
+| Type | Description |
+|------|-------------|
+| `OmitOptionNoneValue()` | `None` is omitted from encoding (default) |
+| `ZeroesOptionNoneValue()` | `None` is encoded as zeroes (requires fixed-size item) |
+| `ConstantOptionNoneValue(bytes)` | `None` is encoded as a specific byte sequence |

--- a/packages/solana_kit_program_client_core/readme.md
+++ b/packages/solana_kit_program_client_core/readme.md
@@ -1,0 +1,221 @@
+# solana_kit_program_client_core
+
+Core building blocks for generated Solana program clients in the Solana Kit Dart SDK.
+
+This package provides the foundational types and utilities used by generated program clients, including instruction types that track storage changes, self-fetch functions for decoder-based account retrieval, and instruction input resolution helpers.
+
+## Installation
+
+Add `solana_kit_program_client_core` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_program_client_core:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Instructions with byte delta
+
+The `InstructionWithByteDelta` class extends the base `Instruction` with a `byteDelta` field that tracks the net change in account storage size. This is useful for calculating rent-exemption balances for a transaction.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_program_client_core/solana_kit_program_client_core.dart';
+
+void main() {
+  const programAddress = Address(
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+  );
+
+  // An instruction that allocates 165 bytes of account space.
+  final createInstruction = InstructionWithByteDelta(
+    programAddress: programAddress,
+    byteDelta: 165, // Positive means bytes are allocated.
+    data: Uint8List.fromList([0, 1, 2, 3]),
+  );
+
+  print(createInstruction.byteDelta); // 165
+  print(createInstruction.programAddress); // TokenkegQ...
+
+  // An instruction that frees 100 bytes of account space.
+  final closeInstruction = InstructionWithByteDelta(
+    programAddress: programAddress,
+    byteDelta: -100, // Negative means bytes are freed.
+  );
+
+  print(closeInstruction.byteDelta); // -100
+
+  // Calculate total byte delta for a transaction.
+  final instructions = [createInstruction, closeInstruction];
+  final totalDelta = instructions.fold<int>(
+    0,
+    (sum, ix) => sum + ix.byteDelta,
+  );
+  print('Net storage change: $totalDelta bytes'); // 65
+}
+```
+
+### Self-fetch functions
+
+The `SelfFetchFunctions<TData>` class augments a decoder with RPC fetch methods, enabling a fluent API where you fetch and decode accounts in one step.
+
+```dart
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_program_client_core/solana_kit_program_client_core.dart';
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+
+// Example: a simple counter account.
+class CounterData {
+  const CounterData(this.count);
+  final int count;
+}
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  // Assume `counterDecoder` is a Decoder<CounterData> for your program's
+  // account layout.
+  final counterDecoder = /* your decoder here */ null as Decoder<CounterData>;
+
+  // Wrap the decoder with self-fetch methods.
+  final fetchable = addSelfFetchFunctions(rpc, counterDecoder);
+
+  const counterAddress = Address('YourCounterAccountAddress1111111111111111111');
+  const address1 = Address('FirstAddress11111111111111111111111111111111');
+  const address2 = Address('SecondAddress1111111111111111111111111111111');
+
+  // Fetch and decode a single account (throws if not found).
+  final account = await fetchable.fetch(counterAddress);
+  print(account.data.count);
+
+  // Fetch and decode, allowing the account to not exist.
+  final maybeAccount = await fetchable.fetchMaybe(counterAddress);
+  if (maybeAccount case ExistingAccount<CounterData>(:final account)) {
+    print('Found: ${account.data.count}');
+  }
+
+  // Fetch and decode multiple accounts (throws if any missing).
+  final accounts = await fetchable.fetchAll([address1, address2]);
+
+  // Fetch multiple, allowing some to not exist.
+  final maybeAccounts = await fetchable.fetchAllMaybe([address1, address2]);
+}
+```
+
+### Instruction input resolution
+
+When building instructions for generated program clients, account inputs must be resolved to their final form. The resolution helpers handle extracting addresses from various account input types.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_program_client_core/solana_kit_program_client_core.dart';
+
+void main() {
+  // Resolve an address from various account input types.
+  const addr = Address('11111111111111111111111111111111');
+
+  // From a plain Address.
+  final resolved = getAddressFromResolvedInstructionAccount('myAccount', addr);
+  print(resolved); // Address('11111...')
+
+  // From a ProgramDerivedAddress (tuple of Address and bump).
+  final pda = (addr, 255);
+  final pdaAddress = getAddressFromResolvedInstructionAccount('myPda', pda);
+  print(pdaAddress); // Address('11111...')
+
+  // Validate non-null inputs.
+  // Throws SolanaError if the value is null.
+  final nonNull = getNonNullResolvedInstructionInput<String>(
+    'myInput',
+    'hello',
+  );
+  print(nonNull); // 'hello'
+}
+```
+
+### Account meta factory
+
+The `getAccountMetaFactory` function creates a converter from resolved instruction accounts to account metas, handling optional accounts and signer detection.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_program_client_core/solana_kit_program_client_core.dart';
+
+void main() {
+  const programAddress = Address('11111111111111111111111111111111');
+
+  // Create a factory that omits optional accounts.
+  final factory = getAccountMetaFactory(
+    programAddress,
+    OptionalAccountStrategy.omitted,
+  );
+
+  // Convert a resolved account to an AccountMeta.
+  final meta = factory(
+    'authority',
+    ResolvedInstructionAccount(
+      isWritable: true,
+      value: const Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+    ),
+  );
+  print(meta?.address); // TokenkegQ...
+
+  // Optional accounts with null values are omitted.
+  final nullMeta = factory(
+    'optionalAccount',
+    ResolvedInstructionAccount(isWritable: false, value: null),
+  );
+  print(nullMeta); // null
+
+  // With programId strategy, null accounts get the program address instead.
+  final programIdFactory = getAccountMetaFactory(
+    programAddress,
+    OptionalAccountStrategy.programId,
+  );
+  final fallbackMeta = programIdFactory(
+    'optionalAccount',
+    ResolvedInstructionAccount(isWritable: false, value: null),
+  );
+  print(fallbackMeta?.address); // Address('11111...')
+}
+```
+
+## API Reference
+
+### Classes
+
+| Class                        | Description                                                                                         |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- |
+| `InstructionWithByteDelta`   | Extends `Instruction` with a `byteDelta` tracking net storage size changes.                         |
+| `SelfFetchFunctions<TData>`  | Wraps a `Decoder<TData>` and `Rpc` with `fetch`, `fetchMaybe`, `fetchAll`, `fetchAllMaybe` methods. |
+| `ResolvedInstructionAccount` | A resolved account input with `isWritable` and `value` (Address, PDA, signer, or null).             |
+
+### Functions
+
+| Function                                                                 | Description                                                                     |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| `addSelfFetchFunctions<T>(rpc, decoder)`                                 | Wraps a decoder in a `SelfFetchFunctions<T>` for fluent fetch-and-decode.       |
+| `getAddressFromResolvedInstructionAccount(inputName, value)`             | Extracts an `Address` from an Address, PDA, or transaction signer.              |
+| `getResolvedInstructionAccountAsProgramDerivedAddress(inputName, value)` | Validates and returns a `ProgramDerivedAddress` from a resolved account.        |
+| `getResolvedInstructionAccountAsTransactionSigner(inputName, value)`     | Validates and returns a transaction signer from a resolved account.             |
+| `getNonNullResolvedInstructionInput<T>(inputName, value)`                | Validates that a resolved input is non-null.                                    |
+| `getAccountMetaFactory(programAddress, strategy)`                        | Creates a function that converts `ResolvedInstructionAccount` to `AccountMeta`. |
+
+### Enums
+
+| Enum                                | Description                                                                          |
+| ----------------------------------- | ------------------------------------------------------------------------------------ |
+| `OptionalAccountStrategy.omitted`   | Optional null accounts are excluded from the instruction.                            |
+| `OptionalAccountStrategy.programId` | Optional null accounts are replaced with the program address as a read-only account. |

--- a/packages/solana_kit_programs/readme.md
+++ b/packages/solana_kit_programs/readme.md
@@ -1,0 +1,157 @@
+# solana_kit_programs
+
+Program error identification utilities for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/programs`](https://github.com/anza-xyz/kit/tree/main/packages/programs) from the Solana TypeScript SDK.
+
+## Installation
+
+Add `solana_kit_programs` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_programs:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Identifying program errors
+
+The `isProgramError` function determines whether an error is a custom program error from a specific program address. Since the Solana RPC only reports the index of the failed instruction, you must provide the transaction message so the function can look up which program was invoked.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_programs/solana_kit_programs.dart';
+
+void main() {
+  const myProgramAddress = Address(
+    'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+  );
+
+  // Build a transaction message input with instruction mappings.
+  final transactionMessage = TransactionMessageInput(
+    instructions: {
+      0: InstructionInput(programAddress: myProgramAddress),
+      1: InstructionInput(
+        programAddress: const Address('11111111111111111111111111111111'),
+      ),
+    },
+  );
+
+  // Simulate an instruction error from the RPC.
+  final error = SolanaError(
+    SolanaErrorCode.instructionErrorCustom,
+    {'index': 0, 'code': 42},
+  );
+
+  // Check if this is any custom error from our program.
+  print(isProgramError(error, transactionMessage, myProgramAddress));
+  // true
+
+  // Check if this is a specific custom error code from our program.
+  print(isProgramError(error, transactionMessage, myProgramAddress, 42));
+  // true
+
+  // Wrong error code.
+  print(isProgramError(error, transactionMessage, myProgramAddress, 99));
+  // false
+
+  // Wrong program.
+  const otherProgram = Address('11111111111111111111111111111111');
+  print(isProgramError(error, transactionMessage, otherProgram));
+  // false
+}
+```
+
+### Catching program errors in transactions
+
+A typical usage pattern is to catch errors after sending a transaction and determine which program raised the error.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_programs/solana_kit_programs.dart';
+
+void main() async {
+  const myProgramAddress = Address(
+    'MyProgram11111111111111111111111111111111111',
+  );
+
+  final transactionMessage = TransactionMessageInput(
+    instructions: {
+      0: InstructionInput(programAddress: myProgramAddress),
+    },
+  );
+
+  try {
+    // Send and confirm your transaction...
+    // await sendAndConfirmTransaction(signedTransaction);
+  } catch (error) {
+    if (isProgramError(error, transactionMessage, myProgramAddress, 6000)) {
+      print('Insufficient funds error from my program');
+    } else if (isProgramError(error, transactionMessage, myProgramAddress)) {
+      print('Some other custom error from my program');
+    } else {
+      rethrow;
+    }
+  }
+}
+```
+
+### Non-SolanaError values
+
+The function safely returns `false` for non-SolanaError values or errors that are not custom program errors.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_programs/solana_kit_programs.dart';
+
+void main() {
+  const programAddress = Address('11111111111111111111111111111111');
+  final transactionMessage = TransactionMessageInput(
+    instructions: {
+      0: InstructionInput(programAddress: programAddress),
+    },
+  );
+
+  // Not a SolanaError at all.
+  print(isProgramError('not an error', transactionMessage, programAddress));
+  // false
+
+  // A SolanaError but not a custom instruction error.
+  final nonInstructionError = SolanaError(SolanaErrorCode.blockHeightExceeded);
+  print(isProgramError(
+    nonInstructionError,
+    transactionMessage,
+    programAddress,
+  ));
+  // false
+
+  // Null values.
+  print(isProgramError(null, transactionMessage, programAddress));
+  // false
+}
+```
+
+## API Reference
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `isProgramError(Object? error, TransactionMessageInput message, Address programAddress, [int? code])` | Returns `true` if the error is a custom program error from the given program, optionally matching a specific error code. |
+
+### Classes
+
+| Class | Description |
+|-------|-------------|
+| `TransactionMessageInput` | A minimal transaction message representation with a `Map<int, InstructionInput> instructions` map indexed by instruction position. |
+| `InstructionInput` | A minimal instruction representation containing only a `programAddress`. |

--- a/packages/solana_kit_rpc/readme.md
+++ b/packages/solana_kit_rpc/readme.md
@@ -1,0 +1,177 @@
+# solana_kit_rpc
+
+Primary RPC client for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc`](https://github.com/anza-xyz/kit/tree/main/packages/rpc) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+### Creating an RPC client
+
+The simplest way to create an RPC client is with `createSolanaRpc`, which sets up a fully configured client with sensible defaults -- including request coalescing, BigInt handling, and a `solana-client` header.
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
+
+// Make an RPC call.
+final slot = await rpc.request('getSlot').send();
+print('Current slot: $slot');
+
+// Query an account balance.
+final balance = await rpc.request('getBalance', [
+  '83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK',
+]).send();
+print('Balance: $balance');
+```
+
+You can pass custom headers and an `http.Client` instance:
+
+```dart
+import 'package:http/http.dart' as http;
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+
+final rpc = createSolanaRpc(
+  url: 'https://api.devnet.solana.com',
+  headers: {'x-api-key': 'my-api-key'},
+  client: http.Client(),
+);
+```
+
+### Creating an RPC client from a custom transport
+
+When you need full control over how requests are sent (for example, during testing or with a custom HTTP stack), use `createSolanaRpcFromTransport`:
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+// A mock transport for testing.
+RpcTransport myMockTransport = (RpcTransportConfig config) async {
+  return {
+    'jsonrpc': '2.0',
+    'result': BigInt.from(42),
+    'id': '0',
+  };
+};
+
+final rpc = createSolanaRpcFromTransport(myMockTransport);
+final slot = await rpc.request('getSlot').send();
+print(slot); // 42
+```
+
+### Default RPC transport
+
+The `createDefaultRpcTransport` function creates a transport with the standard Solana RPC behaviours applied:
+
+- An automatically-set `solana-client` request header containing the SDK version (cannot be overridden).
+- Request coalescing that deduplicates identical calls made within the same microtask.
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+final transport = createDefaultRpcTransport(
+  url: 'https://api.mainnet-beta.solana.com',
+);
+
+// Use the transport directly.
+final response = await transport(
+  RpcTransportConfig(
+    payload: {
+      'id': '0',
+      'jsonrpc': '2.0',
+      'method': 'getSlot',
+      'params': [],
+    },
+  ),
+);
+```
+
+### Request coalescing
+
+When multiple identical requests (same method and params) are made within the same microtask, they are coalesced into a single network request. All callers receive the same response.
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
+
+// These two calls happen in the same microtask, so only one
+// network request is sent. Both futures resolve with the same result.
+final future1 = rpc.request('getSlot').send();
+final future2 = rpc.request('getSlot').send();
+
+final results = await Future.wait([future1, future2]);
+print(results[0] == results[1]); // true
+```
+
+The coalescing key is computed by `getSolanaRpcPayloadDeduplicationKey`, which produces a stable, deterministic key from the method name and params (ignoring `id` and key ordering).
+
+### Integer overflow error
+
+When a `BigInt` value in request parameters exceeds the safe JavaScript integer range, the default configuration throws a `SolanaError`. You can access this factory directly:
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+
+try {
+  throw createSolanaJsonRpcIntegerOverflowError(
+    'getBalance',
+    [0, 'lamports'],
+    BigInt.parse('9007199254740992'), // Number.MAX_SAFE_INTEGER + 1
+  );
+} on Exception catch (e) {
+  print(e);
+  // SolanaError describing the overflow in the 1st argument at path `lamports`
+}
+```
+
+### Using the default configuration
+
+The `defaultRpcConfig` provides the standard `SolanaRpcApiConfig` used by `createSolanaRpc`. It sets the default commitment to `confirmed` and configures an integer overflow handler that throws.
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+// Build a custom RPC using the default config with your own transport.
+final myCustomRpc = createRpc(
+  RpcConfig(
+    api: createSolanaRpcApiAdapter(defaultRpcConfig),
+    transport: myCustomTransport,
+  ),
+);
+```
+
+## API Reference
+
+### Functions
+
+- **`createSolanaRpc({required String url, Map<String, String>? headers, http.Client? client})`** -- Creates an `Rpc` instance with the standard Solana JSON RPC API given a cluster URL and optional transport configuration.
+- **`createSolanaRpcFromTransport(RpcTransport transport)`** -- Creates an `Rpc` instance from a custom `RpcTransport`, applying the standard Solana RPC API and default transformers.
+- **`createDefaultRpcTransport({required String url, Map<String, String>? headers, http.Client? client})`** -- Creates the default `RpcTransport` with request coalescing and a `solana-client` header.
+- **`getRpcTransportWithRequestCoalescing(RpcTransport transport, GetDeduplicationKeyFn getDeduplicationKey)`** -- Wraps a transport with request coalescing logic that deduplicates identical in-flight requests within the same microtask.
+- **`getSolanaRpcPayloadDeduplicationKey(Object? payload)`** -- Returns a stable deduplication key for a JSON-RPC 2.0 payload, or `null` if the payload is not valid.
+- **`createSolanaJsonRpcIntegerOverflowError(String methodName, KeyPath keyPath, BigInt value)`** -- Creates a `SolanaError` describing an integer overflow in an RPC request.
+
+### Constants
+
+- **`defaultRpcConfig`** -- The default `SolanaRpcApiConfig` used by `createSolanaRpc`, with `Commitment.confirmed` and an integer overflow handler.
+
+### Typedefs
+
+- **`GetDeduplicationKeyFn`** -- `String? Function(Object? payload)` -- Produces a deduplication key for coalescing, or `null` to skip.

--- a/packages/solana_kit_rpc_api/readme.md
+++ b/packages/solana_kit_rpc_api/readme.md
@@ -1,0 +1,212 @@
+# solana_kit_rpc_api
+
+RPC method type definitions and API composition for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc-api`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-api) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_api:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+### Creating a Solana RPC API
+
+The `createSolanaRpcApi` function creates a `JsonRpcApi` that converts method calls into `RpcPlan` instances with the standard Solana transformers applied (BigInt downcast, integer overflow checking, default commitment).
+
+```dart
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// Create with defaults.
+final api = createSolanaRpcApi();
+
+// Create with custom configuration.
+final customApi = createSolanaRpcApi(SolanaRpcApiConfig(
+  defaultCommitment: Commitment.finalized,
+  onIntegerOverflow: (request, keyPath, value) {
+    print('Integer overflow in ${request.methodName}: $value');
+  },
+));
+```
+
+### Using with createRpc
+
+To build a full RPC client, wrap the API in an adapter and combine it with a transport:
+
+```dart
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+final rpc = createRpc(
+  RpcConfig(
+    api: createSolanaRpcApiAdapter(SolanaRpcApiConfig(
+      defaultCommitment: Commitment.confirmed,
+    )),
+    transport: myTransport,
+  ),
+);
+
+// Now call any Solana RPC method.
+final balance = await rpc.request('getBalance', [
+  '83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK',
+]).send();
+```
+
+### Method parameter builders
+
+Each RPC method has a corresponding config class and a params builder function. These construct the JSON-RPC parameter lists.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// getBalance parameters.
+final addr = address('83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK');
+final balanceParams = getBalanceParams(addr, GetBalanceConfig(
+  commitment: Commitment.finalized,
+));
+// ['83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK', {'commitment': 'finalized'}]
+
+// getAccountInfo parameters.
+final accountParams = getAccountInfoParams(addr, GetAccountInfoConfig(
+  encoding: 'base64',
+  commitment: Commitment.confirmed,
+));
+```
+
+### Checking method availability by cluster
+
+Not all RPC methods are available on all clusters. For example, `requestAirdrop` is only available on test clusters (devnet, testnet).
+
+```dart
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+
+// Check if a method is available on all clusters (including mainnet).
+print(isSolanaRpcMethodForAllClusters('getBalance')); // true
+print(isSolanaRpcMethodForAllClusters('requestAirdrop')); // false
+
+// Check if a method is available on test clusters.
+print(isSolanaRpcMethodForTestClusters('requestAirdrop')); // true
+
+// Mainnet check (excludes requestAirdrop).
+print(isSolanaRpcMethodForMainnet('getBalance')); // true
+print(isSolanaRpcMethodForMainnet('requestAirdrop')); // false
+```
+
+### Allowed numeric key paths
+
+The `getAllowedNumericKeypaths` function returns a mapping that tells the response transformer which values in RPC responses should remain as `int` rather than being upcast to `BigInt`. This is used internally by the default response transformer.
+
+```dart
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+
+final keypaths = getAllowedNumericKeypaths();
+// Contains mappings like:
+// 'getAccountInfo' -> [[..., 'decimals'], [..., 'uiAmount'], ...]
+// 'getBlock' -> [[..., 'programIdIndex'], [..., 'stackHeight'], ...]
+```
+
+## API Reference
+
+### Classes
+
+- **`SolanaRpcApiConfig`** -- Configuration for creating a Solana RPC API. Fields:
+  - `defaultCommitment` (`Commitment?`) -- Default commitment level.
+  - `onIntegerOverflow` (`IntegerOverflowHandler?`) -- Callback for BigInt overflow detection.
+- **`GetAccountInfoConfig`** -- Parameters for `getAccountInfo` (commitment, encoding, dataSlice, minContextSlot).
+- **`GetBalanceConfig`** -- Parameters for `getBalance` (commitment, minContextSlot).
+- **`GetBlockConfig`** -- Parameters for `getBlock`.
+- **`GetBlockHeightConfig`** -- Parameters for `getBlockHeight`.
+- **`GetLatestBlockhashConfig`** -- Parameters for `getLatestBlockhash`.
+- **`GetProgramAccountsConfig`** -- Parameters for `getProgramAccounts`.
+- **`GetSignatureStatusesConfig`** -- Parameters for `getSignatureStatuses`.
+- **`GetSlotConfig`** -- Parameters for `getSlot`.
+- **`GetTokenAccountsByOwnerConfig`** -- Parameters for `getTokenAccountsByOwner`.
+- **`GetTransactionConfig`** -- Parameters for `getTransaction`.
+- **`SendTransactionConfig`** -- Parameters for `sendTransaction`.
+- **`SimulateTransactionConfig`** -- Parameters for `simulateTransaction`.
+
+### Functions
+
+- **`createSolanaRpcApi([SolanaRpcApiConfig? config])`** -- Creates a `JsonRpcApi` with the standard Solana RPC transformers applied.
+- **`createSolanaRpcApiAdapter([SolanaRpcApiConfig? config])`** -- Creates an `RpcApi` adapter wrapping a Solana RPC API, for use with `createRpc`.
+- **`isSolanaRpcMethodForAllClusters(String methodName)`** -- Returns `true` if the method is available on all clusters.
+- **`isSolanaRpcMethodForTestClusters(String methodName)`** -- Returns `true` if the method is available on test clusters (includes `requestAirdrop`).
+- **`isSolanaRpcMethodForMainnet(String methodName)`** -- Returns `true` if the method is available on mainnet.
+- **`getAllowedNumericKeypaths()`** -- Returns the `AllowedNumericKeypaths` mapping for Solana RPC responses.
+- **`getBalanceParams(Address, [GetBalanceConfig?])`** -- Builds JSON-RPC params for `getBalance`.
+- **`getAccountInfoParams(Address, [GetAccountInfoConfig?])`** -- Builds JSON-RPC params for `getAccountInfo`.
+
+### Constants
+
+- **`solanaRpcMethodsForAllClusters`** -- `List<String>` of 51 RPC method names available on all clusters.
+- **`solanaRpcMethodsForTestClusters`** -- `List<String>` of 52 RPC method names available on test clusters (includes `requestAirdrop`).
+
+### Supported RPC Methods
+
+The package defines parameter types and builders for all 52 Solana JSON-RPC methods:
+
+| Method | Description |
+|--------|-------------|
+| `getAccountInfo` | Returns account information for a given address |
+| `getBalance` | Returns the balance in lamports for a given address |
+| `getBlock` | Returns identity and transaction information about a confirmed block |
+| `getBlockCommitment` | Returns commitment for a particular block |
+| `getBlockHeight` | Returns the current block height |
+| `getBlockProduction` | Returns recent block production information |
+| `getBlocks` | Returns a list of confirmed blocks between two slots |
+| `getBlocksWithLimit` | Returns a list of confirmed blocks starting at a given slot |
+| `getBlockTime` | Returns the estimated production time of a block |
+| `getClusterNodes` | Returns information about all nodes in the cluster |
+| `getEpochInfo` | Returns information about the current epoch |
+| `getEpochSchedule` | Returns epoch schedule information |
+| `getFeeForMessage` | Returns the fee for a given message |
+| `getFirstAvailableBlock` | Returns the slot of the lowest confirmed block |
+| `getGenesisHash` | Returns the genesis hash |
+| `getHealth` | Returns the current health of the node |
+| `getHighestSnapshotSlot` | Returns the highest slot with a snapshot |
+| `getIdentity` | Returns the identity pubkey of the current node |
+| `getInflationGovernor` | Returns the current inflation governor |
+| `getInflationRate` | Returns the current inflation rate |
+| `getInflationReward` | Returns the inflation reward for addresses |
+| `getLargestAccounts` | Returns the 20 largest accounts by lamport balance |
+| `getLatestBlockhash` | Returns the latest blockhash |
+| `getLeaderSchedule` | Returns the leader schedule |
+| `getMaxRetransmitSlot` | Returns the max slot seen from retransmit stage |
+| `getMaxShredInsertSlot` | Returns the max slot seen from shred insert stage |
+| `getMinimumBalanceForRentExemption` | Returns minimum balance for rent exemption |
+| `getMultipleAccounts` | Returns account information for a list of addresses |
+| `getProgramAccounts` | Returns all accounts owned by a program |
+| `getRecentPerformanceSamples` | Returns recent performance samples |
+| `getRecentPrioritizationFees` | Returns recent prioritization fees |
+| `getSignatureStatuses` | Returns the statuses of a list of signatures |
+| `getSignaturesForAddress` | Returns signatures for confirmed transactions involving an address |
+| `getSlot` | Returns the current slot |
+| `getSlotLeader` | Returns the current slot leader |
+| `getSlotLeaders` | Returns the slot leaders for a given slot range |
+| `getStakeMinimumDelegation` | Returns the stake minimum delegation |
+| `getSupply` | Returns information about the current supply |
+| `getTokenAccountBalance` | Returns the token balance of an SPL Token account |
+| `getTokenAccountsByDelegate` | Returns all SPL Token accounts by approved delegate |
+| `getTokenAccountsByOwner` | Returns all SPL Token accounts by token owner |
+| `getTokenLargestAccounts` | Returns the 20 largest token accounts |
+| `getTokenSupply` | Returns the total supply of an SPL Token type |
+| `getTransaction` | Returns transaction details for a confirmed signature |
+| `getTransactionCount` | Returns the current transaction count |
+| `getVersion` | Returns the current Solana version |
+| `getVoteAccounts` | Returns the account info and associated stake for all vote accounts |
+| `isBlockhashValid` | Returns whether a blockhash is still valid |
+| `minimumLedgerSlot` | Returns the lowest slot that the node has information about |
+| `requestAirdrop` | Requests an airdrop of lamports (test clusters only) |
+| `sendTransaction` | Submits a signed transaction |
+| `simulateTransaction` | Simulates sending a transaction |

--- a/packages/solana_kit_rpc_parsed_types/readme.md
+++ b/packages/solana_kit_rpc_parsed_types/readme.md
@@ -1,0 +1,279 @@
+# solana_kit_rpc_parsed_types
+
+Parsed account data types for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc-parsed-types`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-parsed-types) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_parsed_types:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+This package provides type definitions for the parsed account data returned by the Solana RPC when accounts are requested with `jsonParsed` encoding. It covers all native Solana programs.
+
+### Base types
+
+The `RpcParsedType` and `RpcParsedInfo` classes serve as the foundation for all parsed account data.
+
+```dart
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+
+// RpcParsedType carries both a type discriminator and an info payload.
+// Used for programs with multiple account variants (e.g. Token, Stake).
+// RpcParsedType<TType, TInfo>
+
+// RpcParsedInfo carries only an info payload.
+// Used for programs with a single account type (e.g. Nonce, Vote).
+// RpcParsedInfo<TInfo>
+```
+
+### Token program accounts
+
+The `JsonParsedTokenProgramAccount` sealed class represents parsed data from the Token and Token-2022 programs. It has three variants: token accounts, mint accounts, and multisig accounts.
+
+```dart
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// Token account variant.
+final tokenAccount = JsonParsedTokenAccountVariant(
+  info: JsonParsedTokenAccount(
+    isNative: false,
+    mint: Address('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+    owner: Address('83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'),
+    state: TokenAccountState.initialized,
+    tokenAmount: TokenAmount(
+      amount: StringifiedBigInt('1000000'),
+      decimals: 6,
+      uiAmountString: StringifiedNumber('1'),
+    ),
+  ),
+);
+
+print(tokenAccount.type); // 'account'
+print(tokenAccount.info.mint); // EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+print(tokenAccount.info.tokenAmount.amount); // '1000000'
+
+// Mint account variant.
+final mintAccount = JsonParsedMintAccount(
+  info: JsonParsedMintInfo(
+    decimals: 6,
+    isInitialized: true,
+    supply: StringifiedBigInt('1000000000000'),
+    mintAuthority: Address('83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'),
+  ),
+);
+
+print(mintAccount.type); // 'mint'
+print(mintAccount.info.supply); // '1000000000000'
+print(mintAccount.info.decimals); // 6
+
+// Multisig account variant.
+final multisigAccount = JsonParsedMultisigAccount(
+  info: JsonParsedMultisigInfo(
+    isInitialized: true,
+    numRequiredSigners: 2,
+    numValidSigners: 3,
+    signers: [
+      Address('83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'),
+      Address('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+      Address('11111111111111111111111111111111'),
+    ],
+  ),
+);
+
+// Pattern matching on token program account variants.
+void handleTokenProgramAccount(JsonParsedTokenProgramAccount account) {
+  switch (account) {
+    case JsonParsedTokenAccountVariant(:final info):
+      print('Token account for mint: ${info.mint}');
+    case JsonParsedMintAccount(:final info):
+      print('Mint with supply: ${info.supply}');
+    case JsonParsedMultisigAccount(:final info):
+      print('Multisig with ${info.numRequiredSigners}/${info.numValidSigners} signers');
+  }
+}
+```
+
+### Stake program accounts
+
+The `JsonParsedStakeProgramAccount` sealed class covers delegated and initialized stake accounts.
+
+```dart
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+final delegatedStake = JsonParsedDelegatedStake(
+  info: JsonParsedStakeAccountInfo(
+    meta: JsonParsedStakeMeta(
+      authorized: JsonParsedStakeAuthorized(
+        staker: Address('83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'),
+        withdrawer: Address('83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'),
+      ),
+      lockup: JsonParsedStakeLockup(
+        custodian: Address('11111111111111111111111111111111'),
+        epoch: BigInt.zero,
+        unixTimestamp: UnixTimestamp(BigInt.zero),
+      ),
+      rentExemptReserve: StringifiedBigInt('2282880'),
+    ),
+    stake: JsonParsedStakeData(
+      creditsObserved: BigInt.from(100000),
+      delegation: JsonParsedStakeDelegation(
+        activationEpoch: StringifiedBigInt('580'),
+        deactivationEpoch: StringifiedBigInt('18446744073709551615'),
+        stake: StringifiedBigInt('1000000000'),
+        voter: Address('Vote111111111111111111111111111111111111111'),
+        warmupCooldownRate: 0.25,
+      ),
+    ),
+  ),
+);
+
+print(delegatedStake.type); // 'delegated'
+print(delegatedStake.info.stake?.delegation.stake); // '1000000000'
+
+// Pattern matching.
+void handleStakeAccount(JsonParsedStakeProgramAccount account) {
+  switch (account) {
+    case JsonParsedDelegatedStake(:final info):
+      print('Delegated to: ${info.stake?.delegation.voter}');
+    case JsonParsedInitializedStake(:final info):
+      print('Initialized, staker: ${info.meta.authorized.staker}');
+  }
+}
+```
+
+### Nonce accounts
+
+```dart
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+final nonceAccount = JsonParsedNonceAccount(
+  info: JsonParsedNonceInfo(
+    authority: Address('83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'),
+    blockhash: Blockhash('4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY'),
+    feeCalculator: JsonParsedNonceFeeCalculator(
+      lamportsPerSignature: StringifiedBigInt('5000'),
+    ),
+  ),
+);
+
+print(nonceAccount.info.authority); // 83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK
+print(nonceAccount.info.blockhash); // 4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY
+```
+
+### Vote accounts
+
+```dart
+import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+final voteInfo = JsonParsedVoteInfo(
+  authorizedVoters: [
+    JsonParsedAuthorizedVoter(
+      authorizedVoter: Address('Vote111111111111111111111111111111111111111'),
+      epoch: BigInt.from(580),
+    ),
+  ],
+  authorizedWithdrawer: Address('83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'),
+  commission: 10,
+  epochCredits: [
+    JsonParsedEpochCredit(
+      credits: StringifiedBigInt('100000'),
+      epoch: BigInt.from(580),
+      previousCredits: StringifiedBigInt('90000'),
+    ),
+  ],
+  lastTimestamp: JsonParsedLastTimestamp(
+    slot: BigInt.from(250000000),
+    timestamp: UnixTimestamp(BigInt.from(1700000000)),
+  ),
+  nodePubkey: Address('Node1111111111111111111111111111111111111111'),
+  priorVoters: [],
+  votes: [
+    JsonParsedVote(
+      confirmationCount: 31,
+      slot: BigInt.from(250000000),
+    ),
+  ],
+);
+
+print(voteInfo.commission); // 10
+print(voteInfo.votes.first.confirmationCount); // 31
+```
+
+## API Reference
+
+### Base Classes
+
+- **`RpcParsedType<TType, TInfo>`** -- A parsed account type with a `type` discriminator and `info` payload.
+- **`RpcParsedInfo<TInfo>`** -- A parsed account type with only an `info` payload (no type discriminator).
+
+### Token Program
+
+- **`JsonParsedTokenProgramAccount`** -- Sealed class for token program accounts.
+- **`JsonParsedTokenAccountVariant`** -- Token account variant (type: `'account'`).
+- **`JsonParsedTokenAccount`** -- Token account info (mint, owner, state, tokenAmount, isNative, delegate, delegatedAmount, closeAuthority, extensions, rentExemptReserve).
+- **`JsonParsedMintAccount`** -- Mint account variant (type: `'mint'`).
+- **`JsonParsedMintInfo`** -- Mint info (decimals, isInitialized, supply, mintAuthority, freezeAuthority, extensions).
+- **`JsonParsedMultisigAccount`** -- Multisig account variant (type: `'multisig'`).
+- **`JsonParsedMultisigInfo`** -- Multisig info (isInitialized, numRequiredSigners, numValidSigners, signers).
+- **`TokenAccountState`** -- Enum: `frozen`, `initialized`, `uninitialized`.
+
+### Stake Program
+
+- **`JsonParsedStakeProgramAccount`** -- Sealed class for stake program accounts.
+- **`JsonParsedDelegatedStake`** -- Delegated stake variant (type: `'delegated'`).
+- **`JsonParsedInitializedStake`** -- Initialized stake variant (type: `'initialized'`).
+- **`JsonParsedStakeAccountInfo`** -- Stake account info (meta, stake).
+- **`JsonParsedStakeMeta`** -- Stake metadata (authorized, lockup, rentExemptReserve).
+- **`JsonParsedStakeAuthorized`** -- Authorized staker and withdrawer addresses.
+- **`JsonParsedStakeLockup`** -- Lockup configuration (custodian, epoch, unixTimestamp).
+- **`JsonParsedStakeData`** -- Stake delegation data (creditsObserved, delegation).
+- **`JsonParsedStakeDelegation`** -- Delegation details (activationEpoch, deactivationEpoch, stake, voter, warmupCooldownRate).
+
+### Vote Program
+
+- **`JsonParsedVoteAccount`** -- Type alias for `RpcParsedInfo<JsonParsedVoteInfo>`.
+- **`JsonParsedVoteInfo`** -- Vote account info (authorizedVoters, authorizedWithdrawer, commission, epochCredits, lastTimestamp, nodePubkey, priorVoters, rootSlot, votes).
+- **`JsonParsedAuthorizedVoter`** -- Authorized voter entry (authorizedVoter, epoch).
+- **`JsonParsedEpochCredit`** -- Epoch credit entry (credits, epoch, previousCredits).
+- **`JsonParsedLastTimestamp`** -- Last timestamp (slot, timestamp).
+- **`JsonParsedPriorVoter`** -- Prior voter entry (authorizedPubkey, epochOfLastAuthorizedSwitch, targetEpoch).
+- **`JsonParsedVote`** -- Vote entry (confirmationCount, slot).
+
+### Nonce Program
+
+- **`JsonParsedNonceAccount`** -- Type alias for `RpcParsedInfo<JsonParsedNonceInfo>`.
+- **`JsonParsedNonceInfo`** -- Nonce account info (authority, blockhash, feeCalculator).
+- **`JsonParsedNonceFeeCalculator`** -- Fee calculator (lamportsPerSignature).
+
+### Address Lookup Table
+
+- **`JsonParsedAddressLookupTableAccount`** -- Parsed address lookup table account data.
+
+### BPF Upgradeable Loader
+
+- **`JsonParsedBpfUpgradeableLoaderProgramAccount`** -- Sealed class for BPF loader account variants (program, programData, buffer, uninitialized).
+
+### Config Program
+
+- **`JsonParsedConfigProgramAccount`** -- Parsed config account data.
+
+### Sysvar Program
+
+- **`JsonParsedSysvarAccount`** -- Parsed sysvar account data (clock, rent, stakeHistory, etc.).

--- a/packages/solana_kit_rpc_spec/readme.md
+++ b/packages/solana_kit_rpc_spec/readme.md
@@ -1,0 +1,210 @@
+# solana_kit_rpc_spec
+
+RPC specification implementation for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc-spec`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-spec) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_spec:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+### Creating an RPC client
+
+The `Rpc` class is the main RPC client. It wraps an `RpcApi` (which defines how method calls become `RpcPlan` instances) and an `RpcTransport` (which handles the actual network communication). Use `createRpc` to construct one.
+
+```dart
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+final rpc = createRpc(
+  RpcConfig(
+    api: JsonRpcApiAdapter(createJsonRpcApi()),
+    transport: myTransport,
+  ),
+);
+
+// Call an RPC method. This returns a PendingRpcRequest.
+final pending = rpc.request('getSlot');
+
+// Send the request and await the response.
+final slot = await pending.send();
+print('Current slot: $slot');
+```
+
+### PendingRpcRequest
+
+Calling `rpc.request(methodName, params)` returns a `PendingRpcRequest` that encapsulates all the information needed to make the request without actually making it. The request is only triggered when you call `.send()`.
+
+```dart
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+final rpc = createRpc(RpcConfig(api: myApi, transport: myTransport));
+
+// Build the request without sending it.
+final pending = rpc.request('getBalance', ['address123']);
+
+// Send with optional abort signal.
+final result = await pending.send(RpcSendOptions(
+  abortSignal: Future.delayed(Duration(seconds: 10)),
+));
+```
+
+### RpcTransport
+
+An `RpcTransport` is a function that takes a `RpcTransportConfig` and returns a `Future<Object?>`. It is responsible for sending the request payload to the server and returning the raw response.
+
+```dart
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+// A simple mock transport.
+RpcTransport mockTransport = (RpcTransportConfig config) async {
+  final payload = config.payload as Map<String, Object?>;
+  final method = payload['method'] as String;
+
+  if (method == 'getSlot') {
+    return {
+      'jsonrpc': '2.0',
+      'result': BigInt.from(12345),
+      'id': payload['id'],
+    };
+  }
+
+  return {
+    'jsonrpc': '2.0',
+    'error': {'code': -32601, 'message': 'Method not found'},
+    'id': payload['id'],
+  };
+};
+```
+
+### Checking JSON-RPC payloads
+
+The `isJsonRpcPayload` function checks whether a value is a valid JSON-RPC 2.0 payload (has `jsonrpc: '2.0'`, a `method` string, and `params`).
+
+```dart
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+final validPayload = {
+  'jsonrpc': '2.0',
+  'method': 'getSlot',
+  'params': [],
+  'id': '1',
+};
+
+print(isJsonRpcPayload(validPayload)); // true
+print(isJsonRpcPayload({'not': 'valid'})); // false
+print(isJsonRpcPayload(null)); // false
+```
+
+### JsonRpcApi
+
+The `JsonRpcApi` class converts method calls into `RpcPlan` instances that create JSON-RPC 2.0 payloads. It supports optional request and response transformers.
+
+```dart
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+// Create with custom transformers.
+final api = createJsonRpcApi(
+  config: RpcApiConfig(
+    requestTransformer: (request) {
+      // Log every request.
+      print('Calling ${request.methodName} with ${request.params}');
+      return request;
+    },
+    responseTransformer: (response, request) {
+      // Extract the result from a JSON-RPC response.
+      if (response is Map<String, Object?>) {
+        return response['result'];
+      }
+      return response;
+    },
+  ),
+);
+
+// Call a method. Returns an RpcPlan.
+final plan = api.call('getSlot', []);
+```
+
+### RpcApi implementations
+
+There are multiple ways to create an `RpcApi`:
+
+```dart
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+
+// 1. JsonRpcApiAdapter: wraps a JsonRpcApi for dynamic method dispatch.
+final dynamicApi = JsonRpcApiAdapter(createJsonRpcApi());
+
+// 2. MapRpcApi: define handlers for specific methods.
+final mapApi = MapRpcApi({
+  'getSlot': (params) => RpcPlan(
+    execute: (config) async {
+      final response = await config.transport(
+        RpcTransportConfig(payload: {
+          'jsonrpc': '2.0',
+          'method': 'getSlot',
+          'params': params,
+          'id': '1',
+        }),
+      );
+      return response;
+    },
+  ),
+});
+
+// Use either with createRpc.
+final rpc = createRpc(RpcConfig(api: dynamicApi, transport: myTransport));
+```
+
+### Creating JSON-RPC messages
+
+The `createRpcMessage` function (from `solana_kit_rpc_spec_types`) generates a spec-compliant JSON-RPC 2.0 message with an auto-incrementing ID.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+final message = createRpcMessage(RpcRequest(
+  methodName: 'getBalance',
+  params: ['address123'],
+));
+
+print(message);
+// {id: '0', jsonrpc: '2.0', method: 'getBalance', params: ['address123']}
+```
+
+## API Reference
+
+### Classes
+
+- **`Rpc`** -- The main RPC client. Wraps an `RpcApi` and `RpcTransport` to create `PendingRpcRequest` instances. Call `request(methodName, [params])` to build a request and `.send()` to execute it.
+- **`RpcConfig`** -- Configuration for `createRpc`: `api` (`RpcApi`) and `transport` (`RpcTransport`).
+- **`PendingRpcRequest<T>`** -- A lazy RPC request. Call `.send([RpcSendOptions])` to trigger the network request.
+- **`RpcSendOptions`** -- Options for sending a request, including an optional `abortSignal` (`Future<void>`).
+- **`RpcApi`** -- Abstract base class for RPC APIs. Override `getPlan(methodName, params)` to return `RpcPlan` instances.
+- **`JsonRpcApiAdapter`** -- An `RpcApi` backed by a `JsonRpcApi`.
+- **`MapRpcApi`** -- An `RpcApi` backed by a map of method-name-to-handler functions.
+- **`JsonRpcApi`** -- Converts method calls into `RpcPlan` instances with JSON-RPC 2.0 payloads.
+- **`RpcApiConfig`** -- Configuration for `JsonRpcApi`: optional `requestTransformer` and `responseTransformer`.
+- **`RpcPlan<T>`** -- Describes how a particular RPC request should be issued. Contains an `execute` function.
+- **`RpcPlanExecuteConfig`** -- Passed to `RpcPlan.execute`: `transport` and optional `signal`.
+- **`RpcTransportConfig`** -- Configuration for an `RpcTransport` call: `payload` and optional `signal`.
+
+### Functions
+
+- **`createRpc(RpcConfig config)`** -- Creates an `Rpc` instance from the given configuration.
+- **`createJsonRpcApi({RpcApiConfig? config})`** -- Creates a `JsonRpcApi` with optional transformers.
+- **`isJsonRpcPayload(Object? payload)`** -- Returns `true` if the payload is a valid JSON-RPC 2.0 message.
+
+### Typedefs
+
+- **`RpcTransport`** -- `Future<Object?> Function(RpcTransportConfig config)` -- A function that sends an RPC request.
+- **`RpcApiMethod`** -- `RpcPlan<Object?> Function(String methodName, List<Object?> params)` -- A function that creates plans from method calls.

--- a/packages/solana_kit_rpc_spec_types/readme.md
+++ b/packages/solana_kit_rpc_spec_types/readme.md
@@ -1,0 +1,172 @@
+# solana_kit_rpc_spec_types
+
+RPC spec type definitions for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc-spec-types`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-spec-types) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_spec_types:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+### RpcRequest
+
+The `RpcRequest` class describes an RPC request with a method name and parameters.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+final request = RpcRequest<List<Object?>>(
+  methodName: 'getBalance',
+  params: ['83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'],
+);
+
+print(request.methodName); // 'getBalance'
+print(request.params); // ['83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK']
+```
+
+### Request transformers
+
+An `RpcRequestTransformer` is a function that transforms an `RpcRequest` before it is sent. This enables patterns like applying defaults, renaming methods, or serializing values.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+// A transformer that prefixes all method names.
+RpcRequestTransformer prefixTransformer = (request) {
+  return RpcRequest(
+    methodName: 'custom_${request.methodName}',
+    params: request.params,
+  );
+};
+
+final original = RpcRequest<Object?>(
+  methodName: 'getSlot',
+  params: [],
+);
+final transformed = prefixTransformer(original);
+print(transformed.methodName); // 'custom_getSlot'
+```
+
+### RPC response types
+
+The `RpcResponseData` sealed class represents the data in an RPC response, which is either a successful result or an error.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+// A successful response.
+const success = RpcResponseResult<int>(id: '1', result: 42);
+print(success.result); // 42
+
+// An error response.
+const error = RpcResponseError<int>(
+  id: '1',
+  error: RpcErrorResponsePayload(
+    code: -32601,
+    message: 'Method not found',
+  ),
+);
+print(error.error.code); // -32601
+print(error.error.message); // 'Method not found'
+
+// Pattern matching on sealed types.
+void handleResponse(RpcResponseData<int> data) {
+  switch (data) {
+    case RpcResponseResult<int>(:final result):
+      print('Got result: $result');
+    case RpcResponseError<int>(:final error):
+      print('Got error: ${error.message}');
+  }
+}
+```
+
+### Response transformers
+
+An `RpcResponseTransformer` transforms a raw response before returning it to the caller. It receives both the response and the original request for context.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+// A transformer that doubles numeric results.
+RpcResponseTransformer<Object?> doubleTransformer = (response, request) {
+  if (response is int) {
+    return response * 2;
+  }
+  return response;
+};
+```
+
+### Creating JSON-RPC messages
+
+The `createRpcMessage` function builds a spec-compliant JSON-RPC 2.0 message with an auto-incrementing string ID.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+final message = createRpcMessage(RpcRequest(
+  methodName: 'getSlot',
+  params: [],
+));
+print(message);
+// {id: '0', jsonrpc: '2.0', method: 'getSlot', params: []}
+
+// Each call gets a new ID.
+final message2 = createRpcMessage(RpcRequest(
+  methodName: 'getBalance',
+  params: ['address123'],
+));
+print(message2['id']); // '1'
+```
+
+### BigInt-aware JSON parsing
+
+The `parseJsonWithBigInts` and `stringifyJsonWithBigInts` functions handle the fact that Solana RPC responses can contain integers larger than what IEEE 754 doubles can represent. All non-floating-point numbers are parsed as `BigInt`.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+
+// Parse JSON with BigInt support.
+final parsed = parseJsonWithBigInts('{"balance": 9007199254740993, "rate": 1.5}');
+final map = parsed as Map<String, Object?>;
+print(map['balance'] is BigInt); // true
+print(map['balance']); // 9007199254740993 (as BigInt, no precision loss)
+print(map['rate'] is double); // true (floating-point preserved as double)
+
+// Stringify with BigInt support.
+final json = stringifyJsonWithBigInts({
+  'balance': BigInt.parse('9007199254740993'),
+  'rate': 1.5,
+});
+print(json); // {"balance":9007199254740993,"rate":1.5}
+// Note: BigInt values are rendered as raw integers, not quoted strings.
+```
+
+## API Reference
+
+### Classes
+
+- **`RpcRequest<TParams>`** -- Describes an RPC request with `methodName` (`String`) and `params` (`TParams`).
+- **`RpcResponseData<T>`** -- Sealed class representing an RPC response: either `RpcResponseResult<T>` or `RpcResponseError<T>`.
+- **`RpcResponseResult<T>`** -- A successful RPC response with `id` and `result`.
+- **`RpcResponseError<T>`** -- An error RPC response with `id` and `error`.
+- **`RpcErrorResponsePayload`** -- Error payload with `code` (`int`), `message` (`String`), and optional `data`.
+
+### Functions
+
+- **`createRpcMessage<TParams>(RpcRequest<TParams> request)`** -- Creates a JSON-RPC 2.0 message map with auto-incrementing ID.
+- **`parseJsonWithBigInts(String json)`** -- Parses JSON, converting all integer values to `BigInt` while preserving floating-point numbers as `double`.
+- **`stringifyJsonWithBigInts(Object? value)`** -- Converts a value to JSON, rendering `BigInt` values as unquoted large integers.
+
+### Typedefs
+
+- **`RpcRequestTransformer`** -- `RpcRequest<Object?> Function(RpcRequest<Object?> request)` -- Transforms an RPC request before sending.
+- **`RpcResponseTransformer<T>`** -- `T Function(Object? response, RpcRequest<Object?> request)` -- Transforms an RPC response before returning.

--- a/packages/solana_kit_rpc_subscriptions/readme.md
+++ b/packages/solana_kit_rpc_subscriptions/readme.md
@@ -1,0 +1,202 @@
+# solana_kit_rpc_subscriptions
+
+Subscription client for the Solana Kit Dart SDK -- the composition layer that ties together WebSocket channels, the subscriptions API, JSON serialization, and error handling.
+
+This is the Dart port of [`@solana/rpc-subscriptions`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-subscriptions) from the Solana TypeScript SDK.
+
+## Installation
+
+Add `solana_kit_rpc_subscriptions` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_subscriptions:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Creating a subscription client
+
+The primary entry point is `createSolanaRpcSubscriptions`, which composes a fully-featured subscription client with BigInt-safe JSON serialization, autopinging, channel pooling, and subscription coalescing.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+
+void main() async {
+  // Create a subscription client for devnet.
+  final subscriptions = createSolanaRpcSubscriptions(
+    'wss://api.devnet.solana.com',
+  );
+
+  // Subscribe to account notifications.
+  final controller = AbortController();
+  final pending = subscriptions.request('accountNotifications', [
+    '11111111111111111111111111111111',
+    {'encoding': 'base64', 'commitment': 'confirmed'},
+  ]);
+
+  final stream = await pending.subscribe(
+    RpcSubscribeOptions(abortSignal: controller.signal),
+  );
+
+  await for (final notification in stream) {
+    print('Account changed: $notification');
+    // Unsubscribe after the first notification.
+    controller.abort();
+  }
+}
+```
+
+### Including unstable subscription methods
+
+To access unstable subscription methods like `blockNotifications`, `slotsUpdatesNotifications`, and `voteNotifications`, use `createSolanaRpcSubscriptionsUnstable`:
+
+```dart
+import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+
+void main() async {
+  final subscriptions = createSolanaRpcSubscriptionsUnstable(
+    'wss://api.devnet.solana.com',
+  );
+
+  final controller = AbortController();
+  final pending = subscriptions.request('slotsUpdatesNotifications');
+
+  final stream = await pending.subscribe(
+    RpcSubscribeOptions(abortSignal: controller.signal),
+  );
+
+  await for (final notification in stream) {
+    print('Slot update: $notification');
+    controller.abort();
+  }
+}
+```
+
+### Customizing channel configuration
+
+The `DefaultRpcSubscriptionsChannelConfig` class lets you tune connection pooling, autopinging intervals, and send buffer sizes.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';
+
+void main() {
+  final subscriptions = createSolanaRpcSubscriptions(
+    'wss://api.mainnet-beta.solana.com',
+    DefaultRpcSubscriptionsChannelConfig(
+      url: 'wss://api.mainnet-beta.solana.com',
+      intervalMs: 10000, // Ping every 10 seconds.
+      maxSubscriptionsPerChannel: 200, // More subs per channel.
+      minChannels: 2, // Start with 2 channels.
+      sendBufferHighWatermark: 256 * 1024, // 256KB send buffer.
+    ),
+  );
+}
+```
+
+### Building from a custom transport
+
+When you need full control over the transport layer, use `createSolanaRpcSubscriptionsFromTransport`:
+
+```dart
+import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';
+
+void main() {
+  // Create a custom transport with subscription coalescing.
+  final transport = createDefaultRpcSubscriptionsTransport(
+    DefaultRpcSubscriptionsTransportConfig(
+      createChannel: createDefaultSolanaRpcSubscriptionsChannelCreator(
+        DefaultRpcSubscriptionsChannelConfig(
+          url: 'wss://api.devnet.solana.com',
+        ),
+      ),
+    ),
+  );
+
+  final subscriptions = createSolanaRpcSubscriptionsFromTransport(transport);
+}
+```
+
+### Subscription coalescing
+
+When multiple callers subscribe to the same notification with the same parameters, the coalescer deduplicates them into a single server-side subscription. This happens automatically with `createSolanaRpcSubscriptions`.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+
+void main() async {
+  final subscriptions = createSolanaRpcSubscriptions(
+    'wss://api.devnet.solana.com',
+  );
+
+  // Both subscriptions share a single server-side subscription
+  // because they have the same method and params.
+  final controller1 = AbortController();
+  final pending1 = subscriptions.request('slotNotifications');
+  final stream1 = await pending1.subscribe(
+    RpcSubscribeOptions(abortSignal: controller1.signal),
+  );
+
+  final controller2 = AbortController();
+  final pending2 = subscriptions.request('slotNotifications');
+  final stream2 = await pending2.subscribe(
+    RpcSubscribeOptions(abortSignal: controller2.signal),
+  );
+
+  // Both streams receive the same notifications.
+  stream1.listen((n) => print('Listener 1: $n'));
+  stream2.listen((n) => print('Listener 2: $n'));
+}
+```
+
+## API Reference
+
+### Factory functions
+
+| Function | Description |
+|----------|-------------|
+| `createSolanaRpcSubscriptions(String clusterUrl, [DefaultRpcSubscriptionsChannelConfig? config])` | Creates a fully-featured subscription client with BigInt JSON, autopinging, pooling, and coalescing. |
+| `createSolanaRpcSubscriptionsUnstable(String clusterUrl, [DefaultRpcSubscriptionsChannelConfig? config])` | Same as above, but includes unstable subscription methods. |
+| `createSolanaRpcSubscriptionsFromTransport(RpcSubscriptionsTransport transport)` | Creates a subscription client from a custom transport. |
+| `createSubscriptionRpc(RpcSubscriptionsConfig config)` | Low-level factory from an API and transport pair. |
+| `createDefaultRpcSubscriptionsTransport(DefaultRpcSubscriptionsTransportConfig config)` | Creates a transport with subscription coalescing from a channel creator. |
+| `createRpcSubscriptionsTransportFromChannelCreator(RpcSubscriptionsChannelCreator creator)` | Creates a transport from a raw channel creator. |
+
+### Channel creators
+
+| Function | Description |
+|----------|-------------|
+| `createDefaultSolanaRpcSubscriptionsChannelCreator(config)` | Creates a channel creator with BigInt JSON serialization, autopinging, and pooling. |
+| `createDefaultRpcSubscriptionsChannelCreator(config)` | Creates a channel creator with standard JSON serialization, autopinging, and pooling. |
+| `getChannelPoolingChannelCreator(creator, {maxSubscriptionsPerChannel, minChannels})` | Wraps a channel creator with connection pooling. |
+| `getRpcSubscriptionsChannelWithAutoping({abortSignal, channel, intervalMs})` | Wraps a channel to send periodic ping messages. |
+| `getRpcSubscriptionsTransportWithSubscriptionCoalescing(transport)` | Wraps a transport to deduplicate identical subscriptions. |
+
+### Classes
+
+| Class | Description |
+|-------|-------------|
+| `RpcSubscriptions` | The subscription client. Call `request(notificationName, [params])` to create pending subscription requests. |
+| `PendingRpcSubscriptionsRequest<T>` | A pending request. Call `subscribe(options)` to start receiving notifications as a `Stream<T>`. |
+| `RpcSubscribeOptions` | Options for subscribing, including an `AbortSignal`. |
+| `RpcSubscriptionsPlan<T>` | Describes a subscription plan with request details and execution logic. |
+| `DefaultRpcSubscriptionsChannelConfig` | Configuration for channel creation: URL, ping interval, pool size, buffer size. |
+| `RpcSubscriptionsRequest` | A subscription request with a method name and parameters. |
+| `RpcSubscriptionsTransportConfig` | Configuration passed to a transport function. |
+
+### Type aliases
+
+| Type | Description |
+|------|-------------|
+| `RpcSubscriptionsTransport` | `Future<DataPublisher> Function(RpcSubscriptionsTransportConfig)` -- the transport function type. |
+| `RpcSubscriptionsChannelCreator` | `Future<RpcSubscriptionsChannel> Function({required AbortSignal abortSignal})` -- creates channels. |

--- a/packages/solana_kit_rpc_subscriptions_api/readme.md
+++ b/packages/solana_kit_rpc_subscriptions_api/readme.md
@@ -1,0 +1,216 @@
+# solana_kit_rpc_subscriptions_api
+
+Subscription method type definitions and parameter builders for all Solana RPC subscription methods in the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc-subscriptions-api`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-subscriptions-api) from the Solana TypeScript SDK.
+
+## Installation
+
+Add `solana_kit_rpc_subscriptions_api` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_subscriptions_api:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Account notifications
+
+Subscribe to be notified whenever the lamports or data of an account changes.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_subscriptions_api/solana_kit_rpc_subscriptions_api.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+void main() {
+  const myAddress = Address('11111111111111111111111111111111');
+
+  // Build the JSON-RPC params for accountSubscribe.
+  final params = accountNotificationsParams(
+    myAddress,
+    AccountNotificationsConfig(
+      commitment: Commitment.confirmed,
+      encoding: 'base64',
+    ),
+  );
+
+  print(params);
+  // ['11111111111111111111111111111111', {'commitment': 'confirmed', 'encoding': 'base64'}]
+}
+```
+
+### Signature notifications
+
+Subscribe to be notified when a transaction with the given signature reaches a commitment level.
+
+```dart
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_rpc_subscriptions_api/solana_kit_rpc_subscriptions_api.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+void main() {
+  const sig = Signature(
+    '5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW',
+  );
+
+  // Build the JSON-RPC params for signatureSubscribe.
+  final params = signatureNotificationsParams(
+    sig,
+    SignatureNotificationsConfig(
+      commitment: Commitment.finalized,
+      enableReceivedNotification: true,
+    ),
+  );
+
+  print(params);
+  // ['5VERv8N...', {'commitment': 'finalized', 'enableReceivedNotification': true}]
+}
+```
+
+### Logs notifications
+
+Subscribe to transaction logs, optionally filtering by address.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_subscriptions_api/solana_kit_rpc_subscriptions_api.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+void main() {
+  // Subscribe to all non-vote transaction logs.
+  final allParams = logsNotificationsParams(const LogsFilterAll());
+
+  // Subscribe to all transaction logs (including votes).
+  final allWithVotesParams = logsNotificationsParams(
+    const LogsFilterAllWithVotes(),
+  );
+
+  // Subscribe to logs mentioning a specific address.
+  const tokenProgram = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+  final mentionsParams = logsNotificationsParams(
+    LogsFilterMentions(tokenProgram),
+    LogsNotificationsConfig(commitment: Commitment.confirmed),
+  );
+}
+```
+
+### Program notifications
+
+Subscribe to changes in any account owned by a specific program.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_subscriptions_api/solana_kit_rpc_subscriptions_api.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+void main() {
+  const tokenProgram = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+  final params = programNotificationsParams(
+    tokenProgram,
+    ProgramNotificationsConfig(
+      commitment: Commitment.confirmed,
+      encoding: 'base64',
+      filters: [
+        {'dataSize': 165}, // Token account size.
+      ],
+    ),
+  );
+}
+```
+
+### Slot and root notifications
+
+These subscription methods take no parameters.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_api/solana_kit_rpc_subscriptions_api.dart';
+
+void main() {
+  // Subscribe to slot changes.
+  final slotParams = slotNotificationsParams(); // []
+
+  // Subscribe to root changes (highest confirmed slot considered finalized).
+  final rootParams = rootNotificationsParams(); // []
+}
+```
+
+### Checking subscription method stability
+
+Determine whether a subscription method name is stable or unstable.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_api/solana_kit_rpc_subscriptions_api.dart';
+
+void main() {
+  // Stable methods.
+  print(isSolanaRpcSubscriptionMethodStable('accountSubscribe')); // true
+  print(isSolanaRpcSubscriptionMethodStable('slotSubscribe')); // true
+
+  // Unstable methods.
+  print(isSolanaRpcSubscriptionMethodStable('blockSubscribe')); // false
+  print(isSolanaRpcSubscriptionMethod('blockSubscribe')); // true
+
+  // Convert notification names to subscribe/unsubscribe method names.
+  print(notificationNameToSubscribeMethod('accountNotifications'));
+  // 'accountSubscribe'
+  print(notificationNameToUnsubscribeMethod('accountNotifications'));
+  // 'accountUnsubscribe'
+}
+```
+
+## API Reference
+
+### Stable subscription methods
+
+| Notification name | Builder function | Config class |
+|-------------------|-----------------|--------------|
+| `accountNotifications` | `accountNotificationsParams(address, [config])` | `AccountNotificationsConfig` |
+| `logsNotifications` | `logsNotificationsParams(filter, [config])` | `LogsNotificationsConfig` |
+| `programNotifications` | `programNotificationsParams(programId, [config])` | `ProgramNotificationsConfig` |
+| `rootNotifications` | `rootNotificationsParams()` | -- |
+| `signatureNotifications` | `signatureNotificationsParams(signature, [config])` | `SignatureNotificationsConfig` |
+| `slotNotifications` | `slotNotificationsParams()` | -- |
+
+### Unstable subscription methods
+
+| Notification name | Description |
+|-------------------|-------------|
+| `blockNotifications` | Subscribe to new confirmed blocks. |
+| `slotsUpdatesNotifications` | Subscribe to slot update events (created, dead, optimistically confirmed, etc.). |
+| `voteNotifications` | Subscribe to new vote transactions. |
+
+### Logs filter classes
+
+| Class | Description |
+|-------|-------------|
+| `LogsFilterAll` | Matches all non-vote transactions. |
+| `LogsFilterAllWithVotes` | Matches all transactions including vote transactions. |
+| `LogsFilterMentions(Address address)` | Matches transactions mentioning a specific address. |
+
+### Method name utilities
+
+| Function | Description |
+|----------|-------------|
+| `isSolanaRpcSubscriptionMethodStable(String methodName)` | Returns `true` if the method is stable. |
+| `isSolanaRpcSubscriptionMethod(String methodName)` | Returns `true` if the method is stable or unstable. |
+| `notificationNameToSubscribeMethod(String name)` | Converts e.g. `'accountNotifications'` to `'accountSubscribe'`. |
+| `notificationNameToUnsubscribeMethod(String name)` | Converts e.g. `'accountNotifications'` to `'accountUnsubscribe'`. |
+
+### Constants
+
+| Constant | Description |
+|----------|-------------|
+| `solanaRpcSubscriptionsMethodsStable` | List of 6 stable subscription method names. |
+| `solanaRpcSubscriptionsMethodsUnstable` | List of all 9 subscription method names (stable + unstable). |
+| `solanaRpcSubscriptionsNotificationsStable` | List of 6 stable notification names. |
+| `solanaRpcSubscriptionsNotificationsUnstable` | List of all 9 notification names (stable + unstable). |

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/readme.md
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/readme.md
@@ -1,0 +1,202 @@
+# solana_kit_rpc_subscriptions_channel_websocket
+
+WebSocket channel transport for Solana RPC subscriptions in the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc-subscriptions-channel-websocket`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-subscriptions-channel-websocket) from the Solana TypeScript SDK.
+
+## Installation
+
+Add `solana_kit_rpc_subscriptions_channel_websocket` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_subscriptions_channel_websocket:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Creating a WebSocket channel
+
+The `createWebSocketChannel` function opens a WebSocket connection and returns an `RpcSubscriptionsChannel` that supports the `DataPublisher` interface for receiving messages and errors.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+
+void main() async {
+  final controller = AbortController();
+
+  final channel = await createWebSocketChannel(
+    WebSocketChannelConfig(
+      url: Uri.parse('wss://api.devnet.solana.com'),
+      signal: controller.signal,
+    ),
+  );
+
+  // Subscribe to incoming messages.
+  channel.on('message', (data) {
+    print('Received: $data');
+  });
+
+  // Subscribe to errors.
+  channel.on('error', (error) {
+    print('Error: $error');
+  });
+
+  // Send a message through the channel.
+  await channel.send('{"jsonrpc":"2.0","id":1,"method":"slotSubscribe"}');
+
+  // Later, close the channel.
+  controller.abort();
+}
+```
+
+### Abort lifecycle management
+
+The `AbortController` and `AbortSignal` classes manage the lifecycle of WebSocket connections. When you abort the signal, the WebSocket is closed with a normal closure code (1000).
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+
+void main() async {
+  final controller = AbortController();
+
+  // Check signal state.
+  print(controller.signal.isAborted); // false
+
+  // Open a channel with the signal.
+  final channel = await createWebSocketChannel(
+    WebSocketChannelConfig(
+      url: Uri.parse('wss://api.devnet.solana.com'),
+      signal: controller.signal,
+    ),
+  );
+
+  // Abort with a reason.
+  controller.abort('User cancelled');
+
+  print(controller.signal.isAborted); // true
+  print(controller.signal.reason); // 'User cancelled'
+
+  // Sending on a closed channel throws SolanaError with code
+  // rpcSubscriptionsChannelConnectionClosed.
+}
+```
+
+### Waiting for abort asynchronously
+
+The `AbortSignal` provides a `future` that completes when the signal is aborted. This is useful for composing with other async operations.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+
+void main() async {
+  final controller = AbortController();
+
+  // Wait for the signal to fire.
+  controller.signal.future.then((_) {
+    print('Signal was aborted!');
+  });
+
+  // Abort after some delay.
+  await Future<void>.delayed(Duration(seconds: 5));
+  controller.abort();
+  // Prints: 'Signal was aborted!'
+}
+```
+
+### Configuring the send buffer
+
+The `sendBufferHighWatermark` parameter controls how much data is allowed into the WebSocket's send buffer before messages are queued on the client.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+
+void main() async {
+  final controller = AbortController();
+
+  final channel = await createWebSocketChannel(
+    WebSocketChannelConfig(
+      url: Uri.parse('wss://api.devnet.solana.com'),
+      sendBufferHighWatermark: 256 * 1024, // 256KB buffer.
+      signal: controller.signal,
+    ),
+  );
+
+  // Use the channel...
+  controller.abort();
+}
+```
+
+### Error handling
+
+The function throws `SolanaError` in several situations:
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+
+void main() async {
+  final controller = AbortController();
+
+  try {
+    final channel = await createWebSocketChannel(
+      WebSocketChannelConfig(
+        url: Uri.parse('wss://invalid-host.example.com'),
+        signal: controller.signal,
+      ),
+    );
+  } on SolanaError catch (e) {
+    if (isSolanaError(e, SolanaErrorCode.rpcSubscriptionsChannelFailedToConnect)) {
+      print('Connection failed');
+    }
+  }
+
+  // Already-aborted signals prevent connection.
+  final abortedController = AbortController()..abort();
+  try {
+    await createWebSocketChannel(
+      WebSocketChannelConfig(
+        url: Uri.parse('wss://api.devnet.solana.com'),
+        signal: abortedController.signal,
+      ),
+    );
+  } on SolanaError catch (e) {
+    if (isSolanaError(
+      e,
+      SolanaErrorCode.rpcSubscriptionsChannelConnectionClosed,
+    )) {
+      print('Channel was already closed');
+    }
+  }
+}
+```
+
+## API Reference
+
+### Functions
+
+| Function | Description |
+|----------|-------------|
+| `createWebSocketChannel(WebSocketChannelConfig config)` | Opens a WebSocket connection and returns `Future<RpcSubscriptionsChannel>`. |
+
+### Classes
+
+| Class | Description |
+|-------|-------------|
+| `RpcSubscriptionsChannel` | An interface extending `DataPublisher` with a `send(Object)` method for outgoing messages. Supports `on('message', ...)` and `on('error', ...)`. |
+| `WebSocketChannelConfig` | Configuration: `url` (Uri), `sendBufferHighWatermark` (int, default 128KB), `signal` (AbortSignal?). |
+| `AbortController` | Creates and manages an `AbortSignal`. Call `abort([reason])` to fire the signal. |
+| `AbortSignal` | Represents an abort signal. Properties: `isAborted`, `reason`, `future`. |
+
+### Constants
+
+| Constant | Description |
+|----------|-------------|
+| `normalClosureCode` | `1000` -- the RFC 6455 normal closure code used when aborting a channel. |

--- a/packages/solana_kit_rpc_transformers/readme.md
+++ b/packages/solana_kit_rpc_transformers/readme.md
@@ -1,0 +1,320 @@
+# solana_kit_rpc_transformers
+
+Request and response transformers for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc-transformers`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-transformers) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_transformers:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+This package provides helpers for transforming Solana JSON-RPC requests and responses in various ways. The default transformers handle BigInt conversion, integer overflow detection, default commitment injection, error throwing, and result extraction.
+
+### Default request transformer
+
+The `getDefaultRequestTransformerForSolanaRpc` function composes three request transformers into one:
+
+1. **Integer overflow check** -- Detects BigInt values that exceed the safe JavaScript integer range.
+2. **BigInt downcast** -- Converts all BigInt values to int for JSON encoding compatibility.
+3. **Default commitment** -- Injects a default commitment level when none is provided.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+final transformer = getDefaultRequestTransformerForSolanaRpc(
+  RequestTransformerConfig(
+    defaultCommitment: Commitment.confirmed,
+    onIntegerOverflow: (request, keyPath, value) {
+      print('Overflow in ${request.methodName} at $keyPath: $value');
+    },
+  ),
+);
+
+final request = RpcRequest<Object?>(
+  methodName: 'getBalance',
+  params: ['address123', {'commitment': null}],
+);
+
+final transformed = transformer(request);
+// The commitment will be set to 'confirmed' and BigInt values downcast.
+```
+
+### Default response transformer
+
+The `getDefaultResponseTransformerForSolanaRpc` function composes three response transformers:
+
+1. **Throw on error** -- Throws a `SolanaError` if the response body contains an error.
+2. **Result extraction** -- Extracts the `result` field from the JSON-RPC response.
+3. **BigInt upcast** -- Converts integer values to BigInt (except those in allowed numeric key paths).
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+
+final transformer = getDefaultResponseTransformerForSolanaRpc(
+  ResponseTransformerConfig(
+    allowedNumericKeyPaths: {
+      'getAccountInfo': [
+        ['value', 'data', 'parsed', 'info', 'tokenAmount', 'decimals'],
+      ],
+    },
+  ),
+);
+
+// Successful response.
+final response = {
+  'jsonrpc': '2.0',
+  'result': {
+    'context': {'slot': BigInt.from(12345)},
+    'value': BigInt.from(1000000),
+  },
+  'id': '1',
+};
+
+final request = RpcRequest<Object?>(
+  methodName: 'getBalance',
+  params: ['address123'],
+);
+
+final result = transformer(response, request);
+// Returns {'context': {'slot': BigInt(12345)}, 'value': BigInt(1000000)}
+```
+
+### BigInt downcast request transformer
+
+Converts all `BigInt` values in request parameters to `int`, since JSON encoding does not support `BigInt` directly.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+
+final transformer = getBigIntDowncastRequestTransformer();
+
+final request = RpcRequest<Object?>(
+  methodName: 'getBalance',
+  params: ['address', {'minContextSlot': BigInt.from(100)}],
+);
+
+final result = transformer(request);
+// params now contain int(100) instead of BigInt(100)
+```
+
+### Integer overflow request transformer
+
+Walks the request parameter tree and invokes the provided handler whenever a `BigInt` value exceeds the safe JavaScript integer range (2^53 - 1).
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+
+final transformer = getIntegerOverflowRequestTransformer(
+  (request, keyPath, value) {
+    throw Exception(
+      'Value $value at path $keyPath in ${request.methodName} exceeds safe range',
+    );
+  },
+);
+
+final request = RpcRequest<Object?>(
+  methodName: 'sendTransaction',
+  params: [BigInt.parse('9007199254740993')], // MAX_SAFE_INTEGER + 1
+);
+
+// This will invoke the handler and throw.
+// transformer(request);
+```
+
+### Default commitment request transformer
+
+Injects a default commitment level into the options object of RPC methods that accept one, but only when the caller has not already specified a commitment.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+final transformer = getDefaultCommitmentRequestTransformer(
+  optionsObjectPositionByMethod: OPTIONS_OBJECT_POSITION_BY_METHOD,
+  defaultCommitment: Commitment.confirmed,
+);
+
+// Request without commitment -> gets 'confirmed' injected.
+final request = RpcRequest<Object?>(
+  methodName: 'getBalance',
+  params: ['address123'],
+);
+final result = transformer(request);
+// params: ['address123', {'commitment': 'confirmed'}]
+```
+
+### BigInt upcast response transformer
+
+Converts all integer values in a response to `BigInt`, except for values at specified key paths which remain as `int`.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+
+// Keep 'decimals' as int, upcast everything else to BigInt.
+final transformer = getBigIntUpcastResponseTransformer([
+  ['value', 'data', 'parsed', 'info', 'tokenAmount', 'decimals'],
+]);
+
+final request = RpcRequest<Object?>(
+  methodName: 'getAccountInfo',
+  params: ['address123'],
+);
+
+final response = {
+  'value': {
+    'lamports': 1000000,
+    'data': {
+      'parsed': {
+        'info': {
+          'tokenAmount': {'amount': '1000000', 'decimals': 6},
+        },
+      },
+    },
+  },
+};
+
+final result = transformer(response, request);
+// 'lamports' -> BigInt(1000000), 'decimals' -> int(6)
+```
+
+### Result response transformer
+
+Extracts the `result` field from a JSON-RPC 2.0 response envelope.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+
+final transformer = getResultResponseTransformer();
+final request = RpcRequest<Object?>(methodName: 'getSlot', params: []);
+
+final result = transformer(
+  {'jsonrpc': '2.0', 'result': BigInt.from(12345), 'id': '1'},
+  request,
+);
+print(result); // BigInt(12345)
+```
+
+### Throw Solana error response transformer
+
+Inspects the response for a JSON-RPC error field and throws a `SolanaError` if one is found.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+
+final transformer = getThrowSolanaErrorResponseTransformer();
+final request = RpcRequest<Object?>(methodName: 'getSlot', params: []);
+
+try {
+  transformer(
+    {
+      'jsonrpc': '2.0',
+      'error': {'code': -32005, 'message': 'Node is unhealthy'},
+      'id': '1',
+    },
+    request,
+  );
+} on SolanaError catch (e) {
+  print(e.code); // SolanaErrorCode.jsonRpcServerErrorNodeUnhealthy
+}
+```
+
+### Tree traversal
+
+The `getTreeWalkerRequestTransformer` and `getTreeWalkerResponseTransformer` functions create transformers that recursively traverse data structures and apply visitor functions at each leaf node.
+
+```dart
+import 'package:solana_kit_rpc_spec_types/solana_kit_rpc_spec_types.dart';
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+
+// A visitor that converts all strings to uppercase.
+NodeVisitor uppercaseVisitor = (value, state) {
+  if (value is String) return value.toUpperCase();
+  return value;
+};
+
+final transformer = getTreeWalkerRequestTransformer(
+  [uppercaseVisitor],
+  const TraversalState(keyPath: []),
+);
+
+final request = RpcRequest<Object?>(
+  methodName: 'test',
+  params: ['hello', {'name': 'world'}],
+);
+
+final result = transformer(request);
+// params: ['HELLO', {'name': 'WORLD'}]
+```
+
+You can use `KEYPATH_WILDCARD` to match any key at a given position in a key path:
+
+```dart
+import 'package:solana_kit_rpc_transformers/solana_kit_rpc_transformers.dart';
+
+// Match any element in an array.
+final keyPath = ['accounts', KEYPATH_WILDCARD, 'balance'];
+// Matches: accounts[0].balance, accounts[1].balance, etc.
+```
+
+## API Reference
+
+### Request Transformers
+
+- **`getDefaultRequestTransformerForSolanaRpc([RequestTransformerConfig?])`** -- Composes the integer overflow, BigInt downcast, and default commitment transformers.
+- **`getBigIntDowncastRequestTransformer()`** -- Downcasts all `BigInt` values to `int`.
+- **`getIntegerOverflowRequestTransformer(IntegerOverflowHandler)`** -- Detects BigInt values that exceed the safe integer range.
+- **`getDefaultCommitmentRequestTransformer({required Map optionsObjectPositionByMethod, Commitment? defaultCommitment})`** -- Injects a default commitment into RPC method options.
+- **`getTreeWalkerRequestTransformer(List<NodeVisitor>, TraversalState)`** -- Creates a request transformer from a list of tree-walking visitors.
+
+### Response Transformers
+
+- **`getDefaultResponseTransformerForSolanaRpc([ResponseTransformerConfig?])`** -- Composes error throwing, result extraction, and BigInt upcast transformers.
+- **`getDefaultResponseTransformerForSolanaRpcSubscriptions([ResponseTransformerConfig?])`** -- BigInt upcast transformer only (for WebSocket subscriptions).
+- **`getBigIntUpcastResponseTransformer(List<KeyPath>)`** -- Upcasts integers to `BigInt`, except at the specified key paths.
+- **`getResultResponseTransformer()`** -- Extracts the `result` field from a JSON-RPC response.
+- **`getThrowSolanaErrorResponseTransformer()`** -- Throws a `SolanaError` if the response contains an error.
+- **`getTreeWalkerResponseTransformer(List<NodeVisitor>, TraversalState)`** -- Creates a response transformer from a list of tree-walking visitors.
+
+### Configuration Classes
+
+- **`RequestTransformerConfig`** -- Configuration with optional `defaultCommitment` and `onIntegerOverflow`.
+- **`ResponseTransformerConfig`** -- Configuration with optional `allowedNumericKeyPaths`.
+
+### Tree Traversal
+
+- **`TraversalState`** -- Holds the current `keyPath` during tree traversal.
+- **`KeyPath`** -- `List<Object>` representing a path through a nested data structure.
+- **`KEYPATH_WILDCARD`** -- Sentinel value that matches any key at a given level.
+- **`NodeVisitor`** -- `Object? Function(Object? value, TraversalState state)` -- A function applied at each leaf node.
+
+### Typedefs
+
+- **`IntegerOverflowHandler`** -- `void Function(RpcRequest<Object?>, KeyPath, BigInt)` -- Called when a BigInt exceeds safe range.
+- **`AllowedNumericKeypaths`** -- `Map<String, List<KeyPath>>` -- Maps method names to key paths that should remain as `int`.
+
+### Constants
+
+- **`OPTIONS_OBJECT_POSITION_BY_METHOD`** -- Maps each Solana RPC method name to the index of its options object in the params array.
+- **`jsonParsedTokenAccountsConfigs`** -- Key paths for numeric values in parsed token accounts.
+- **`jsonParsedAccountsConfigs`** -- Key paths for numeric values in all parsed accounts.
+- **`innerInstructionsConfigs`** -- Key paths for numeric values in inner instructions.
+- **`messageConfig`** -- Key paths for numeric values in transaction messages.

--- a/packages/solana_kit_rpc_transport_http/readme.md
+++ b/packages/solana_kit_rpc_transport_http/readme.md
@@ -1,0 +1,224 @@
+# solana_kit_rpc_transport_http
+
+HTTP transport for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc-transport-http`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-transport-http) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_transport_http:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+This package provides HTTP transport implementations for sending JSON-RPC requests. It uses the `http` Dart package under the hood.
+
+### Generic HTTP transport
+
+The `createHttpTransport` function creates a generic JSON-RPC transport that sends POST requests with JSON payloads.
+
+```dart
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart';
+
+final transport = createHttpTransport(
+  HttpTransportConfig(url: 'https://api.mainnet-beta.solana.com'),
+);
+
+final response = await transport(
+  RpcTransportConfig(
+    payload: {
+      'id': '1',
+      'jsonrpc': '2.0',
+      'method': 'getSlot',
+      'params': [],
+    },
+  ),
+);
+
+print(response);
+// {'jsonrpc': '2.0', 'result': 250000000, 'id': '1'}
+```
+
+### Custom headers
+
+Pass custom headers through the `HttpTransportConfig`. Note that `accept`, `content-length`, and `content-type` are set automatically and cannot be overridden. Forbidden headers (per the MDN specification) are also rejected.
+
+```dart
+import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart';
+
+final transport = createHttpTransport(
+  HttpTransportConfig(
+    url: 'https://api.mainnet-beta.solana.com',
+    headers: {
+      'x-api-key': 'my-secret-key',
+      'authorization': 'Bearer my-token',
+    },
+  ),
+);
+```
+
+### Custom JSON serialization
+
+You can provide custom `toJson` and `fromJson` functions to control how request payloads are serialized and response bodies are deserialized.
+
+```dart
+import 'dart:convert';
+import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart';
+
+final transport = createHttpTransport(
+  HttpTransportConfig(
+    url: 'https://api.mainnet-beta.solana.com',
+    toJson: (payload) {
+      // Custom serialization.
+      return jsonEncode(payload);
+    },
+    fromJson: (rawResponse, payload) {
+      // Custom deserialization.
+      return jsonDecode(rawResponse);
+    },
+  ),
+);
+```
+
+### Solana-specific HTTP transport
+
+The `createHttpTransportForSolanaRpc` function creates a transport with BigInt-aware JSON handling. It uses `parseJsonWithBigInts` and `stringifyJsonWithBigInts` for Solana RPC requests, and standard `jsonEncode`/`jsonDecode` for other requests.
+
+```dart
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart';
+
+final transport = createHttpTransportForSolanaRpc(
+  url: 'https://api.mainnet-beta.solana.com',
+);
+
+final response = await transport(
+  RpcTransportConfig(
+    payload: {
+      'id': '1',
+      'jsonrpc': '2.0',
+      'method': 'getBalance',
+      'params': ['83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'],
+    },
+  ),
+);
+
+// The response will have BigInt values for large integers.
+final result = response as Map<String, Object?>;
+final value = result['result'] as Map<String, Object?>;
+print(value['value'] is BigInt); // true
+```
+
+Pass custom headers and an `http.Client` for testing:
+
+```dart
+import 'package:http/http.dart' as http;
+import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart';
+
+final transport = createHttpTransportForSolanaRpc(
+  url: 'https://api.devnet.solana.com',
+  headers: {'x-api-key': 'my-key'},
+  client: http.Client(), // or a mock client for testing
+);
+```
+
+### Checking for Solana requests
+
+The `isSolanaRequest` function checks whether a payload is a JSON-RPC 2.0 request for a known Solana RPC method. This is used internally to decide whether to apply BigInt-aware JSON handling.
+
+```dart
+import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart';
+
+final payload = {
+  'jsonrpc': '2.0',
+  'method': 'getBalance',
+  'params': ['address123'],
+  'id': '1',
+};
+
+print(isSolanaRequest(payload)); // true
+
+final nonSolanaPayload = {
+  'jsonrpc': '2.0',
+  'method': 'custom_method',
+  'params': [],
+  'id': '1',
+};
+
+print(isSolanaRequest(nonSolanaPayload)); // false
+```
+
+### Header validation
+
+The `assertIsAllowedHttpRequestHeaders` function validates that no forbidden or protocol-reserved headers are included. It is called automatically in debug mode by `createHttpTransport`.
+
+```dart
+import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart';
+
+// These are fine.
+assertIsAllowedHttpRequestHeaders({
+  'x-api-key': 'my-key',
+  'authorization': 'Bearer token',
+});
+
+// These will throw (forbidden/disallowed headers).
+// assertIsAllowedHttpRequestHeaders({'content-type': 'text/plain'}); // throws
+// assertIsAllowedHttpRequestHeaders({'host': 'example.com'}); // throws
+// assertIsAllowedHttpRequestHeaders({'sec-fetch-mode': 'cors'}); // throws
+```
+
+### Using a mock client for testing
+
+Both `createHttpTransport` and `createHttpTransportForSolanaRpc` accept an optional `http.Client` parameter, making it straightforward to inject a mock for testing.
+
+```dart
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart';
+
+final mockClient = MockClient((request) async {
+  return http.Response(
+    '{"jsonrpc":"2.0","result":42,"id":"1"}',
+    200,
+    headers: {'content-type': 'application/json'},
+  );
+});
+
+final transport = createHttpTransport(
+  HttpTransportConfig(url: 'https://api.mainnet-beta.solana.com'),
+  client: mockClient,
+);
+
+final response = await transport(
+  RpcTransportConfig(
+    payload: {'id': '1', 'jsonrpc': '2.0', 'method': 'getSlot', 'params': []},
+  ),
+);
+print(response); // {jsonrpc: 2.0, result: 42, id: 1}
+```
+
+## API Reference
+
+### Functions
+
+- **`createHttpTransport(HttpTransportConfig config, {http.Client? client})`** -- Creates a generic `RpcTransport` that sends JSON-RPC requests over HTTP POST. Returns a function matching the `RpcTransport` typedef.
+- **`createHttpTransportForSolanaRpc({required String url, Map<String, String>? headers, http.Client? client})`** -- Creates an `RpcTransport` with BigInt-aware JSON serialization for Solana RPC requests. Uses `parseJsonWithBigInts`/`stringifyJsonWithBigInts` for known Solana methods.
+- **`isSolanaRequest(Object? payload)`** -- Returns `true` if the payload is a JSON-RPC 2.0 request for a known Solana RPC method.
+- **`assertIsAllowedHttpRequestHeaders(Map<String, String> headers)`** -- Throws a `SolanaError` if any headers are forbidden or protocol-reserved.
+- **`normalizeHeaders(Map<String, String> headers)`** -- Returns a new map with all header names lowercased.
+
+### Classes
+
+- **`HttpTransportConfig`** -- Configuration for `createHttpTransport`:
+  - `url` (`String`, required) -- The target endpoint URL.
+  - `headers` (`Map<String, String>?`) -- Optional custom headers.
+  - `toJson` (`String Function(Object?)?`) -- Optional custom JSON serializer.
+  - `fromJson` (`Object? Function(String, Object?)?`) -- Optional custom JSON deserializer (receives raw response and request payload).

--- a/packages/solana_kit_rpc_types/readme.md
+++ b/packages/solana_kit_rpc_types/readme.md
@@ -1,0 +1,300 @@
+# solana_kit_rpc_types
+
+Shared RPC types for the Solana Kit Dart SDK.
+
+This is the Dart port of [`@solana/rpc-types`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-types) from the Solana TypeScript SDK.
+
+## Installation
+
+Add the dependency to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_rpc_types:
+```
+
+If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+
+## Usage
+
+### Commitment levels
+
+The `Commitment` enum represents the three finality levels for Solana RPC queries. The `commitmentComparator` orders them by finality (processed < confirmed < finalized).
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// The three commitment levels.
+const c1 = Commitment.processed;
+const c2 = Commitment.confirmed;
+const c3 = Commitment.finalized;
+
+// Compare commitments by finality level.
+print(commitmentComparator(Commitment.processed, Commitment.finalized)); // -1
+print(commitmentComparator(Commitment.finalized, Commitment.finalized)); // 0
+print(commitmentComparator(Commitment.finalized, Commitment.confirmed)); // 1
+
+// Use the comparator to sort a list.
+final commitments = [Commitment.finalized, Commitment.processed, Commitment.confirmed];
+commitments.sort(commitmentComparator);
+print(commitments); // [processed, confirmed, finalized]
+```
+
+### Lamports
+
+`Lamports` is an extension type wrapping `BigInt` that represents a value denominated in the smallest unit of SOL (1 SOL = 10^9 lamports). It includes validation, encoding, and decoding utilities.
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// Create a Lamports value from a trusted BigInt.
+const oneSol = Lamports(BigInt.from(1000000000)); // 1 SOL
+
+// Create from untrusted input (validates range 0 to 2^64-1).
+final validated = lamports(BigInt.from(500000));
+
+// Check validity without throwing.
+print(isLamports(BigInt.from(100))); // true
+print(isLamports(BigInt.from(-1))); // false
+
+// Assert validity (throws SolanaError if out of range).
+assertIsLamports(BigInt.from(100)); // OK
+// assertIsLamports(BigInt.from(-1)); // throws SolanaError
+
+// Encode/decode Lamports as 8-byte little-endian (u64).
+final encoder = getDefaultLamportsEncoder();
+final decoder = getDefaultLamportsDecoder();
+final codec = getDefaultLamportsCodec();
+```
+
+### Blockhash
+
+`Blockhash` is an extension type wrapping `String` that represents a validated base58-encoded blockhash (same format as a Solana address -- 32 bytes).
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// Create from a trusted string.
+const bh = Blockhash('4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY');
+
+// Create from untrusted input (validates base58 encoding and byte length).
+final validated = blockhash('4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY');
+
+// Check validity.
+print(isBlockhash('4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY')); // true
+print(isBlockhash('too-short')); // false
+
+// Encode/decode as 32 bytes.
+final encoder = getBlockhashEncoder();
+final decoder = getBlockhashDecoder();
+final codec = getBlockhashCodec();
+
+// Sort blockhashes using base58 collation.
+final comparator = getBlockhashComparator();
+final sorted = ['Zzz', 'Aaa', 'aaa']..sort(comparator);
+```
+
+### Unix timestamps
+
+`UnixTimestamp` is an extension type wrapping `BigInt` that represents a Unix timestamp in seconds (i64 range).
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// Create from a trusted BigInt.
+const ts = UnixTimestamp(BigInt.from(1700000000));
+
+// Create from untrusted input (validates i64 range).
+final validated = unixTimestamp(BigInt.from(1700000000));
+
+// Check validity.
+print(isUnixTimestamp(BigInt.from(1700000000))); // true
+```
+
+### Cluster URLs
+
+Branded extension types for cluster URLs provide compile-time safety when working with different Solana clusters.
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// Create branded URLs for each cluster.
+final mainnetUrl = mainnet('https://api.mainnet-beta.solana.com');
+final devnetUrl = devnet('https://api.devnet.solana.com');
+final testnetUrl = testnet('https://api.testnet.solana.com');
+
+// All are still Strings underneath, but typed for safety.
+print(mainnetUrl is MainnetUrl); // true
+print(devnetUrl is DevnetUrl); // true
+```
+
+### Slot and Epoch
+
+`Slot` and `Epoch` are type aliases for `BigInt`, representing slot numbers and epoch numbers on the Solana blockchain.
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+Slot currentSlot = BigInt.from(250000000);
+Epoch currentEpoch = BigInt.from(580);
+
+// MicroLamports is an extension type for priority fee calculations.
+const fee = MicroLamports(BigInt.from(5000));
+```
+
+### Stringified BigInt and Number
+
+These extension types represent values that the RPC returns as strings to avoid precision loss during JSON transit.
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// StringifiedBigInt: a BigInt encoded as a string.
+final amount = stringifiedBigInt('1000000000');
+print(isStringifiedBigInt('1000000000')); // true
+print(isStringifiedBigInt('not-a-number')); // false
+
+// StringifiedNumber: a number encoded as a string.
+final uiAmount = stringifiedNumber('1.5');
+print(isStringifiedNumber('1.5')); // true
+```
+
+### Token amounts
+
+The `TokenAmount` class represents a token balance as returned by the Solana RPC, including the raw amount, decimal configuration, and human-readable string.
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+final tokenAmount = TokenAmount(
+  amount: StringifiedBigInt('1000000'),
+  decimals: 6,
+  uiAmountString: StringifiedNumber('1'),
+);
+
+print(tokenAmount.amount); // '1000000'
+print(tokenAmount.decimals); // 6
+print(tokenAmount.uiAmountString); // '1'
+```
+
+### Account info
+
+`AccountInfoBase` provides the core fields common to all account info variants. Specialized subclasses handle different data encodings.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+final accountInfo = AccountInfoBase(
+  executable: false,
+  lamports: Lamports(BigInt.from(1000000)),
+  owner: Address('11111111111111111111111111111111'),
+  space: BigInt.from(165),
+);
+
+print(accountInfo.executable); // false
+print(accountInfo.lamports); // Lamports(1000000)
+print(accountInfo.owner); // 11111111111111111111111111111111
+```
+
+Data encoding variants:
+
+- `AccountInfoWithBase64EncodedData` -- base64-encoded data
+- `AccountInfoWithBase64EncodedZStdCompressedData` -- base64+zstd-compressed data
+- `AccountInfoWithJsonData` -- JSON-parsed data (sealed: `AccountInfoJsonDataParsed` or `AccountInfoJsonDataBase64` fallback)
+- `AccountInfoWithPubkey<T>` -- wraps any account info variant with its public key
+
+### Transaction and instruction errors
+
+Sealed class hierarchies provide type-safe representations of Solana runtime errors.
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+// Transaction errors.
+const simpleError = TransactionErrorSimple('BlockhashNotFound');
+print(simpleError.label); // 'BlockhashNotFound'
+
+const instructionError = TransactionErrorInstructionError(
+  0,
+  InstructionErrorCustom(42),
+);
+print(instructionError.instructionIndex); // 0
+print(instructionError.instructionError.label); // 'Custom'
+print((instructionError.instructionError as InstructionErrorCustom).code); // 42
+
+// Pattern matching on sealed types.
+void handleError(TransactionError error) {
+  switch (error) {
+    case TransactionErrorSimple(:final label):
+      print('Simple error: $label');
+    case TransactionErrorInstructionError(:final instructionIndex, :final instructionError):
+      print('Instruction $instructionIndex failed: ${instructionError.label}');
+    case TransactionErrorDuplicateInstruction(:final instructionIndex):
+      print('Duplicate instruction at index $instructionIndex');
+    case TransactionErrorInsufficientFundsForRent(:final accountIndex):
+      print('Insufficient funds for rent at account $accountIndex');
+    case TransactionErrorProgramExecutionTemporarilyRestricted(:final accountIndex):
+      print('Program execution restricted for account $accountIndex');
+  }
+}
+```
+
+## API Reference
+
+### Enums
+
+- **`Commitment`** -- Finality levels: `processed`, `confirmed`, `finalized`.
+
+### Extension Types
+
+- **`Lamports(BigInt)`** -- A value denominated in lamports (10^-9 SOL).
+- **`Blockhash(String)`** -- A validated base58-encoded blockhash.
+- **`UnixTimestamp(BigInt)`** -- A Unix timestamp in seconds (i64 range).
+- **`MainnetUrl(String)`** -- A branded mainnet cluster URL.
+- **`DevnetUrl(String)`** -- A branded devnet cluster URL.
+- **`TestnetUrl(String)`** -- A branded testnet cluster URL.
+- **`MicroLamports(BigInt)`** -- A value denominated in micro-lamports (10^-6 lamports).
+- **`StringifiedBigInt(String)`** -- A BigInt encoded as a string.
+- **`StringifiedNumber(String)`** -- A number encoded as a string.
+
+### Classes
+
+- **`AccountInfoBase`** -- Base account info with `executable`, `lamports`, `owner`, `space`.
+- **`AccountInfoWithBase64EncodedData`** -- Account info with base64-encoded data.
+- **`AccountInfoWithBase64EncodedZStdCompressedData`** -- Account info with zstd-compressed data.
+- **`AccountInfoWithJsonData`** -- Account info with JSON-parsed data.
+- **`AccountInfoWithPubkey<T>`** -- Account info paired with its public key address.
+- **`ParsedAccountData`** -- Parsed account data with `type`, `program`, `space`, and optional `info`.
+- **`TokenAmount`** -- Token balance with `amount`, `decimals`, `uiAmountString`.
+- **`InstructionError`** -- Sealed class for instruction-level errors (`InstructionErrorCustom`, `InstructionErrorSimple`).
+- **`TransactionError`** -- Sealed class for transaction-level errors (`TransactionErrorSimple`, `TransactionErrorInstructionError`, `TransactionErrorDuplicateInstruction`, `TransactionErrorInsufficientFundsForRent`, `TransactionErrorProgramExecutionTemporarilyRestricted`).
+
+### Functions
+
+- **`commitmentComparator(Commitment, Commitment)`** -- Compares two commitments by finality level.
+- **`lamports(BigInt)`** -- Validates and creates a `Lamports` value.
+- **`isLamports(BigInt)`** / **`assertIsLamports(BigInt)`** -- Lamports range checks.
+- **`blockhash(String)`** -- Validates and creates a `Blockhash`.
+- **`isBlockhash(String)`** / **`assertIsBlockhash(String)`** -- Blockhash validation.
+- **`unixTimestamp(BigInt)`** -- Validates and creates a `UnixTimestamp`.
+- **`isUnixTimestamp(BigInt)`** / **`assertIsUnixTimestamp(BigInt)`** -- Timestamp range checks.
+- **`stringifiedBigInt(String)`** -- Validates and creates a `StringifiedBigInt`.
+- **`stringifiedNumber(String)`** -- Validates and creates a `StringifiedNumber`.
+- **`mainnet(String)`** / **`devnet(String)`** / **`testnet(String)`** -- Cluster URL constructors.
+- **`getDefaultLamportsEncoder()`** / **`getDefaultLamportsDecoder()`** / **`getDefaultLamportsCodec()`** -- u64 codec for Lamports.
+- **`getBlockhashEncoder()`** / **`getBlockhashDecoder()`** / **`getBlockhashCodec()`** -- 32-byte codec for Blockhash.
+- **`getBlockhashComparator()`** -- Returns a base58 collation comparator for blockhashes.
+
+### Typedefs
+
+- **`Slot`** -- `BigInt` representing a slot number.
+- **`Epoch`** -- `BigInt` representing an epoch number.
+- **`SignedLamports`** -- `BigInt` representing a signed lamport amount.
+- **`F64UnsafeSeeDocumentation`** -- `double` for floating-point RPC values with precision caveats.
+- **`ClusterUrl`** -- `String` union type for all cluster URL types.
+
+### Abstract Final Classes (Constants)
+
+- **`InstructionErrorLabel`** -- String constants for all known instruction error labels.
+- **`TransactionErrorLabel`** -- String constants for all known transaction error labels.

--- a/packages/solana_kit_signers/readme.md
+++ b/packages/solana_kit_signers/readme.md
@@ -1,0 +1,426 @@
+# solana_kit_signers
+
+Signer interfaces and utilities for signing Solana messages and transactions -- a Dart port of [`@solana/signers`](https://github.com/anza-xyz/kit/tree/main/packages/signers).
+
+## Installation
+
+Add `solana_kit_signers` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_signers:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Creating a key pair signer
+
+A `KeyPairSigner` is the most common signer -- it holds an Ed25519 key pair and implements both the `MessagePartialSigner` and `TransactionPartialSigner` interfaces.
+
+```dart
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+
+void main() {
+  // Generate a new random key pair signer.
+  final signer = generateKeyPairSigner();
+  print('Address: ${signer.address.value}');
+  print('Public key: ${signer.keyPair.publicKey}');
+}
+```
+
+### Restoring a signer from bytes
+
+Create a `KeyPairSigner` from existing key material.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+
+void main() {
+  // From a 64-byte array (32 private + 32 public).
+  final fullBytes = Uint8List(64); // replace with real bytes
+  final signer64 = createKeyPairSignerFromBytes(fullBytes);
+
+  // From a 32-byte private key only (public key is derived).
+  final privateKeyBytes = Uint8List(32); // replace with real bytes
+  final signer32 = createKeyPairSignerFromPrivateKeyBytes(privateKeyBytes);
+
+  // From an existing KeyPair instance.
+  final keyPair = generateKeyPair();
+  final signerFromPair = createSignerFromKeyPair(keyPair);
+
+  print(signer64.address.value);
+  print(signer32.address.value);
+  print(signerFromPair.address.value);
+}
+```
+
+### Signing messages
+
+Create a `SignableMessage` and sign it with one or more signers. The `SignableMessage` class pairs message content with a map of existing signatures.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+
+Future<void> main() async {
+  final signer = generateKeyPairSigner();
+
+  // Create a signable message from a UTF-8 string.
+  final message = createSignableMessage('Hello, Solana!');
+
+  // Or from raw bytes.
+  final messageFromBytes = createSignableMessage(
+    Uint8List.fromList([1, 2, 3, 4]),
+  );
+
+  // Sign the message. Returns a list of signature dictionaries (one per message).
+  final signaturesList = await signer.signMessages([message]);
+  final signatures = signaturesList[0];
+
+  print('Signed by: ${signatures.keys.first.value}');
+  print('Signature length: ${signatures.values.first.value.length}'); // 64
+}
+```
+
+### Using a noop signer
+
+A `NoopSigner` implements the partial signer interfaces but returns empty signature dictionaries. This is useful as a placeholder in tests or when building transaction messages that will be signed later.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+
+Future<void> main() async {
+  final noopSigner = createNoopSigner(
+    address('11111111111111111111111111111111'),
+  );
+
+  final message = createSignableMessage('test');
+  final signaturesList = await noopSigner.signMessages([message]);
+
+  // Noop signer returns empty signature maps.
+  print('Signatures: ${signaturesList[0]}'); // {}
+}
+```
+
+### Attaching signers to instructions
+
+Use `addSignersToInstruction` to associate signer objects with the account metas of an instruction. The signer is attached when the account has a signer role and its address matches the signer's address.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+
+void main() {
+  final signer = generateKeyPairSigner();
+
+  final instruction = Instruction(
+    programAddress: address('11111111111111111111111111111111'),
+    accounts: [
+      AccountMeta(
+        address: signer.address,
+        role: AccountRole.writableSigner,
+      ),
+    ],
+  );
+
+  // Attach the signer to matching account metas.
+  final updated = addSignersToInstruction([signer], instruction);
+
+  // The matching account meta is now an AccountSignerMeta.
+  print(updated.accounts![0] is AccountSignerMeta); // true
+}
+```
+
+### Attaching signers to transaction messages
+
+Use `addSignersToTransactionMessage` to attach signers to all instructions within a transaction message, and optionally to the fee payer.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+void main() {
+  final signer = generateKeyPairSigner();
+
+  final txMessage = TransactionMessage(
+    version: TransactionVersion.v0,
+    feePayer: signer.address,
+    instructions: [
+      Instruction(
+        programAddress: address('11111111111111111111111111111111'),
+        accounts: [
+          AccountMeta(
+            address: signer.address,
+            role: AccountRole.writableSigner,
+          ),
+        ],
+      ),
+    ],
+  );
+
+  // Attach signers to all matching account metas and the fee payer.
+  final updated = addSignersToTransactionMessage([signer], txMessage);
+
+  // The fee payer is now stored as a signer.
+  print(updated is TransactionMessageWithFeePayerSigner); // true
+}
+```
+
+### Setting a fee payer signer
+
+Use `setTransactionMessageFeePayerSigner` to set the fee payer of a transaction message to a signer object (rather than just an address).
+
+```dart
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+void main() {
+  final feePayer = generateKeyPairSigner();
+
+  final txMessage = TransactionMessage(
+    version: TransactionVersion.v0,
+  );
+
+  // Set the fee payer as a signer.
+  final withFeePayer = setTransactionMessageFeePayerSigner(
+    feePayer,
+    txMessage,
+  );
+
+  print(withFeePayer.feePayer?.value); // the fee payer's address
+}
+```
+
+### Signing a full transaction
+
+Once signers are attached to a transaction message, use the high-level signing functions to produce a signed transaction.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+Future<void> main() async {
+  final signer = generateKeyPairSigner();
+
+  // Build a transaction message with attached signers.
+  var txMessage = TransactionMessage(
+    version: TransactionVersion.v0,
+    instructions: [
+      Instruction(
+        programAddress: address('11111111111111111111111111111111'),
+        accounts: [
+          AccountMeta(
+            address: signer.address,
+            role: AccountRole.writableSigner,
+          ),
+        ],
+      ),
+    ],
+  );
+
+  // Set the fee payer signer and attach signers to instructions.
+  txMessage = setTransactionMessageFeePayerSigner(signer, txMessage);
+  txMessage = addSignersToTransactionMessage([signer], txMessage);
+
+  // Partially sign -- does not assert all signatures are present.
+  final partiallySigned = await partiallySignTransactionMessageWithSigners(
+    txMessage,
+  );
+  print('Partially signed: ${partiallySigned.signatures}');
+
+  // Fully sign -- asserts all required signatures are present.
+  final fullySigned = await signTransactionMessageWithSigners(txMessage);
+  print('Fully signed: ${fullySigned.signatures}');
+}
+```
+
+### Signing and sending a transaction
+
+Use `signAndSendTransactionMessageWithSigners` when your transaction message contains a `TransactionSendingSigner`. This function signs the transaction and immediately submits it to the network.
+
+```dart
+// Pseudocode -- requires a TransactionSendingSigner implementation
+// (e.g. a wallet adapter).
+//
+// final sendingSigner = myWalletSendingSigner;
+// final txMessage = setTransactionMessageFeePayerSigner(
+//   sendingSigner,
+//   transactionMessage,
+// );
+//
+// final txSignature = await signAndSendTransactionMessageWithSigners(
+//   txMessage,
+// );
+// print('Transaction signature: ${txSignature.value}');
+```
+
+### Deduplicating signers
+
+When composing transactions from multiple sources, you may end up with duplicate signer references. Use `deduplicateSigners` to remove duplicates by address.
+
+```dart
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+
+void main() {
+  final signer = generateKeyPairSigner();
+
+  // Same signer referenced multiple times -- deduplicated to one.
+  final deduplicated = deduplicateSigners([signer, signer, signer]);
+  print('Count: ${deduplicated.length}'); // 1
+
+  // Two different signers with the same address would throw SolanaError
+  // with code signerAddressCannotHaveMultipleSigners.
+}
+```
+
+### Type guards
+
+The package provides type guard functions for each signer interface.
+
+```dart
+import 'package:solana_kit_signers/solana_kit_signers.dart';
+
+void main() {
+  final signer = generateKeyPairSigner();
+
+  // Check signer interfaces.
+  print(isKeyPairSigner(signer)); // true
+  print(isMessagePartialSigner(signer)); // true
+  print(isTransactionPartialSigner(signer)); // true
+  print(isMessageModifyingSigner(signer)); // false
+  print(isTransactionModifyingSigner(signer)); // false
+  print(isTransactionSendingSigner(signer)); // false
+
+  // Composite checks.
+  print(isMessageSigner(signer)); // true (partial or modifying)
+  print(isTransactionSigner(signer)); // true (partial, modifying, or sending)
+
+  // Assert variants throw SolanaError on failure.
+  assertIsKeyPairSigner(signer);
+  assertIsMessagePartialSigner(signer);
+  assertIsTransactionPartialSigner(signer);
+}
+```
+
+## Signer interfaces
+
+The package defines five abstract signer interfaces. Implementations can mix and match these as needed.
+
+### Message signers
+
+| Interface | Method | Description |
+|-----------|--------|-------------|
+| `MessagePartialSigner` | `signMessages(List<SignableMessage>)` | Signs messages without modifying content. Parallel-safe. |
+| `MessageModifyingSigner` | `modifyAndSignMessages(List<SignableMessage>)` | May modify message content before signing. Must run sequentially, before partial signers. |
+
+### Transaction signers
+
+| Interface | Method | Description |
+|-----------|--------|-------------|
+| `TransactionPartialSigner` | `signTransactions(List<Transaction>)` | Signs transactions without modifying them. Parallel-safe. |
+| `TransactionModifyingSigner` | `modifyAndSignTransactions(List<Transaction>)` | May modify transactions before signing. Must run sequentially, before partial signers. |
+| `TransactionSendingSigner` | `signAndSendTransactions(List<Transaction>)` | Signs and immediately sends transactions. Only one per transaction. Must be the last signer. |
+
+## API Reference
+
+### Concrete signers
+
+| Export | Description |
+|--------|-------------|
+| `KeyPairSigner` | Implements `MessagePartialSigner` and `TransactionPartialSigner` using an Ed25519 `KeyPair`. |
+| `NoopSigner` | Implements `MessagePartialSigner` and `TransactionPartialSigner` returning empty signature maps. |
+
+### Signer factories
+
+| Function | Description |
+|----------|-------------|
+| `generateKeyPairSigner()` | Generates a random `KeyPairSigner`. |
+| `createSignerFromKeyPair(KeyPair)` | Creates a `KeyPairSigner` from an existing key pair. |
+| `createKeyPairSignerFromBytes(Uint8List)` | Creates a `KeyPairSigner` from a 64-byte array (32 private + 32 public). |
+| `createKeyPairSignerFromPrivateKeyBytes(Uint8List)` | Creates a `KeyPairSigner` from a 32-byte private key. |
+| `createNoopSigner(Address)` | Creates a `NoopSigner` for the given address. |
+
+### Message utilities
+
+| Export | Description |
+|--------|-------------|
+| `SignableMessage` | Class with `content` (`Uint8List`) and `signatures` (`Map<Address, SignatureBytes>`). |
+| `createSignableMessage(Object, [Map?])` | Creates a `SignableMessage` from a `String` or `Uint8List`, with optional existing signatures. |
+
+### Transaction signing
+
+| Function | Description |
+|----------|-------------|
+| `partiallySignTransactionMessageWithSigners(TransactionMessage)` | Extracts signers from the message and returns a partially signed `Transaction`. |
+| `signTransactionMessageWithSigners(TransactionMessage)` | Same as above but asserts all required signatures are present. |
+| `signAndSendTransactionMessageWithSigners(TransactionMessage)` | Signs and sends via the embedded `TransactionSendingSigner`. Returns `Future<SignatureBytes>`. |
+
+### Signer attachment
+
+| Function | Description |
+|----------|-------------|
+| `addSignersToInstruction(List<Object>, Instruction)` | Attaches signers to matching account metas of an instruction. |
+| `addSignersToTransactionMessage(List<Object>, TransactionMessage)` | Attaches signers to all instructions and the fee payer of a transaction message. |
+| `setTransactionMessageFeePayerSigner(Object, TransactionMessage)` | Sets the fee payer of a transaction message to a signer. |
+
+### Signer deduplication
+
+| Function | Description |
+|----------|-------------|
+| `deduplicateSigners<T>(List<T>)` | Removes duplicate signers by address. Throws if two distinct signers share an address. |
+
+### Type guards and assertions
+
+| Function | Description |
+|----------|-------------|
+| `isKeyPairSigner(Object?)` | Returns `true` if value is a `KeyPairSigner`. |
+| `isMessagePartialSigner(Object?)` | Returns `true` if value implements `MessagePartialSigner`. |
+| `isMessageModifyingSigner(Object?)` | Returns `true` if value implements `MessageModifyingSigner`. |
+| `isMessageSigner(Object?)` | Returns `true` if value is any message signer. |
+| `isTransactionPartialSigner(Object?)` | Returns `true` if value implements `TransactionPartialSigner`. |
+| `isTransactionModifyingSigner(Object?)` | Returns `true` if value implements `TransactionModifyingSigner`. |
+| `isTransactionSendingSigner(Object?)` | Returns `true` if value implements `TransactionSendingSigner`. |
+| `isTransactionSigner(Object?)` | Returns `true` if value is any transaction signer. |
+| `assertIsKeyPairSigner(Object?)` | Asserts value is a `KeyPairSigner`. Throws `SolanaError` on failure. |
+| `assertIsMessagePartialSigner(Object?)` | Asserts value implements `MessagePartialSigner`. |
+| `assertIsMessageModifyingSigner(Object?)` | Asserts value implements `MessageModifyingSigner`. |
+| `assertIsMessageSigner(Object?)` | Asserts value is any message signer. |
+| `assertIsTransactionPartialSigner(Object?)` | Asserts value implements `TransactionPartialSigner`. |
+| `assertIsTransactionModifyingSigner(Object?)` | Asserts value implements `TransactionModifyingSigner`. |
+| `assertIsTransactionSendingSigner(Object?)` | Asserts value implements `TransactionSendingSigner`. |
+| `assertIsTransactionSigner(Object?)` | Asserts value is any transaction signer. |
+
+### Configuration
+
+| Export | Description |
+|--------|-------------|
+| `SignerConfig` | Base configuration with an `aborted` flag for cancellation. |
+| `TransactionSignerConfig` | Extends `SignerConfig` with an optional `minContextSlot` for simulation. |
+
+### Advanced exports
+
+| Export | Description |
+|--------|-------------|
+| `AccountSignerMeta` | Extends `AccountMeta` to hold a signer reference alongside the account metadata. |
+| `TransactionMessageWithFeePayerSigner` | Extends `TransactionMessage` to store a signer as the fee payer. |
+| `getSignersFromInstruction(Instruction)` | Extracts and deduplicates signers from an instruction's account metas. |
+| `getSignersFromTransactionMessage(TransactionMessage)` | Extracts and deduplicates all signers from a transaction message. |
+| `isTransactionMessageWithSingleSendingSigner(TransactionMessage)` | Returns `true` if the message has exactly one `TransactionSendingSigner`. |
+| `assertIsTransactionMessageWithSingleSendingSigner(TransactionMessage)` | Asserts exactly one sending signer exists. |

--- a/packages/solana_kit_subscribable/readme.md
+++ b/packages/solana_kit_subscribable/readme.md
@@ -1,0 +1,241 @@
+# solana_kit_subscribable
+
+Subscribable and observable patterns for the Solana Kit Dart SDK -- a publish/subscribe event system with named channels, Dart `Stream` bridging, and event demultiplexing.
+
+This is the Dart port of [`@solana/subscribable`](https://github.com/anza-xyz/kit/tree/main/packages/subscribable) from the Solana TypeScript SDK.
+
+## Installation
+
+Add `solana_kit_subscribable` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_subscribable:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Creating a data publisher
+
+The `createDataPublisher()` factory returns a `WritableDataPublisher` that supports both subscribing to and publishing data on named channels.
+
+```dart
+import 'package:solana_kit_subscribable/solana_kit_subscribable.dart';
+
+void main() {
+  final publisher = createDataPublisher();
+
+  // Subscribe to the 'data' channel.
+  final unsubscribe = publisher.on('data', (message) {
+    print('Got message: $message');
+  });
+
+  // Publish a message.
+  publisher.publish('data', 'hello');
+  // Prints: Got message: hello
+
+  publisher.publish('data', 'world');
+  // Prints: Got message: world
+
+  // Unsubscribe -- idempotent and safe to call multiple times.
+  unsubscribe();
+
+  // This message is not received.
+  publisher.publish('data', 'ignored');
+}
+```
+
+### Multiple channels and subscribers
+
+A single publisher supports multiple named channels, and each channel can have multiple subscribers.
+
+```dart
+import 'package:solana_kit_subscribable/solana_kit_subscribable.dart';
+
+void main() {
+  final publisher = createDataPublisher();
+
+  // Subscribe to different channels.
+  publisher.on('message', (data) {
+    print('Message: $data');
+  });
+
+  publisher.on('error', (data) {
+    print('Error: $data');
+  });
+
+  publisher.on('message', (data) {
+    print('Also got: $data');
+  });
+
+  publisher.publish('message', 'hello');
+  // Prints:
+  //   Message: hello
+  //   Also got: hello
+
+  publisher.publish('error', 'something failed');
+  // Prints:
+  //   Error: something failed
+}
+```
+
+### Converting a data publisher to a Dart Stream
+
+The `createStreamFromDataPublisher` function bridges the `DataPublisher` pattern to Dart's native `Stream` API. It creates a broadcast stream that forwards messages from a data channel and errors from an error channel.
+
+```dart
+import 'package:solana_kit_subscribable/solana_kit_subscribable.dart';
+
+void main() {
+  final publisher = createDataPublisher();
+
+  final stream = createStreamFromDataPublisher<String>(
+    StreamFromDataPublisherConfig(
+      dataChannelName: 'notification',
+      dataPublisher: publisher,
+      errorChannelName: 'error',
+    ),
+  );
+
+  stream.listen(
+    (message) => print('Got: $message'),
+    onError: (Object error) => print('Error: $error'),
+  );
+
+  // Messages are forwarded to the stream.
+  publisher.publish('notification', 'update 1');
+  // Prints: Got: update 1
+
+  publisher.publish('notification', 'update 2');
+  // Prints: Got: update 2
+
+  // Errors are forwarded as stream errors.
+  publisher.publish('error', StateError('connection lost'));
+  // Prints: Error: Bad state: connection lost
+}
+```
+
+### Async iterable from a data publisher
+
+The `createAsyncIterableFromDataPublisher` function creates a single-subscription `Stream` that closely matches the TypeScript async iterable behavior. It supports abort signals for lifecycle control.
+
+```dart
+import 'dart:async';
+
+import 'package:solana_kit_subscribable/solana_kit_subscribable.dart';
+
+void main() async {
+  final publisher = createDataPublisher();
+  final abortCompleter = Completer<void>();
+
+  final stream = createAsyncIterableFromDataPublisher<String>(
+    dataPublisher: publisher,
+    dataChannelName: 'message',
+    errorChannelName: 'error',
+    abortSignal: abortCompleter.future,
+  );
+
+  // Publish some messages first (they will be queued until listened to).
+  publisher.publish('message', 'first');
+  publisher.publish('message', 'second');
+
+  // Listen with await for.
+  var count = 0;
+  await for (final message in stream) {
+    print('Got: $message');
+    count++;
+    if (count >= 2) {
+      abortCompleter.complete(); // Stop the stream.
+    }
+  }
+  // Prints:
+  //   Got: first
+  //   Got: second
+}
+```
+
+### Demultiplexing events
+
+The `demultiplexDataPublisher` function splits a single source channel into multiple derived channels using a message transformer. The source subscription is lazy -- it only starts when the first subscriber appears and stops when the last one unsubscribes.
+
+```dart
+import 'package:solana_kit_subscribable/solana_kit_subscribable.dart';
+
+void main() {
+  final sourcePublisher = createDataPublisher();
+
+  // Create a demultiplexed publisher that routes by subscriber ID.
+  final demuxed = demultiplexDataPublisher<Map<String, Object?>>(
+    sourcePublisher: sourcePublisher,
+    sourceChannelName: 'message',
+    messageTransformer: (message) {
+      final id = message['subscriberId'] as String;
+      return ('notification-for:$id', message);
+    },
+  );
+
+  // Subscribe to notifications for specific subscriber IDs.
+  final unsub1 = demuxed.on('notification-for:abc', (data) {
+    print('Subscriber abc got: $data');
+  });
+
+  demuxed.on('notification-for:xyz', (data) {
+    print('Subscriber xyz got: $data');
+  });
+
+  // Publish to the source -- messages are routed to the right subscribers.
+  sourcePublisher.publish('message', {
+    'subscriberId': 'abc',
+    'value': 42,
+  });
+  // Prints: Subscriber abc got: {subscriberId: abc, value: 42}
+
+  sourcePublisher.publish('message', {
+    'subscriberId': 'xyz',
+    'value': 99,
+  });
+  // Prints: Subscriber xyz got: {subscriberId: xyz, value: 99}
+
+  // When all subscribers unsubscribe, the source subscription is cancelled.
+  unsub1();
+}
+```
+
+## API Reference
+
+### Interfaces
+
+| Interface | Description |
+|-----------|-------------|
+| `DataPublisher` | Subscribe to named channels via `on(channelName, subscriber)`, which returns an `UnsubscribeFn`. |
+| `WritableDataPublisher` | Extends `DataPublisher` with `publish(channelName, data)` for emitting events. |
+
+### Factory functions
+
+| Function | Description |
+|----------|-------------|
+| `createDataPublisher()` | Creates a new `WritableDataPublisher` with named channel support. |
+| `createStreamFromDataPublisher<T>(config)` | Creates a broadcast `Stream<T>` from a `DataPublisher`. |
+| `createAsyncIterableFromDataPublisher<T>({...})` | Creates a single-subscription `Stream<T>` with abort signal support. |
+| `demultiplexDataPublisher<T>({sourcePublisher, sourceChannelName, messageTransformer})` | Splits one channel into many derived channels with lazy subscription and reference counting. |
+
+### Type aliases
+
+| Type | Description |
+|------|-------------|
+| `UnsubscribeFn` | `void Function()` -- returned by `on()` to unsubscribe a listener. |
+| `Subscriber<T>` | `void Function(T data)` -- a function that receives published data. |
+| `MessageTransformer<T>` | `(String, Object?)? Function(T)` -- transforms a source message into a channel/message pair, or `null` to drop. |
+
+### Configuration classes
+
+| Class | Description |
+|-------|-------------|
+| `StreamFromDataPublisherConfig` | Configuration for `createStreamFromDataPublisher`: `dataChannelName`, `dataPublisher`, `errorChannelName`. |

--- a/packages/solana_kit_sysvars/readme.md
+++ b/packages/solana_kit_sysvars/readme.md
@@ -1,0 +1,254 @@
+# solana_kit_sysvars
+
+System variable (sysvar) account access for the Solana Kit Dart SDK -- provides typed access to Solana runtime sysvar accounts like Clock, Rent, EpochSchedule, and more.
+
+This is the Dart port of [`@solana/sysvars`](https://github.com/anza-xyz/kit/tree/main/packages/sysvars) from the Solana TypeScript SDK.
+
+## Installation
+
+Add `solana_kit_sysvars` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_sysvars:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Sysvar addresses
+
+All Solana sysvar account addresses are available as `const Address` values.
+
+```dart
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+
+void main() {
+  print(sysvarClockAddress);
+  // Address('SysvarC1ock11111111111111111111111111111111')
+
+  print(sysvarRentAddress);
+  // Address('SysvarRent111111111111111111111111111111111')
+
+  print(sysvarEpochScheduleAddress);
+  // Address('SysvarEpochSchedu1e111111111111111111111111')
+
+  print(sysvarSlotHashesAddress);
+  // Address('SysvarS1otHashes111111111111111111111111111')
+
+  print(sysvarSlotHistoryAddress);
+  // Address('SysvarS1otHistory11111111111111111111111111')
+
+  print(sysvarStakeHistoryAddress);
+  // Address('SysvarStakeHistory1111111111111111111111111')
+
+  print(sysvarRecentBlockhashesAddress);
+  // Address('SysvarRecentB1ockHashes11111111111111111111')
+
+  print(sysvarInstructionsAddress);
+  // Address('Sysvar1nstructions1111111111111111111111111')
+
+  print(sysvarEpochRewardsAddress);
+  // Address('SysvarEpochRewards1111111111111111111111111')
+
+  print(sysvarLastRestartSlotAddress);
+  // Address('SysvarLastRestartS1ot1111111111111111111111')
+}
+```
+
+### Fetching the Clock sysvar
+
+The `Clock` sysvar contains data about the current slot, epoch, and Unix timestamp. It is updated every slot.
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  final clock = await fetchSysvarClock(rpc);
+  print('Current slot: ${clock.slot}');
+  print('Current epoch: ${clock.epoch}');
+  print('Unix timestamp: ${clock.unixTimestamp}');
+  print('Epoch start timestamp: ${clock.epochStartTimestamp}');
+  print('Leader schedule epoch: ${clock.leaderScheduleEpoch}');
+}
+```
+
+The `SysvarClock` class contains:
+
+```dart
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+
+void main() {
+  // Construct a SysvarClock value directly (e.g. for testing).
+  final clock = SysvarClock(
+    slot: BigInt.from(100),
+    epochStartTimestamp: BigInt.from(1700000000),
+    epoch: BigInt.from(5),
+    leaderScheduleEpoch: BigInt.from(6),
+    unixTimestamp: BigInt.from(1700001000),
+  );
+
+  print(clock.slot); // 100
+  print(clock.epoch); // 5
+}
+```
+
+### Fetching the Rent sysvar
+
+The `Rent` sysvar contains rent configuration for the cluster.
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  final rent = await fetchSysvarRent(rpc);
+  print('Lamports per byte-year: ${rent.lamportsPerByteYear}');
+  print('Exemption threshold: ${rent.exemptionThreshold} years');
+  print('Burn percent: ${rent.burnPercent}%');
+}
+```
+
+### Fetching the EpochSchedule sysvar
+
+The `EpochSchedule` sysvar includes the number of slots per epoch, leader schedule timing, and warmup information.
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  final schedule = await fetchSysvarEpochSchedule(rpc);
+  print('Slots per epoch: ${schedule.slotsPerEpoch}');
+  print('Leader schedule slot offset: ${schedule.leaderScheduleSlotOffset}');
+  print('Warmup: ${schedule.warmup}');
+  print('First normal epoch: ${schedule.firstNormalEpoch}');
+  print('First normal slot: ${schedule.firstNormalSlot}');
+}
+```
+
+### Fetching encoded sysvar accounts
+
+For sysvars that do not yet have a dedicated fetch function, or when you need the raw encoded bytes, use `fetchEncodedSysvarAccount`.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+
+Future<void> main() async {
+  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+  // Fetch the raw encoded data for any sysvar.
+  final maybeAccount = await fetchEncodedSysvarAccount(
+    rpc,
+    sysvarSlotHashesAddress,
+  );
+
+  switch (maybeAccount) {
+    case ExistingAccount<Uint8List>(:final account):
+      print('SlotHashes data: ${account.data.length} bytes');
+    case NonExistingAccount():
+      print('Sysvar account not found');
+  }
+}
+```
+
+### Using sysvar codecs
+
+Each sysvar type has encoder, decoder, and codec factory functions for binary serialization.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
+
+void main() {
+  // Encode a Clock sysvar value to bytes.
+  final encoder = getSysvarClockEncoder();
+  final clock = SysvarClock(
+    slot: BigInt.from(42),
+    epochStartTimestamp: BigInt.from(1700000000),
+    epoch: BigInt.from(5),
+    leaderScheduleEpoch: BigInt.from(6),
+    unixTimestamp: BigInt.from(1700001000),
+  );
+  final bytes = encoder.encode(clock);
+  print(bytes.length); // 40 (sysvarClockSize)
+
+  // Decode bytes back to a SysvarClock.
+  final decoder = getSysvarClockDecoder();
+  final (decoded, _) = decoder.read(bytes, 0);
+  print(decoded.slot); // 42
+
+  // Use the combined codec.
+  final codec = getSysvarClockCodec();
+  final roundTripped = codec.decode(codec.encode(clock));
+  print(roundTripped == clock); // true
+}
+```
+
+## API Reference
+
+### Sysvar addresses
+
+| Constant                         | Address                                       |
+| -------------------------------- | --------------------------------------------- |
+| `sysvarClockAddress`             | `SysvarC1ock11111111111111111111111111111111` |
+| `sysvarRentAddress`              | `SysvarRent111111111111111111111111111111111` |
+| `sysvarEpochScheduleAddress`     | `SysvarEpochSchedu1e111111111111111111111111` |
+| `sysvarEpochRewardsAddress`      | `SysvarEpochRewards1111111111111111111111111` |
+| `sysvarInstructionsAddress`      | `Sysvar1nstructions1111111111111111111111111` |
+| `sysvarLastRestartSlotAddress`   | `SysvarLastRestartS1ot1111111111111111111111` |
+| `sysvarRecentBlockhashesAddress` | `SysvarRecentB1ockHashes11111111111111111111` |
+| `sysvarSlotHashesAddress`        | `SysvarS1otHashes111111111111111111111111111` |
+| `sysvarSlotHistoryAddress`       | `SysvarS1otHistory11111111111111111111111111` |
+| `sysvarStakeHistoryAddress`      | `SysvarStakeHistory1111111111111111111111111` |
+
+### Sysvar types
+
+| Class                 | Fields                                                                                       |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| `SysvarClock`         | `slot`, `epochStartTimestamp`, `epoch`, `leaderScheduleEpoch`, `unixTimestamp`               |
+| `SysvarRent`          | `lamportsPerByteYear`, `exemptionThreshold`, `burnPercent`                                   |
+| `SysvarEpochSchedule` | `slotsPerEpoch`, `leaderScheduleSlotOffset`, `warmup`, `firstNormalEpoch`, `firstNormalSlot` |
+
+### Fetch functions
+
+| Function                                             | Description                                                                          |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `fetchSysvarClock(rpc, {config?})`                   | Fetches and decodes the Clock sysvar. Returns `Future<SysvarClock>`.                 |
+| `fetchSysvarRent(rpc, {config?})`                    | Fetches and decodes the Rent sysvar. Returns `Future<SysvarRent>`.                   |
+| `fetchSysvarEpochSchedule(rpc, {config?})`           | Fetches and decodes the EpochSchedule sysvar. Returns `Future<SysvarEpochSchedule>`. |
+| `fetchEncodedSysvarAccount(rpc, address, {config?})` | Fetches any sysvar as a `MaybeEncodedAccount`.                                       |
+
+### Codec functions
+
+| Sysvar        | Encoder                           | Decoder                           | Codec                           |
+| ------------- | --------------------------------- | --------------------------------- | ------------------------------- |
+| Clock         | `getSysvarClockEncoder()`         | `getSysvarClockDecoder()`         | `getSysvarClockCodec()`         |
+| Rent          | `getSysvarRentEncoder()`          | `getSysvarRentDecoder()`          | `getSysvarRentCodec()`          |
+| EpochSchedule | `getSysvarEpochScheduleEncoder()` | `getSysvarEpochScheduleDecoder()` | `getSysvarEpochScheduleCodec()` |
+
+### Size constants
+
+| Constant                  | Value | Description                                     |
+| ------------------------- | ----- | ----------------------------------------------- |
+| `sysvarClockSize`         | `40`  | Size of the Clock sysvar data in bytes.         |
+| `sysvarRentSize`          | `17`  | Size of the Rent sysvar data in bytes.          |
+| `sysvarEpochScheduleSize` | `33`  | Size of the EpochSchedule sysvar data in bytes. |

--- a/packages/solana_kit_test_matchers/readme.md
+++ b/packages/solana_kit_test_matchers/readme.md
@@ -1,0 +1,177 @@
+# solana_kit_test_matchers
+
+Custom test matchers for the Solana Kit Dart SDK -- provides assertion helpers for Solana errors, addresses, byte arrays, and transactions.
+
+This is an internal package (`publish_to: none`) used by other packages in the `solana_kit` monorepo for testing.
+
+## Installation
+
+Since this is an internal package, add it as a dev dependency referencing the local path:
+
+```yaml
+dev_dependencies:
+  solana_kit_test_matchers:
+```
+
+This package is not published to pub.dev.
+
+## Usage
+
+### Solana error matchers
+
+Match errors by code, code with context, or simply by type.
+
+```dart
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_test_matchers/solana_kit_test_matchers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('error has the expected code', () {
+    final error = SolanaError(SolanaErrorCode.blockHeightExceeded);
+    expect(error, isSolanaErrorWithCode(SolanaErrorCode.blockHeightExceeded));
+  });
+
+  test('error has the expected code and context', () {
+    final error = SolanaError(
+      SolanaErrorCode.accountsAccountNotFound,
+      {'address': '11111111111111111111111111111111'},
+    );
+
+    expect(
+      error,
+      isSolanaErrorWithCodeAndContext(
+        SolanaErrorCode.accountsAccountNotFound,
+        {'address': '11111111111111111111111111111111'},
+      ),
+    );
+  });
+
+  test('function throws a SolanaError with a specific code', () {
+    expect(
+      () => throw SolanaError(SolanaErrorCode.transactionFeePayerMissing),
+      throwsSolanaErrorWithCode(SolanaErrorCode.transactionFeePayerMissing),
+    );
+  });
+
+  test('value is any SolanaError', () {
+    final error = SolanaError(SolanaErrorCode.blockHeightExceeded);
+    expect(error, isSolanaErrorMatcher);
+  });
+
+  test('function throws any SolanaError', () {
+    expect(
+      () => throw SolanaError(SolanaErrorCode.blockHeightExceeded),
+      throwsSolanaError,
+    );
+  });
+}
+```
+
+### Address matchers
+
+Validate and compare Solana addresses in tests.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_test_matchers/solana_kit_test_matchers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('value is a valid Solana address', () {
+    final addr = address('11111111111111111111111111111111');
+    expect(addr, isValidSolanaAddress);
+  });
+
+  test('two addresses are equal', () {
+    final addr1 = address('11111111111111111111111111111111');
+    final addr2 = address('11111111111111111111111111111111');
+    expect(addr1, equalsAddress(addr2));
+  });
+}
+```
+
+### Byte array matchers
+
+Compare byte arrays, check lengths, and verify prefixes.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_test_matchers/solana_kit_test_matchers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('byte arrays are equal', () {
+    final expected = Uint8List.fromList([0x01, 0x02, 0x03]);
+    final actual = Uint8List.fromList([0x01, 0x02, 0x03]);
+    expect(actual, equalsBytes(expected));
+  });
+
+  test('byte array has the expected length', () {
+    final bytes = Uint8List(32);
+    expect(bytes, hasByteLength(32));
+  });
+
+  test('byte array starts with a prefix', () {
+    final bytes = Uint8List.fromList([0x01, 0x02, 0x03, 0x04, 0x05]);
+    final prefix = Uint8List.fromList([0x01, 0x02]);
+    expect(bytes, startsWithBytes(prefix));
+  });
+}
+```
+
+### Transaction matchers
+
+Verify transaction signature state.
+
+```dart
+import 'package:solana_kit_test_matchers/solana_kit_test_matchers.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Verify a transaction is fully signed (all signatures populated and non-zero).
+  // test('transaction is fully signed', () {
+  //   expect(signedTransaction, isFullySignedTransactionMatcher);
+  // });
+
+  // Verify a transaction has the expected number of signatures.
+  // test('transaction has 2 signatures', () {
+  //   expect(transaction, hasSignatureCount(2));
+  // });
+}
+```
+
+## API Reference
+
+### Solana error matchers
+
+| Matcher / Function | Description |
+|--------------------|-------------|
+| `isSolanaErrorWithCode(int code)` | Matches a `SolanaError` with the given error code. |
+| `throwsSolanaErrorWithCode(int code)` | Matches a function that throws a `SolanaError` with the given code. |
+| `isSolanaErrorWithCodeAndContext(int code, Map<String, Object?> context)` | Matches a `SolanaError` with the given code whose context contains the expected entries. |
+| `isSolanaErrorMatcher` | Matches any `SolanaError` instance. |
+| `throwsSolanaError` | Matches a function that throws any `SolanaError`. |
+
+### Address matchers
+
+| Matcher / Function | Description |
+|--------------------|-------------|
+| `isValidSolanaAddress` | Matches a value that is a valid Solana `Address`. |
+| `equalsAddress(Address expected)` | Matches an `Address` that equals the expected address. |
+
+### Byte array matchers
+
+| Matcher / Function | Description |
+|--------------------|-------------|
+| `equalsBytes(Uint8List expected)` | Matches a `Uint8List` that is byte-for-byte equal to the expected value. |
+| `hasByteLength(int length)` | Matches a `Uint8List` with the given length. |
+| `startsWithBytes(Uint8List prefix)` | Matches a `Uint8List` that starts with the given prefix bytes. |
+
+### Transaction matchers
+
+| Matcher / Function | Description |
+|--------------------|-------------|
+| `isFullySignedTransactionMatcher` | Matches a `Transaction` with all signatures populated and non-zero. |
+| `hasSignatureCount(int count)` | Matches a `Transaction` with exactly `count` signatures. |

--- a/packages/solana_kit_transaction_confirmation/readme.md
+++ b/packages/solana_kit_transaction_confirmation/readme.md
@@ -1,0 +1,295 @@
+# solana_kit_transaction_confirmation
+
+Transaction confirmation tracking for the Solana Kit Dart SDK -- provides multiple strategies to confirm or detect expiry of Solana transactions.
+
+This is the Dart port of [`@solana/transaction-confirmation`](https://github.com/anza-xyz/kit/tree/main/packages/transaction-confirmation) from the Solana TypeScript SDK.
+
+## Installation
+
+Add `solana_kit_transaction_confirmation` to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  solana_kit_transaction_confirmation:
+```
+
+Or, if you are using the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Strategy overview
+
+This package provides five confirmation strategies that can be composed together:
+
+1. **Recent Signature Confirmation** -- Watches for a signature to reach a target commitment level.
+2. **Block Height Exceedence** -- Detects when the network has progressed past the last valid block height for a transaction.
+3. **Nonce Invalidation** -- Detects when a durable nonce has been advanced, meaning the transaction has expired.
+4. **Timeout** -- A simple timeout-based fallback.
+5. **Strategy Racing** -- Races multiple strategies against each other, resolving with the first to complete.
+
+### Confirming a recent transaction (block height strategy)
+
+The recommended approach for confirming blockhash-based transactions is to race the signature confirmation against block height exceedence.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+
+Future<void> confirmTransaction(String signature) async {
+  final controller = AbortController();
+
+  // Create the signature confirmation factory.
+  // This watches the RPC for signature status updates.
+  final getRecentSignatureConfirmation =
+      createRecentSignatureConfirmationPromiseFactory(
+        RecentSignatureConfirmationConfig(
+          getSignatureStatuses: (sigs, {required abortSignal}) async {
+            // Call your RPC's getSignatureStatuses method.
+            // Return a list of SignatureStatus? (null if not found).
+            return [];
+          },
+          onSignatureNotification: (sig, {
+            required abortSignal,
+            required commitment,
+            required onNotification,
+          }) async {
+            // Subscribe to signatureNotifications via WebSocket.
+            // Call onNotification(err: null) when the signature is confirmed.
+          },
+        ),
+      );
+
+  // Create the block height exceedence factory.
+  // This monitors the network's block height and rejects when it exceeds
+  // the transaction's lastValidBlockHeight.
+  final getBlockHeightExceedence =
+      createBlockHeightExceedencePromiseFactory(
+        BlockHeightExceedenceConfig(
+          getEpochInfo: ({required abortSignal, commitment}) async {
+            // Call your RPC's getEpochInfo method.
+            return EpochInfo(
+              absoluteSlot: BigInt.from(100),
+              blockHeight: BigInt.from(90),
+            );
+          },
+          onSlotNotification: ({
+            required abortSignal,
+            required onNotification,
+          }) async {
+            // Subscribe to slotNotifications via WebSocket.
+          },
+        ),
+      );
+
+  // Wait for confirmation, racing against block height expiry.
+  await waitForRecentTransactionConfirmation(
+    abortSignal: controller.signal,
+    commitment: Commitment.confirmed,
+    getBlockHeightExceedencePromise: getBlockHeightExceedence,
+    getRecentSignatureConfirmationPromise: getRecentSignatureConfirmation,
+    lastValidBlockHeight: BigInt.from(200),
+    signature: signature,
+  );
+
+  print('Transaction confirmed!');
+}
+```
+
+### Confirming a durable nonce transaction
+
+For transactions using durable nonces, race signature confirmation against nonce invalidation.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+
+Future<void> confirmNonceTransaction({
+  required String signature,
+  required String nonceAccountAddress,
+  required String nonceValue,
+  required GetRecentSignatureConfirmationPromise getRecentSignatureConfirmation,
+}) async {
+  final controller = AbortController();
+
+  // Create the nonce invalidation factory.
+  // This monitors a nonce account and rejects when its value changes,
+  // indicating the transaction has expired.
+  final getNonceInvalidation =
+      createNonceInvalidationPromiseFactory(
+        NonceInvalidationConfig(
+          getNonceAccount: (address, {
+            required abortSignal,
+            required commitment,
+          }) async {
+            // Fetch and parse the nonce account data.
+            return NonceAccountInfo(nonceValue: 'current-nonce-value');
+          },
+          onAccountNotification: (address, {
+            required abortSignal,
+            required commitment,
+            required onNotification,
+          }) async {
+            // Subscribe to accountNotifications for the nonce account.
+          },
+        ),
+      );
+
+  // Wait for confirmation, racing against nonce invalidation.
+  await waitForDurableNonceTransactionConfirmation(
+    abortSignal: controller.signal,
+    commitment: Commitment.confirmed,
+    getNonceInvalidationPromise: getNonceInvalidation,
+    getRecentSignatureConfirmationPromise: getRecentSignatureConfirmation,
+    nonceAccountAddress: nonceAccountAddress,
+    nonceValue: nonceValue,
+    signature: signature,
+  );
+
+  print('Durable nonce transaction confirmed!');
+}
+```
+
+### Comparing commitment levels
+
+The `commitmentComparator` function (re-exported from `solana_kit_rpc_types`) enables comparing commitment levels.
+
+```dart
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+
+void main() {
+  // commitmentComparator returns:
+  //   < 0 if c1 is lower than c2
+  //   0 if c1 equals c2
+  //   > 0 if c1 is higher than c2
+
+  print(commitmentComparator(Commitment.finalized, Commitment.confirmed) > 0);
+  // true -- finalized is higher than confirmed
+
+  print(commitmentComparator(Commitment.processed, Commitment.confirmed) < 0);
+  // true -- processed is lower than confirmed
+
+  print(commitmentComparator(Commitment.confirmed, Commitment.confirmed) == 0);
+  // true -- same level
+}
+```
+
+### Racing custom strategies
+
+The `raceStrategies` function races a signature confirmation promise against a list of other strategy futures. The first to resolve or reject determines the outcome.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+
+Future<void> confirmWithCustomStrategy({
+  required String signature,
+  required GetRecentSignatureConfirmationPromise confirmationFactory,
+}) async {
+  final controller = AbortController();
+
+  // Race signature confirmation against both a timeout and a custom strategy.
+  await raceStrategies(
+    signature,
+    BaseTransactionConfirmationStrategyConfig(
+      abortSignal: controller.signal,
+      commitment: Commitment.confirmed,
+      getRecentSignatureConfirmationPromise: confirmationFactory,
+    ),
+    ({required AbortSignal abortSignal}) => [
+      getTimeoutPromise(
+        abortSignal: abortSignal,
+        commitment: Commitment.confirmed,
+      ),
+    ],
+  );
+
+  print('Transaction confirmed before timeout!');
+}
+```
+
+### Timeout strategy
+
+The `getTimeoutPromise` function provides a simple timeout-based fallback. It uses 30 seconds for `processed` commitment and 60 seconds otherwise.
+
+```dart
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:solana_kit_transaction_confirmation/solana_kit_transaction_confirmation.dart';
+
+Future<void> main() async {
+  final controller = AbortController();
+
+  try {
+    await getTimeoutPromise(
+      abortSignal: controller.signal,
+      commitment: Commitment.confirmed,
+    );
+  } on TimeoutException {
+    print('Transaction timed out after 60 seconds');
+  }
+}
+```
+
+## API Reference
+
+### Waiter functions
+
+| Function                                                  | Description                                                    |
+| --------------------------------------------------------- | -------------------------------------------------------------- |
+| `waitForRecentTransactionConfirmation({...})`             | Races signature confirmation against block height exceedence.  |
+| `waitForDurableNonceTransactionConfirmation({...})`       | Races signature confirmation against nonce invalidation.       |
+| `waitForRecentTransactionConfirmationUntilTimeout({...})` | _(Deprecated)_ Races signature confirmation against a timeout. |
+
+### Factory functions
+
+| Function                                                  | Description                                                                      |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `createRecentSignatureConfirmationPromiseFactory(config)` | Creates a function that resolves when a signature reaches a target commitment.   |
+| `createBlockHeightExceedencePromiseFactory(config)`       | Creates a function that rejects when block height exceeds the last valid height. |
+| `createNonceInvalidationPromiseFactory(config)`           | Creates a function that rejects when a durable nonce has been advanced.          |
+
+### Strategy functions
+
+| Function                                           | Description                                                         |
+| -------------------------------------------------- | ------------------------------------------------------------------- |
+| `raceStrategies(signature, config, getStrategies)` | Races a signature confirmation against specific strategies.         |
+| `getTimeoutPromise({abortSignal, commitment})`     | Returns a future that rejects after 30s (processed) or 60s (other). |
+
+### Comparators
+
+| Function                       | Description                                                            |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `commitmentComparator(c1, c2)` | Compares two `Commitment` levels. Returns negative, zero, or positive. |
+
+### Configuration classes
+
+| Class                                       | Description                                                                                              |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `RecentSignatureConfirmationConfig`         | Config: `getSignatureStatuses`, `onSignatureNotification`.                                               |
+| `BlockHeightExceedenceConfig`               | Config: `getEpochInfo`, `onSlotNotification`.                                                            |
+| `NonceInvalidationConfig`                   | Config: `getNonceAccount`, `onAccountNotification`.                                                      |
+| `BaseTransactionConfirmationStrategyConfig` | Base config for `raceStrategies`: `commitment`, `getRecentSignatureConfirmationPromise`, `abortSignal?`. |
+
+### Type aliases
+
+| Type                                    | Description                                                                                                                                                       |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GetRecentSignatureConfirmationPromise` | Function type for signature confirmation: `Future<void> Function({required AbortSignal abortSignal, required Commitment commitment, required String signature})`. |
+
+### Data classes
+
+| Class              | Description                                                     |
+| ------------------ | --------------------------------------------------------------- |
+| `SignatureStatus`  | Status of a transaction signature: `confirmationStatus`, `err`. |
+| `EpochInfo`        | Epoch info: `absoluteSlot`, `blockHeight`.                      |
+| `SlotNotification` | A slot notification: `slot`.                                    |
+| `NonceAccountInfo` | Nonce account info: `nonceValue`.                               |

--- a/packages/solana_kit_transaction_messages/readme.md
+++ b/packages/solana_kit_transaction_messages/readme.md
@@ -1,0 +1,272 @@
+# solana_kit_transaction_messages
+
+Build, compile, and decompile Solana transaction messages.
+
+This is the Dart port of [`@solana/transaction-messages`](https://github.com/anza-xyz/kit/tree/main/packages/transaction-messages) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_transaction_messages:
+```
+
+Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Creating a transaction message
+
+Transaction messages are built step by step using an immutable builder pattern. Each transform function returns a new `TransactionMessage` instance.
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+// Create an empty v0 transaction message.
+final message = createTransactionMessage(version: TransactionVersion.v0);
+```
+
+### Setting a fee payer
+
+Every transaction needs a fee payer -- the account that pays for the transaction processing fees.
+
+```dart
+final feePayer = Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu');
+final messageWithFeePayer = setTransactionMessageFeePayer(feePayer, message);
+```
+
+### Setting a blockhash lifetime
+
+A transaction must include a recent blockhash to be eligible for execution on the network. The transaction remains valid until the blockhash expires.
+
+```dart
+final messageWithLifetime = setTransactionMessageLifetimeUsingBlockhash(
+  BlockhashLifetimeConstraint(
+    blockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N',
+    lastValidBlockHeight: BigInt.from(300000),
+  ),
+  messageWithFeePayer,
+);
+```
+
+### Appending instructions
+
+Instructions can be appended or prepended to the transaction message.
+
+```dart
+import 'dart:typed_data';
+
+final transferInstruction = Instruction(
+  programAddress: Address('11111111111111111111111111111111'),
+  accounts: [
+    AccountMeta(
+      address: Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu'),
+      role: AccountRole.writableSigner,
+    ),
+    AccountMeta(
+      address: Address('GDhQoTpNbYUaCAjFKBMCPCdrCaKaLiSqhx5M7r4SrEFy'),
+      role: AccountRole.writable,
+    ),
+  ],
+  data: Uint8List.fromList([2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0]),
+);
+
+// Append a single instruction.
+final messageWithInstruction = appendTransactionMessageInstruction(
+  transferInstruction,
+  messageWithLifetime,
+);
+
+// Append multiple instructions at once.
+final messageWithInstructions = appendTransactionMessageInstructions(
+  [transferInstruction],
+  messageWithLifetime,
+);
+
+// Prepend an instruction to the beginning.
+final messageWithPrepended = prependTransactionMessageInstruction(
+  transferInstruction,
+  messageWithLifetime,
+);
+```
+
+### Building a full transaction message using the pipeline pattern
+
+The `pipe` extension (from `solana_kit_functional`) allows chaining transforms together in a readable pipeline:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_functional/solana_kit_functional.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+final myAddress = Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu');
+final recipient = Address('GDhQoTpNbYUaCAjFKBMCPCdrCaKaLiSqhx5M7r4SrEFy');
+
+final txMessage = createTransactionMessage(version: TransactionVersion.v0)
+    .pipe((m) => setTransactionMessageFeePayer(myAddress, m))
+    .pipe(
+      (m) => setTransactionMessageLifetimeUsingBlockhash(
+        BlockhashLifetimeConstraint(
+          blockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N',
+          lastValidBlockHeight: BigInt.from(300000),
+        ),
+        m,
+      ),
+    )
+    .pipe(
+      (m) => appendTransactionMessageInstruction(
+        Instruction(
+          programAddress: Address('11111111111111111111111111111111'),
+          accounts: [
+            AccountMeta(address: myAddress, role: AccountRole.writableSigner),
+            AccountMeta(address: recipient, role: AccountRole.writable),
+          ],
+          data: Uint8List.fromList([
+            2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0,
+          ]),
+        ),
+        m,
+      ),
+    );
+```
+
+### Durable nonce lifetime
+
+For transactions that must remain valid indefinitely (until the nonce is consumed), use a durable nonce lifetime instead of a blockhash:
+
+```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+final messageWithNonce = setTransactionMessageLifetimeUsingDurableNonce(
+  DurableNonceConfig(
+    nonce: '4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi',
+    nonceAccountAddress:
+        Address('8GsjzsJwQa2BbJxifoKpH5nUBJWigQqoBWWBy4VLVBCR'),
+    nonceAuthorityAddress:
+        Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu'),
+  ),
+  txMessage,
+);
+
+// This automatically prepends an AdvanceNonceAccount instruction.
+print(isTransactionMessageWithDurableNonceLifetime(messageWithNonce)); // true
+```
+
+### Compiling a transaction message
+
+Once the transaction message is fully built, compile it into a `CompiledTransactionMessage` suitable for encoding and execution:
+
+```dart
+final compiledMessage = compileTransactionMessage(txMessage);
+// compiledMessage contains: version, header, staticAccounts,
+// lifetimeToken, instructions, and addressTableLookups.
+```
+
+### Decompiling a transaction message
+
+You can reconstruct a `TransactionMessage` from a `CompiledTransactionMessage`. Because compilation is lossy, you may need to supply extra context:
+
+```dart
+final decompiled = decompileTransactionMessage(compiledMessage);
+
+// With extra context for address lookup tables and block height:
+final decompiledWithContext = decompileTransactionMessage(
+  compiledMessage,
+  DecompileTransactionMessageConfig(
+    lastValidBlockHeight: BigInt.from(300000),
+    addressesByLookupTableAddress: {
+      Address('4wBqpZM9msxygPoFDEBSm7BKZRXBT6DzChAZ87UMVGim'): [
+        Address('GDhQoTpNbYUaCAjFKBMCPCdrCaKaLiSqhx5M7r4SrEFy'),
+      ],
+    },
+  ),
+);
+```
+
+### Compressing with address lookup tables
+
+For v0 transactions, you can compress a transaction message by replacing non-signer accounts with address lookup table references:
+
+```dart
+final compressedMessage =
+    compressTransactionMessageUsingAddressLookupTables(
+  txMessage,
+  {
+    Address('4wBqpZM9msxygPoFDEBSm7BKZRXBT6DzChAZ87UMVGim'): [
+      Address('GDhQoTpNbYUaCAjFKBMCPCdrCaKaLiSqhx5M7r4SrEFy'),
+    ],
+  },
+);
+```
+
+### Checking lifetime types
+
+```dart
+// Blockhash lifetime.
+print(isTransactionMessageWithBlockhashLifetime(txMessage)); // true
+assertIsTransactionMessageWithBlockhashLifetime(txMessage);
+
+// Durable nonce lifetime.
+print(isTransactionMessageWithDurableNonceLifetime(messageWithNonce)); // true
+assertIsTransactionMessageWithDurableNonceLifetime(messageWithNonce);
+```
+
+## API Reference
+
+### Classes
+
+- **`TransactionMessage`** -- An immutable transaction message with `version`, `feePayer`, `instructions`, and `lifetimeConstraint`.
+- **`CompiledTransactionMessage`** -- A compiled message ready for wire encoding, with `header`, `staticAccounts`, `instructions`, `lifetimeToken`, and `addressTableLookups`.
+- **`MessageHeader`** -- Describes account roles in a compiled message (`numSignerAccounts`, `numReadonlySignerAccounts`, `numReadonlyNonSignerAccounts`).
+- **`CompiledInstruction`** -- A compiled instruction with `programAddressIndex`, `accountIndices`, and `data`.
+- **`AddressTableLookup`** -- An address table lookup with `lookupTableAddress`, `writableIndexes`, and `readonlyIndexes`.
+- **`DecompileTransactionMessageConfig`** -- Configuration for decompiling with `addressesByLookupTableAddress` and `lastValidBlockHeight`.
+- **`DurableNonceConfig`** -- Configuration for durable nonce lifetime with `nonce`, `nonceAccountAddress`, and `nonceAuthorityAddress`.
+
+### Enums
+
+- **`TransactionVersion`** -- `legacy` or `v0`.
+
+### Sealed classes
+
+- **`LifetimeConstraint`** -- Sealed base class.
+  - **`BlockhashLifetimeConstraint`** -- Blockhash-based lifetime with `blockhash` and `lastValidBlockHeight`.
+  - **`DurableNonceLifetimeConstraint`** -- Nonce-based lifetime with `nonce`.
+
+### Functions
+
+| Function | Description |
+| --- | --- |
+| `createTransactionMessage` | Creates a new empty transaction message with the given version. |
+| `setTransactionMessageFeePayer` | Returns a new message with the fee payer set. |
+| `setTransactionMessageLifetimeUsingBlockhash` | Returns a new message with a blockhash lifetime constraint. |
+| `setTransactionMessageLifetimeUsingDurableNonce` | Returns a new message with a durable nonce lifetime. |
+| `appendTransactionMessageInstruction` | Returns a new message with an instruction appended. |
+| `appendTransactionMessageInstructions` | Returns a new message with multiple instructions appended. |
+| `prependTransactionMessageInstruction` | Returns a new message with an instruction prepended. |
+| `prependTransactionMessageInstructions` | Returns a new message with multiple instructions prepended. |
+| `compileTransactionMessage` | Compiles a `TransactionMessage` into a `CompiledTransactionMessage`. |
+| `decompileTransactionMessage` | Reconstructs a `TransactionMessage` from a compiled message. |
+| `compressTransactionMessageUsingAddressLookupTables` | Replaces non-signer accounts with lookup table references. |
+| `isTransactionMessageWithBlockhashLifetime` | Returns `true` if the message has a blockhash lifetime. |
+| `assertIsTransactionMessageWithBlockhashLifetime` | Throws if the message does not have a blockhash lifetime. |
+| `isTransactionMessageWithDurableNonceLifetime` | Returns `true` if the message has a durable nonce lifetime. |
+| `assertIsTransactionMessageWithDurableNonceLifetime` | Throws if the message does not have a durable nonce lifetime. |
+| `getCompiledTransactionMessageEncoder` | Returns an encoder for compiled transaction messages. |
+| `getCompiledTransactionMessageDecoder` | Returns a decoder for compiled transaction messages. |
+| `getCompiledTransactionMessageCodec` | Returns a codec for compiled transaction messages. |
+
+### Constants
+
+- **`maxSupportedTransactionVersion`** -- The maximum supported transaction version (currently `0`).

--- a/packages/solana_kit_transactions/readme.md
+++ b/packages/solana_kit_transactions/readme.md
@@ -1,0 +1,229 @@
+# solana_kit_transactions
+
+Compile, sign, encode, and decode Solana transactions.
+
+This is the Dart port of [`@solana/transactions`](https://github.com/anza-xyz/kit/tree/main/packages/transactions) from the Solana TypeScript SDK.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_transactions:
+```
+
+Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+
+```yaml
+dependencies:
+  solana_kit:
+```
+
+## Usage
+
+### Compiling a transaction
+
+A `Transaction` is compiled from a `TransactionMessage` that has a fee payer and a lifetime constraint. The compiled transaction includes the wire-format message bytes and a signatures map with `null` entries for each required signer.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+final myAddress = Address('mpngsFd4tmbUfzDYJayjKZwZcaR7aWb2793J6grLsGu');
+
+// Build a transaction message (see solana_kit_transaction_messages).
+final txMessage = TransactionMessage(
+  version: TransactionVersion.v0,
+  feePayer: myAddress,
+  instructions: [
+    Instruction(
+      programAddress: Address('11111111111111111111111111111111'),
+      accounts: [
+        AccountMeta(address: myAddress, role: AccountRole.writableSigner),
+        AccountMeta(
+          address: Address('GDhQoTpNbYUaCAjFKBMCPCdrCaKaLiSqhx5M7r4SrEFy'),
+          role: AccountRole.writable,
+        ),
+      ],
+      data: Uint8List.fromList([2, 0, 0, 0, 0, 202, 154, 59, 0, 0, 0, 0]),
+    ),
+  ],
+  lifetimeConstraint: BlockhashLifetimeConstraint(
+    blockhash: 'EkSnNWid2cvwEVnVx9aBqawnmiCNiDgp3gUdkDPTKN1N',
+    lastValidBlockHeight: BigInt.from(300000),
+  ),
+);
+
+// Compile the message into a transaction. Signatures are initially null.
+final transaction = compileTransaction(txMessage);
+print(transaction.signatures); // {Address('mpngs...'): null}
+```
+
+### Signing transactions
+
+Sign a transaction with one or more `KeyPair` objects. Use `signTransaction` to sign and assert all required signatures are present, or `partiallySignTransaction` when you only have a subset of signers.
+
+```dart
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+Future<void> main() async {
+  // Generate an Ed25519 key pair for the fee payer.
+  final keyPair = await generateKeyPair();
+
+  // Sign the transaction (throws if not all signers are provided).
+  final signedTx = await signTransaction([keyPair], transaction);
+
+  // Or partially sign (does not require all signers).
+  final partiallySigned = await partiallySignTransaction(
+    [keyPair],
+    transaction,
+  );
+
+  // Check if a transaction is fully signed.
+  print(isFullySignedTransaction(signedTx)); // true
+}
+```
+
+### Getting the transaction signature
+
+The transaction signature (also called the transaction ID) is the fee payer's signature:
+
+```dart
+final signature = getSignatureFromTransaction(signedTx);
+print(signature); // The base58-encoded transaction signature.
+```
+
+### Checking the transaction size
+
+Solana transactions must fit within 1232 bytes (the MTU minus network header overhead). This package provides helpers to check and assert size constraints:
+
+```dart
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+// Get the size in bytes of a compiled transaction.
+final size = getTransactionSize(transaction);
+print(size);
+
+// Check against the 1232-byte limit.
+print(isTransactionWithinSizeLimit(transaction)); // true or false
+
+// Throws SolanaError if the transaction exceeds the size limit.
+assertIsTransactionWithinSizeLimit(transaction);
+
+// You can also check the size directly from a TransactionMessage,
+// which compiles it internally.
+final messageSize = getTransactionMessageSize(txMessage);
+print(isTransactionMessageWithinSizeLimit(txMessage));
+```
+
+### Encoding and decoding transactions
+
+Use codecs to convert transactions to and from their wire format:
+
+```dart
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+void main() {
+  // Encode a transaction to bytes (wire format).
+  final encoder = getTransactionEncoder();
+  final wireBytes = encoder.encode(signedTx);
+
+  // Decode a transaction from wire bytes.
+  final decoder = getTransactionDecoder();
+  final (decodedTx, _) = decoder.read(wireBytes, 0);
+
+  // Or use the combined codec.
+  final codec = getTransactionCodec();
+  final roundTripped = codec.decode(codec.encode(signedTx));
+}
+```
+
+### Getting a base64 wire transaction
+
+For sending transactions via RPC, you typically need the base64-encoded wire transaction:
+
+```dart
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+void main() {
+  final base64Wire = getBase64EncodedWireTransaction(signedTx);
+  print(base64Wire); // Base64-encoded string ready for sendTransaction RPC.
+}
+```
+
+### Sendable transaction checks
+
+A transaction is sendable if it is fully signed and within the size limit:
+
+```dart
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+void main() {
+  print(isSendableTransaction(signedTx)); // true
+
+  // Throws if not sendable.
+  assertIsSendableTransaction(signedTx);
+}
+```
+
+### Transaction lifetime constraints
+
+Transactions carry lifetime metadata. This package provides types and checkers for both blockhash and durable nonce lifetimes:
+
+```dart
+import 'package:solana_kit_transactions/solana_kit_transactions.dart';
+
+void main() {
+  // Check blockhash lifetime.
+  print(isTransactionWithBlockhashLifetime(transaction)); // true
+
+  // Check durable nonce lifetime.
+  print(isTransactionWithDurableNonceLifetime(transaction)); // false
+}
+```
+
+## API Reference
+
+### Classes
+
+- **`Transaction`** -- A compiled transaction with `messageBytes` and `signatures` map.
+- **`TransactionWithLifetime`** -- Extends `Transaction` with a `lifetimeConstraint` (either `TransactionBlockhashLifetime` or `TransactionDurableNonceLifetime`).
+- **`TransactionBlockhashLifetime`** -- Blockhash-based lifetime with `blockhash` and `lastValidBlockHeight`.
+- **`TransactionDurableNonceLifetime`** -- Durable nonce lifetime with `nonce` and `nonceAccountAddress`.
+
+### Functions
+
+| Function                                      | Description                                                        |
+| --------------------------------------------- | ------------------------------------------------------------------ |
+| `compileTransaction`                          | Compiles a `TransactionMessage` into a `TransactionWithLifetime`.  |
+| `signTransaction`                             | Signs a transaction and asserts it is fully signed.                |
+| `partiallySignTransaction`                    | Signs a transaction with a subset of required signers.             |
+| `isFullySignedTransaction`                    | Returns `true` if all signers have provided signatures.            |
+| `assertIsFullySignedTransaction`              | Throws if any signer signature is missing.                         |
+| `getSignatureFromTransaction`                 | Returns the fee payer's signature (the transaction ID).            |
+| `getTransactionSize`                          | Returns the encoded size in bytes.                                 |
+| `isTransactionWithinSizeLimit`                | Returns `true` if the transaction fits within 1232 bytes.          |
+| `assertIsTransactionWithinSizeLimit`          | Throws if the transaction exceeds the size limit.                  |
+| `getTransactionMessageSize`                   | Returns the compiled transaction size from a `TransactionMessage`. |
+| `isTransactionMessageWithinSizeLimit`         | Returns `true` if the compiled message fits within the limit.      |
+| `assertIsTransactionMessageWithinSizeLimit`   | Throws if the compiled message exceeds the limit.                  |
+| `isSendableTransaction`                       | Returns `true` if fully signed and within size limit.              |
+| `assertIsSendableTransaction`                 | Throws if the transaction is not sendable.                         |
+| `getTransactionEncoder`                       | Returns a wire-format encoder for `Transaction`.                   |
+| `getTransactionDecoder`                       | Returns a wire-format decoder for `Transaction`.                   |
+| `getTransactionCodec`                         | Returns a combined encoder/decoder codec.                          |
+| `getBase64EncodedWireTransaction`             | Returns a base64-encoded wire transaction string.                  |
+| `isTransactionWithBlockhashLifetime`          | Returns `true` if the transaction has a blockhash lifetime.        |
+| `assertIsTransactionWithBlockhashLifetime`    | Throws if the transaction does not have a blockhash lifetime.      |
+| `isTransactionWithDurableNonceLifetime`       | Returns `true` if the transaction has a durable nonce lifetime.    |
+| `assertIsTransactionWithDurableNonceLifetime` | Throws if the transaction does not have a durable nonce lifetime.  |
+
+### Constants
+
+- **`transactionPacketSize`** -- Maximum network packet size: `1280` bytes.
+- **`transactionPacketHeader`** -- Network header overhead: `48` bytes (IPv6 + fragment header).
+- **`transactionSizeLimit`** -- Maximum transaction content size: `1232` bytes.

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,25 @@
 
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 
-A Dart port of the [Solana TypeScript SDK](https://github.com/anza-xyz/kit) (`@solana/kit`). This monorepo contains ~37 packages that mirror the upstream TS package structure, built with modern Dart 3.10+ features.
+A Dart port of the [Solana TypeScript SDK](https://github.com/anza-xyz/kit) (`@solana/kit`). This monorepo contains 37 packages that mirror the upstream TS package structure, built with modern Dart 3.10+ features including sealed classes, extension types, records, and patterns.
+
+## Quick Start
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+// Create an RPC client
+final rpc = createSolanaRpc('https://api.mainnet-beta.solana.com');
+
+// Generate a key pair
+final keyPair = await generateKeyPair();
+
+// Create and send a transaction
+final message = createTransactionMessage()
+  .pipe(setTransactionMessageFeePayer(keyPair.address))
+  .pipe(setTransactionMessageLifetimeUsingBlockhash(blockhash))
+  .pipe(appendTransactionMessageInstruction(instruction));
+```
 
 ## Getting Started
 
@@ -46,27 +64,550 @@ fix:all
 
 ## Packages
 
-| Package                             | Description                         |
-| ----------------------------------- | ----------------------------------- |
-| `solana_kit`                        | Umbrella re-exporting all packages  |
-| `solana_kit_errors`                 | Error codes and SolanaError class   |
-| `solana_kit_addresses`              | Base58 address utilities            |
-| `solana_kit_keys`                   | Key pair and Ed25519 operations     |
-| `solana_kit_codecs`                 | Umbrella for all codec sub-packages |
-| `solana_kit_codecs_core`            | Core codec interfaces               |
-| `solana_kit_codecs_numbers`         | Numeric codecs                      |
-| `solana_kit_codecs_strings`         | String codecs                       |
-| `solana_kit_codecs_data_structures` | Struct, enum, tuple codecs          |
-| `solana_kit_rpc`                    | Primary RPC client                  |
-| `solana_kit_rpc_subscriptions`      | Subscription client                 |
-| `solana_kit_transactions`           | Transaction compilation and signing |
-| `solana_kit_transaction_messages`   | Building transaction messages       |
-| `solana_kit_signers`                | Signer interfaces                   |
-| `solana_kit_accounts`               | Account fetching and decoding       |
-| `solana_kit_programs`               | Program utilities                   |
-| `solana_kit_functional`             | Pipe, compose utilities             |
-| `solana_kit_options`                | Rust-like Option type codec         |
-| ...and more                         | See `packages/` directory           |
+The SDK is organized into 37 packages under `packages/`. Most users only need the umbrella package `solana_kit`, but each sub-package can be imported independently for smaller dependency footprints.
+
+### Umbrella Packages
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit`](#solana_kit) | Single import for the entire SDK. Re-exports all public packages. |
+| [`solana_kit_codecs`](#solana_kit_codecs) | Single import for all codec functionality. Re-exports all codec sub-packages. |
+
+### Error Handling
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_errors`](#solana_kit_errors) | Foundation package. Defines `SolanaError`, numeric error codes, and structured error context used by every other package. |
+
+### Addresses & Keys
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_addresses`](#solana_kit_addresses) | Base58-encoded Solana addresses, validation, program-derived addresses (PDAs), and address comparison. |
+| [`solana_kit_keys`](#solana_kit_keys) | Ed25519 key pair generation, private/public key types, and signature creation. |
+| [`solana_kit_signers`](#solana_kit_signers) | Signer interfaces: message signers, transaction signers, fee payer signers, modifying signers, and key pair signers. |
+
+### Codecs (Binary Serialization)
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_codecs_core`](#solana_kit_codecs_core) | Core `Codec<T>`, `Encoder<T>`, and `Decoder<T>` interfaces with composition utilities (size prefixing, padding, sentinels, offsets). |
+| [`solana_kit_codecs_numbers`](#solana_kit_codecs_numbers) | Numeric codecs: `u8`–`u128`, `i8`–`i128`, `f32`, `f64`, and `shortU16` in little-endian format. |
+| [`solana_kit_codecs_strings`](#solana_kit_codecs_strings) | String codecs: `base10`, `base16`, `base58`, `base64`, `utf8`, and generic `baseX` encoding. |
+| [`solana_kit_codecs_data_structures`](#solana_kit_codecs_data_structures) | Composite codecs: `struct`, `array`, `tuple`, `union`, `map`, `set`, `boolean`, `nullable`, `bytes`, and `bitArray`. |
+| [`solana_kit_options`](#solana_kit_options) | Rust-style `Option<T>` type with `Some`/`None` variants and a dedicated codec for on-chain optional fields. |
+
+### Instructions & Transactions
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_instructions`](#solana_kit_instructions) | Core `Instruction` and `AccountMeta` types with account role definitions (signer, writable, readonly). |
+| [`solana_kit_transaction_messages`](#solana_kit_transaction_messages) | Build and compile transaction messages with support for v0 messages, address table lookups, blockhash lifetimes, and durable nonces. |
+| [`solana_kit_transactions`](#solana_kit_transactions) | Transaction compilation, signature collection, wire-format encoding, and size calculation. |
+| [`solana_kit_offchain_messages`](#solana_kit_offchain_messages) | Off-chain message signing with envelope formatting, domain specifications, and signatory tracking. |
+| [`solana_kit_instruction_plans`](#solana_kit_instruction_plans) | Plan multi-step operations as sequential or parallel instruction trees, then execute them as batched transactions. |
+
+### RPC Client
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_rpc`](#solana_kit_rpc) | High-level RPC client factory with request coalescing, deduplication, and default configuration. The main entry point for RPC calls. |
+| [`solana_kit_rpc_api`](#solana_kit_rpc_api) | Type-safe definitions for all ~60 Solana JSON-RPC methods (`getAccountInfo`, `getBalance`, `sendTransaction`, etc.). |
+| [`solana_kit_rpc_types`](#solana_kit_rpc_types) | Shared types: `AccountInfo`, `Commitment`, `Lamports`, `TokenAmount`, `ClusterUrl`, `RpcResponse<T>`, and encoding helpers. |
+| [`solana_kit_rpc_spec`](#solana_kit_rpc_spec) | Core JSON-RPC 2.0 protocol: `Rpc`, `RpcApi`, and `RpcTransport` interfaces. |
+| [`solana_kit_rpc_spec_types`](#solana_kit_rpc_spec_types) | Low-level RPC protocol types: `RpcRequest`, `RpcResponse<T>`, `RpcMessage`, and `JsonBigInt`. |
+| [`solana_kit_rpc_parsed_types`](#solana_kit_rpc_parsed_types) | Typed representations of parsed account data for token, stake, vote, config, nonce, and other native program accounts. |
+| [`solana_kit_rpc_transformers`](#solana_kit_rpc_transformers) | Request/response transformation middleware: default commitment injection, BigInt handling, integer overflow detection, and error throwing. |
+| [`solana_kit_rpc_transport_http`](#solana_kit_rpc_transport_http) | HTTP transport implementation for RPC communication using the `http` package. |
+
+### RPC Subscriptions
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_rpc_subscriptions`](#solana_kit_rpc_subscriptions) | High-level subscription client factory with connection pooling, auto-ping, and subscription coalescing. |
+| [`solana_kit_rpc_subscriptions_api`](#solana_kit_rpc_subscriptions_api) | Type-safe definitions for all Solana subscription methods (`accountNotifications`, `slotNotifications`, `logsNotifications`, etc.). |
+| [`solana_kit_rpc_subscriptions_channel_websocket`](#solana_kit_rpc_subscriptions_channel_websocket) | WebSocket transport for RPC subscriptions using `web_socket_channel`. |
+| [`solana_kit_subscribable`](#solana_kit_subscribable) | Observable data publisher pattern with conversions to Dart `Stream` and async iterables. |
+
+### Accounts & Programs
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_accounts`](#solana_kit_accounts) | Fetch, decode, and parse on-chain account data with typed `Account<T>` and `MaybeAccount<T>` wrappers. |
+| [`solana_kit_programs`](#solana_kit_programs) | Program error handling utilities: `ProgramError` representation and program-specific error detection. |
+| [`solana_kit_program_client_core`](#solana_kit_program_client_core) | Core utilities for building typed program clients: instruction input resolution and self-fetching account helpers. |
+| [`solana_kit_sysvars`](#solana_kit_sysvars) | Type-safe access to Solana sysvars: `Clock`, `Rent`, `EpochSchedule`, `SlotHashes`, `StakeHistory`, and more. |
+
+### Transaction Confirmation
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_transaction_confirmation`](#solana_kit_transaction_confirmation) | Multiple confirmation strategies: block height polling, nonce invalidation, signature watching, timeout, and strategy racing. |
+
+### Utilities
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_functional`](#solana_kit_functional) | Adds a `.pipe()` extension for functional pipeline composition, used throughout the SDK for building transaction messages. |
+| [`solana_kit_fast_stable_stringify`](#solana_kit_fast_stable_stringify) | Deterministic JSON serialization with sorted keys, used for request deduplication and hashing. |
+
+### Internal (Not Published)
+
+| Package | Description |
+| --- | --- |
+| [`solana_kit_lints`](#solana_kit_lints) | Shared lint rules based on `very_good_analysis` used across the monorepo. |
+| [`solana_kit_test_matchers`](#solana_kit_test_matchers) | Custom test matchers for addresses, byte arrays, error codes, and transaction assertions. |
+
+## Package Details
+
+### solana_kit
+
+The umbrella package. Import this one package to get access to the entire SDK:
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+```
+
+Re-exports all public sub-packages with namespace conflict resolution. Ideal for applications that use multiple SDK features. Use individual sub-packages instead when you want to minimize transitive dependencies.
+
+### solana_kit_errors
+
+The foundation of the SDK's error handling. Every other package depends on this. Provides:
+
+- `SolanaError` — a structured error class carrying a numeric code and contextual data
+- `SolanaErrorCode` — an abstract final class with `static const int` codes covering addresses, codecs, keys, RPC, instructions, transactions, signers, and more
+- `isSolanaError()` — a type guard for checking error codes
+
+Exists because: Solana operations fail in many specific ways (invalid addresses, encoding mismatches, RPC errors, signing failures). Structured error codes let calling code handle failures precisely rather than parsing error message strings.
+
+### solana_kit_addresses
+
+Handles Solana's base58-encoded 32-byte addresses:
+
+- `Address` — a zero-overhead extension type wrapping a validated base58 string
+- `address()` — factory that validates and creates addresses
+- `ProgramDerivedAddress` — PDA generation from seeds and program IDs
+- `AddressCodec` — base58 encoding/decoding for wire formats
+
+Exists because: Addresses are the most fundamental Solana primitive. Encoding them as an extension type catches invalid addresses at construction time with zero runtime cost, and PDA derivation is needed for interacting with most Solana programs.
+
+### solana_kit_keys
+
+Ed25519 key pair operations:
+
+- `KeyPair` — holds a 32-byte private key and public key
+- `generateKeyPair()` — cryptographically secure random key generation
+- `createKeyPairFromBytes()` — reconstruct from a 64-byte seed
+- Signature creation and verification
+
+Exists because: Every transaction on Solana requires Ed25519 signatures. This package wraps the `ed25519_edwards` library with Solana-specific key formats and validation.
+
+### solana_kit_signers
+
+Defines a hierarchy of signer interfaces:
+
+- `MessagePartialSigner` / `TransactionPartialSigner` — sign without needing all signatures
+- `TransactionSendingSigner` — signs and submits in one step
+- `MessageModifyingSigner` / `TransactionModifyingSigner` — can alter content before signing (for wallets that add metadata)
+- `KeyPairSigner` — concrete signer backed by a `KeyPair`
+- `NoopSigner` — placeholder for addresses that will be signed externally
+
+Exists because: Solana transactions can require multiple signers with different capabilities. A hardware wallet signs differently from an in-memory key pair, and a custodial service may need to modify the transaction before signing. The interface hierarchy captures these real-world signing patterns.
+
+### solana_kit_codecs_core
+
+The codec framework's foundation:
+
+- `Codec<T>` — generic encoder + decoder pair
+- `FixedSizeCodec<T>` / `VariableSizeCodec<T>` — size-aware variants
+- Composition: `addCodecSizePrefix()`, `addCodecSentinel()`, `offsetCodec()`, `fixCodecSize()`, `padCodec()`, `reverseCodec()`, `transformCodec()`
+
+Exists because: Solana's on-chain data is binary. A composable codec system lets you describe complex layouts declaratively (e.g., "a u32 length prefix followed by N structs") rather than hand-writing byte manipulation.
+
+### solana_kit_codecs_numbers
+
+Numeric codecs for all integer and float widths:
+
+- Unsigned: `u8`, `u16`, `u32`, `u64`, `u128`
+- Signed: `i8`, `i16`, `i32`, `i64`, `i128`
+- Floats: `f32`, `f64`
+- `shortU16` — Solana's compact u16 encoding used in transaction headers
+
+All use little-endian byte order, matching Solana's on-chain format.
+
+Exists because: On-chain data uses fixed-width integers at specific byte offsets. These codecs handle endianness, overflow detection, and BigInt support for values exceeding 64 bits.
+
+### solana_kit_codecs_strings
+
+String and base encoding codecs:
+
+- `base58` — Solana addresses and transaction signatures
+- `base64` — account data in RPC responses
+- `base16` — hex encoding
+- `base10` — decimal string encoding
+- `utf8` — UTF-8 text encoding
+- `baseX()` / `baseXReslice()` — generic base-N encoding
+
+Exists because: Solana uses multiple string encodings across its APIs. Base58 for addresses, base64 for account data, hex for debugging. Having them as composable codecs means they integrate with the rest of the codec system.
+
+### solana_kit_codecs_data_structures
+
+High-level composite codecs:
+
+- `struct()` — named fields, like a C struct
+- `array()` — fixed or variable-length arrays
+- `tuple()` — ordered unnamed fields
+- `union()` / `discriminatedUnion()` — tagged variants (Rust enums)
+- `map()` / `set()` — collection types
+- `boolean`, `nullable()`, `bytes`, `bitArray()`, `unit`, `constant()`
+
+Exists because: On-chain program data is structured as structs, enums, and arrays. These codecs let you describe Solana account layouts and instruction data as composable type-safe definitions.
+
+### solana_kit_options
+
+Rust-style `Option<T>` type with codec support:
+
+- `Option<T>` — sealed class with `Some<T>` and `None` variants
+- `OptionCodec<T>` — encodes as a discriminator byte (0/1) followed by the value
+- `unwrapOption()` / `unwrapOptionRecursively()` — extraction helpers
+
+Exists because: Solana programs written in Rust serialize `Option<T>` as a 1-byte discriminator followed by the value. This codec faithfully represents that layout so Dart code can read and write optional on-chain fields correctly.
+
+### solana_kit_codecs
+
+Umbrella package that re-exports:
+- `solana_kit_codecs_core`
+- `solana_kit_codecs_numbers`
+- `solana_kit_codecs_strings`
+- `solana_kit_codecs_data_structures`
+- `solana_kit_options`
+
+Exists because: Codec work typically requires types from multiple sub-packages. This single import avoids managing five separate imports.
+
+### solana_kit_instructions
+
+Core instruction types:
+
+- `Instruction` — a program ID, list of account metas, and binary data
+- `AccountMeta` — an account's address, signer status, and writability
+- Account roles: `isSigner`, `isWritable`, and their combinations
+
+Exists because: Instructions are the atomic unit of Solana computation. Every interaction with a program — transferring SOL, creating accounts, invoking DeFi protocols — is an instruction. This package defines the types that all higher-level packages build upon.
+
+### solana_kit_transaction_messages
+
+Transaction message construction:
+
+- `createTransactionMessage()` — start a new message
+- `setTransactionMessageFeePayer()` — set who pays
+- `setTransactionMessageLifetimeUsingBlockhash()` — set expiry
+- `appendTransactionMessageInstruction()` — add instructions
+- `compileTransactionMessage()` — compile to wire format
+- Support for v0 messages with address table lookups and durable nonce lifetimes
+
+Exists because: Building a Solana transaction requires assembling a fee payer, lifetime, and instructions into a specific binary format. This package provides a pipeline-friendly API that catches errors (missing fee payer, duplicate accounts) at compile time.
+
+### solana_kit_transactions
+
+Transaction compilation and encoding:
+
+- `compileTransaction()` — produce a `Transaction` from a compiled message
+- `TransactionCodec` — wire-format serialization
+- `transactionSize()` — calculate byte size (important for Solana's 1232-byte limit)
+- Signature slot management
+
+Exists because: Compiled transactions need signatures attached and must be serialized to a specific wire format for submission. Size calculation is critical since Solana rejects oversized transactions.
+
+### solana_kit_offchain_messages
+
+Off-chain message signing:
+
+- `Envelope` — wraps a message with domain and signatory metadata
+- `compileEnvelope()` — compile into signable bytes
+- Domain specifications for application and signing contexts
+
+Exists because: Solana's off-chain message signing standard lets wallets sign arbitrary messages for authentication, proof-of-ownership, and other non-transaction use cases without risking accidental transaction submission.
+
+### solana_kit_instruction_plans
+
+Multi-step transaction planning:
+
+- `InstructionPlan` — tree of sequential and parallel instruction groups
+- `TransactionPlanner` — splits plans into optimally-batched transactions
+- `TransactionPlanExecutor` — executes plans with signing and submission
+
+Exists because: Complex operations (e.g., initializing a DeFi position) may require dozens of instructions that exceed a single transaction's size limit. Instruction plans let you describe the full operation and automatically batch it into multiple transactions.
+
+### solana_kit_rpc
+
+The primary RPC client:
+
+- `createSolanaRpc()` — factory with sensible defaults
+- Request coalescing — deduplicates identical in-flight requests
+- Configurable transport and transformers
+
+Exists because: This is the main entry point for talking to Solana validators. It wires together transport, transformers, and the API layer into a ready-to-use client.
+
+### solana_kit_rpc_api
+
+Type-safe definitions for all Solana RPC methods:
+
+- Account queries: `getAccountInfo`, `getBalance`, `getProgramAccounts`, `getTokenAccountsByOwner`
+- Block queries: `getBlock`, `getBlockHeight`, `getBlockTime`, `getBlocks`
+- Transaction methods: `sendTransaction`, `simulateTransaction`, `getTransaction`, `getSignatureStatuses`
+- Cluster info: `getClusterNodes`, `getEpochInfo`, `getHealth`, `getVersion`
+- And ~50 more methods
+
+Exists because: Each RPC method has specific parameter shapes and return types. Type-safe definitions catch misuse at compile time and provide IDE autocompletion for all method parameters.
+
+### solana_kit_rpc_types
+
+Shared types across RPC packages:
+
+- `Commitment` — `processed`, `confirmed`, `finalized`
+- `Lamports` — SOL amount (u64)
+- `AccountInfo<T>` — generic account data wrapper
+- `TokenAmount` / `TokenBalance` — SPL token amounts
+- `ClusterUrl` — mainnet, devnet, testnet, localnet URLs
+- `RpcResponse<T>` — standard response wrapper with context
+
+Exists because: RPC methods share many types (commitments, lamports, account info shapes). Centralizing them avoids duplication and ensures consistency across the API and subscription layers.
+
+### solana_kit_rpc_spec
+
+Core JSON-RPC 2.0 protocol implementation:
+
+- `Rpc` — sends requests through a transport and returns typed responses
+- `RpcApi` — defines available methods
+- `RpcTransport` — pluggable transport interface
+
+Exists because: The RPC protocol layer is transport-agnostic. Separating it from HTTP allows testing with mock transports and potentially supporting other transports in the future.
+
+### solana_kit_rpc_spec_types
+
+Low-level protocol types:
+
+- `RpcRequest` — method name + params
+- `RpcResponse<T>` — result or error
+- `JsonBigInt` — BigInt JSON handling
+
+Exists because: These types define the JSON-RPC 2.0 wire format independently of any Solana-specific methods, keeping the protocol layer clean.
+
+### solana_kit_rpc_parsed_types
+
+Typed parsed account data:
+
+- Token accounts, stake accounts, vote accounts
+- Config accounts, nonce accounts
+- Address lookup table accounts, BPF upgradeable loader accounts
+- Sysvar accounts
+
+Exists because: Solana's `jsonParsed` encoding returns structured data for native program accounts. These types provide compile-time safety when working with parsed account data.
+
+### solana_kit_rpc_transformers
+
+Request/response middleware:
+
+- `defaultCommitment` — injects commitment level if not specified
+- `bigintDowncast` / `bigintUpcast` — converts between BigInt and int
+- `integerOverflow` — detects values that exceed safe integer range
+- `throwSolanaError` — converts RPC error responses into `SolanaError`
+- `treeTraversal` — recursive transformation of nested response structures
+
+Exists because: Raw RPC responses need post-processing (BigInt conversion, error mapping, default injection). Middleware keeps this logic composable and out of the main client code.
+
+### solana_kit_rpc_transport_http
+
+HTTP transport for RPC:
+
+- `createHttpTransport()` — generic HTTP transport
+- `createHttpTransportForSolanaRpc()` — Solana-specific defaults
+- Custom header support and request validation
+
+Exists because: HTTP is the standard transport for Solana RPC. Separating it from the protocol layer allows swapping transports and customizing HTTP behavior (headers, timeouts).
+
+### solana_kit_rpc_subscriptions
+
+High-level subscription client:
+
+- `createSolanaRpcSubscriptions()` — factory with defaults
+- Connection pooling — reuses WebSocket connections
+- Auto-ping — keeps connections alive
+- Subscription coalescing — deduplicates identical subscriptions
+
+Exists because: Real-time updates (account changes, new slots, transaction confirmations) require WebSocket subscriptions. This client handles the connection lifecycle complexity.
+
+### solana_kit_rpc_subscriptions_api
+
+Type-safe subscription method definitions:
+
+- `accountNotifications` — account data changes
+- `programNotifications` — program account changes
+- `logsNotifications` — transaction log output
+- `signatureNotifications` — transaction confirmation
+- `slotNotifications` / `rootNotifications` — chain progress
+
+Exists because: Like the RPC API package, this provides compile-time safety for subscription parameters and notification shapes.
+
+### solana_kit_rpc_subscriptions_channel_websocket
+
+WebSocket transport for subscriptions:
+
+- `createWebSocketChannel()` — create a managed WebSocket connection
+- Configuration for URL, protocols, and reconnection
+
+Exists because: WebSocket is the transport for Solana's subscription API. This package wraps `web_socket_channel` with Solana-specific connection management.
+
+### solana_kit_subscribable
+
+Observable data publisher pattern:
+
+- `DataPublisher<T>` — publish/subscribe event system
+- `createStreamFromDataPublisher()` — bridge to Dart `Stream`
+- `demultiplexDataPublisher()` — route events by channel
+
+Exists because: The subscription system needs an event distribution mechanism that supports both the RPC subscription protocol and Dart's native `Stream` API.
+
+### solana_kit_accounts
+
+Account data access:
+
+- `fetchAccount<T>()` — fetch and decode an account in one call
+- `decodeAccount<T>()` — decode raw account bytes using a codec
+- `Account<T>` / `MaybeAccount<T>` — typed wrappers with existence checking
+
+Exists because: Reading on-chain data is the most common RPC operation. This package combines fetching and decoding into a type-safe workflow.
+
+### solana_kit_programs
+
+Program error utilities:
+
+- `ProgramError` — represents errors from on-chain programs
+- `isProgramError()` — check if an error came from a specific program
+
+Exists because: On-chain programs return custom error codes. This package provides a standard way to represent and identify program-specific errors.
+
+### solana_kit_program_client_core
+
+Building blocks for typed program clients:
+
+- Instruction input resolution
+- Self-fetching account helpers
+
+Exists because: Code-generated program clients (e.g., for SPL Token or custom Anchor programs) share common patterns for resolving instruction inputs and fetching accounts. This package provides those shared utilities.
+
+### solana_kit_sysvars
+
+Type-safe sysvar access:
+
+- `Clock` — current slot, epoch, and Unix timestamp
+- `Rent` — rent exemption calculation
+- `EpochSchedule` — epoch timing parameters
+- `SlotHashes`, `SlotHistory`, `RecentBlockhashes` — recent chain state
+- `StakeHistory` — staking metrics per epoch
+
+Exists because: Sysvars are special Solana accounts containing cluster state. Typed access eliminates manual byte parsing and provides meaningful field names.
+
+### solana_kit_transaction_confirmation
+
+Transaction confirmation strategies:
+
+- `ConfirmationStrategyBlockheight` — wait until block height exceeds transaction's last valid block height
+- `ConfirmationStrategyRecentSignature` — subscribe to signature status updates
+- `ConfirmationStrategyNonce` — watch for nonce advancement (durable transactions)
+- `ConfirmationStrategyTimeout` — simple time-based timeout
+- `ConfirmationStrategyRacer` — race multiple strategies, first to resolve wins
+
+Exists because: Transaction confirmation on Solana is nuanced. A transaction might be confirmed, finalized, expired, or dropped. Multiple strategies handle different scenarios (recent transactions vs. durable nonce transactions) and the racer pattern provides reliable confirmation with timeout fallback.
+
+### solana_kit_functional
+
+Functional composition:
+
+- `.pipe()` — chain transformations: `value.pipe(fn1).pipe(fn2).pipe(fn3)`
+
+Exists because: The SDK uses a functional pipeline pattern for building transaction messages. `.pipe()` makes this read naturally in Dart without deeply nested function calls.
+
+### solana_kit_fast_stable_stringify
+
+Deterministic JSON serialization:
+
+- `fastStableStringify()` — JSON output with alphabetically sorted keys
+
+Exists because: Request coalescing and deduplication need to compare JSON payloads. Standard JSON serialization doesn't guarantee key order, so identical objects could produce different strings. Stable stringification solves this.
+
+### solana_kit_lints
+
+Shared lint configuration using `very_good_analysis`. Not published — internal to the monorepo.
+
+### solana_kit_test_matchers
+
+Custom test matchers:
+
+- `addressMatchers` — validate address format and equality
+- `bytesMatchers` — compare byte arrays
+- `solanaErrorMatchers` — assert specific error codes and context
+- `transactionMatchers` — verify signatures and transaction structure
+
+Not published — internal to the monorepo.
+
+## Architecture
+
+### Package Dependency Graph
+
+```
+solana_kit_errors (foundation — no deps)
+├── solana_kit_addresses
+│   └── solana_kit_keys
+│       └── solana_kit_signers
+│
+├── solana_kit_codecs_core
+│   ├── solana_kit_codecs_numbers
+│   ├── solana_kit_codecs_strings
+│   └── solana_kit_codecs_data_structures
+│       └── solana_kit_codecs (umbrella)
+│           └── solana_kit_options
+│
+├── solana_kit_instructions
+│   └── solana_kit_transaction_messages
+│       └── solana_kit_transactions
+│
+├── solana_kit_rpc_spec_types
+│   ├── solana_kit_rpc_spec
+│   │   ├── solana_kit_rpc_transport_http
+│   │   └── solana_kit_rpc_transformers
+│   ├── solana_kit_rpc_types
+│   ├── solana_kit_rpc_parsed_types
+│   └── solana_kit_rpc_api
+│       └── solana_kit_rpc (main client)
+│
+├── solana_kit_subscribable
+│   ├── solana_kit_rpc_subscriptions_channel_websocket
+│   ├── solana_kit_rpc_subscriptions_api
+│   └── solana_kit_rpc_subscriptions (subscription client)
+│
+├── solana_kit_accounts
+│   ├── solana_kit_sysvars
+│   └── solana_kit_program_client_core
+│
+├── solana_kit_transaction_confirmation
+├── solana_kit_instruction_plans
+├── solana_kit_offchain_messages
+├── solana_kit_programs
+│
+├── solana_kit_functional (utility — no deps)
+├── solana_kit_fast_stable_stringify (utility — no deps)
+│
+└── solana_kit (umbrella — re-exports everything)
+```
+
+### Design Principles
+
+- **Mirror the TypeScript SDK** — package boundaries, APIs, and naming follow [anza-xyz/kit](https://github.com/anza-xyz/kit) so developers familiar with the TS SDK can transfer their knowledge
+- **Tree-shakeable** — import only the packages you need; the umbrella package is optional
+- **Zero code generation** — no freezed, no build_runner; everything is hand-written using Dart 3.10+ language features
+- **Extension types for zero-cost abstractions** — `Address`, `Lamports`, and other wrapper types compile away to their underlying representation
+- **Composable codecs** — describe on-chain data layouts declaratively rather than writing manual serialization
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add detailed readme documentation for every package in the monorepo (37 package readmes + root readme update)
- Each readme includes installation instructions, real Dart code examples, API reference tables, and links to the corresponding TypeScript SDK packages
- Add CLAUDE.md rules: never delete `.changeset/` files, always keep readme files and docs up to date
- Fix commented-out code examples across 7 packages (accounts, transactions, instruction_plans, sysvars, transaction_confirmation, offchain_messages, program_client_core) by replacing placeholder stubs with real, uncommented API usage

## Test plan

- [x] All 37 package readmes created with real code examples
- [x] Commented-out code statements reduced from 64 to 5 (remaining are appropriate placeholders)
- [x] `dprint check` passes on all updated files
- [x] CLAUDE.md rules added for changeset protection and doc maintenance