### PR TITLE
feat: harden transports and add release/quality automation

### DIFF
--- a/.changeset/project-hardening-roadmap.md
+++ b/.changeset/project-hardening-roadmap.md
@@ -1,0 +1,11 @@
+---
+solana_kit_program_client_core: patch
+solana_kit_rpc: patch
+solana_kit_rpc_api: patch
+solana_kit_rpc_subscriptions: patch
+solana_kit_rpc_subscriptions_channel_websocket: patch
+solana_kit_rpc_transport_http: patch
+solana_kit_rpc_types: patch
+---
+
+Harden transport defaults (secure HTTP/WS by default with explicit insecure opt-in), flesh out program client core send/planning callbacks, expand RPC model/params/subscription test coverage, and improve workspace CI/testing automation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,26 @@ on:
     branches: [main]
 
 jobs:
+  changeset-required:
+    if: github.event_name == 'pull_request'
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require changes to be documented
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: scripts/check-pr-changeset.sh
+
+  docs-drift:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check workspace documentation drift
+        run: scripts/workspace-doc-drift.sh --check
+
   lint:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,85 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_workflow:
+        description: Knope publish workflow to run
+        required: true
+        default: publish
+        type: choice
+        options:
+          - publish
+          - publish-day-1
+          - publish-day-2
+          - publish-day-3
+      dry_run:
+        description: Run publish workflow in dry-run mode
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: renderers/renderers-dart/pnpm-lock.yaml
+      - name: Validate target branch
+        if: ${{ !inputs.dry_run }}
+        run: |
+          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
+            echo "Non-dry-run publishes must run from main. Current ref: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+      - name: Configure publish credentials
+        if: ${{ !inputs.dry_run }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          PUB_TOKEN: ${{ secrets.PUB_TOKEN }}
+        run: |
+          if [[ -z "${PUB_TOKEN:-}" ]]; then
+            echo "Missing PUB_TOKEN secret." >&2
+            exit 1
+          fi
+
+          if [[ -z "${NPM_TOKEN:-}" ]]; then
+            echo "Missing NPM_TOKEN secret." >&2
+            exit 1
+          fi
+
+          dart pub token add https://pub.dev --env-var PUB_TOKEN
+          printf "//registry.npmjs.org/:_authToken=%s\n" "${NPM_TOKEN}" > ~/.npmrc
+        shell: devenv shell -- bash -e {0}
+      - name: Run publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          workflow_name="${{ inputs.publish_workflow }}"
+
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            knope --dry-run "${workflow_name}"
+          else
+            knope "${workflow_name}"
+          fi
+        shell: devenv shell -- bash -e {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Run release in dry-run mode
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Validate target branch
+        if: ${{ !inputs.dry_run }}
+        run: |
+          if [[ "${GITHUB_REF_NAME}" != "main" ]]; then
+            echo "Non-dry-run releases must run from main. Current ref: ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+      - name: Run release workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            knope --dry-run release
+          else
+            knope release
+          fi
+        shell: devenv shell -- bash -e {0}

--- a/devenv.nix
+++ b/devenv.nix
@@ -216,15 +216,16 @@
             continue
           fi
 
-          # Skip Flutter packages (they need flutter test)
-          if grep -q "flutter:" "$pkg_dir/pubspec.yaml" 2>/dev/null; then
-            continue
-          fi
-
           pkg_name="$(basename "$pkg_dir")"
           echo "Testing $pkg_name..."
-          if ! dart test "$pkg_dir"; then
-            failed=1
+          if grep -q "flutter:" "$pkg_dir/pubspec.yaml" 2>/dev/null; then
+            if ! flutter test "$pkg_dir"; then
+              failed=1
+            fi
+          else
+            if ! dart test "$pkg_dir"; then
+              failed=1
+            fi
           fi
         done
 
@@ -255,6 +256,8 @@
 
         rm -rf coverage
         mkdir -p coverage
+        failed=0
+        failed_packages=()
 
         echo "Generating coverage for packages..."
         for pkg_dir in packages/*/; do
@@ -264,15 +267,21 @@
 
           pkg_name="$(basename "$pkg_dir")"
 
-          # Skip Flutter packages (they need flutter test)
-          if grep -q "flutter:" "$pkg_dir/pubspec.yaml" 2>/dev/null; then
-            echo "Generating coverage for Flutter package: $pkg_name"
-            (cd "$pkg_dir" && rm -rf coverage && flutter test --coverage) || true
-          else
-            echo "Generating coverage for Dart package: $pkg_name"
-            (cd "$pkg_dir" && rm -rf coverage && dart test --coverage=coverage && format_coverage --lcov --in=coverage --out=coverage/lcov.info --package=. --report-on=lib) || true
+          echo "Generating coverage for package: $pkg_name"
+          if ! (
+            rm -rf "$pkg_dir/coverage" &&
+            mkdir -p "$pkg_dir/coverage" &&
+            flutter test "$pkg_dir" --coverage --coverage-path="$pkg_dir/coverage/lcov.info"
+          ); then
+            failed=1
+            failed_packages+=("$pkg_name")
           fi
         done
+
+        if [ "$failed" -ne 0 ]; then
+          echo "Coverage generation failed for package(s): ''${failed_packages[*]}" >&2
+          exit 1
+        fi
 
         echo "Merging LCOV reports..."
         : > coverage/lcov.info

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -4,7 +4,13 @@ This guide covers how to version, release, and publish the `solana_kit` Dart SDK
 
 ## Overview
 
-The Solana Kit SDK consists of 38 publishable packages under `packages/` plus 2 internal packages (`solana_kit_lints` and `solana_kit_test_matchers`) that are not published. Versioning is managed by [knope](https://knope.tech/) using changesets stored in `.changeset/`. Publishing is executed via `knope` workflows that call `melos publish`, so Melos manages dependency-aware publish sequencing.
+<!-- workspace-summary:start -->
+
+This monorepo contains **40 packages** under `packages/`: **38 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
+
+<!-- workspace-summary:end -->
+
+Versioning is managed by [knope](https://knope.tech/) using changesets stored in `.changeset/`. Publishing is executed via `knope` workflows that call `melos publish` (plus renderer npm publish), so Melos manages dependency-aware publish sequencing for Dart packages.
 
 ## Package Inventory
 
@@ -58,6 +64,57 @@ The Solana Kit SDK consists of 38 publishable packages under `packages/` plus 2 
 | `solana_kit_lints`         | Shared lint rules (`very_good_analysis`) |
 | `solana_kit_test_matchers` | Solana-specific test matchers            |
 
+### Workspace Dependency Graph (generated)
+
+Generated from package `pubspec.yaml` files with `scripts/workspace-doc-drift.sh --write`.
+
+<!-- workspace-dependency-graph:start -->
+
+```text
+solana_kit -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs, solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_functional, solana_kit_instruction_plans, solana_kit_instructions, solana_kit_keys, solana_kit_offchain_messages, solana_kit_options, solana_kit_program_client_core, solana_kit_programs, solana_kit_rpc, solana_kit_rpc_parsed_types, solana_kit_rpc_spec_types, solana_kit_rpc_subscriptions, solana_kit_rpc_transport_http, solana_kit_rpc_types, solana_kit_signers, solana_kit_subscribable, solana_kit_sysvars, solana_kit_transaction_confirmation, solana_kit_transaction_messages, solana_kit_transactions
+solana_kit_accounts -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors, solana_kit_rpc_spec, solana_kit_rpc_types
+solana_kit_addresses -> solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
+solana_kit_codecs -> solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_options
+solana_kit_codecs_core -> solana_kit_errors
+solana_kit_codecs_data_structures -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
+solana_kit_codecs_numbers -> solana_kit_codecs_core, solana_kit_errors
+solana_kit_codecs_strings -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
+solana_kit_errors -> (none)
+solana_kit_fast_stable_stringify -> (none)
+solana_kit_functional -> (none)
+solana_kit_helius -> solana_kit_errors
+solana_kit_instruction_plans -> solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_transaction_messages, solana_kit_transactions
+solana_kit_instructions -> solana_kit_addresses, solana_kit_errors
+solana_kit_keys -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
+solana_kit_lints -> (none)
+solana_kit_mobile_wallet_adapter -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_mobile_wallet_adapter_protocol, solana_kit_transactions
+solana_kit_mobile_wallet_adapter_protocol -> solana_kit_codecs_strings, solana_kit_errors
+solana_kit_offchain_messages -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_errors, solana_kit_keys
+solana_kit_options -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
+solana_kit_program_client_core -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_errors, solana_kit_instructions, solana_kit_rpc_spec, solana_kit_rpc_types, solana_kit_signers
+solana_kit_programs -> solana_kit_addresses, solana_kit_errors
+solana_kit_rpc -> solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_transport_http, solana_kit_rpc_types
+solana_kit_rpc_api -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_rpc_parsed_types, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_types, solana_kit_transaction_messages, solana_kit_transactions
+solana_kit_rpc_parsed_types -> solana_kit_addresses, solana_kit_errors, solana_kit_rpc_types
+solana_kit_rpc_spec -> solana_kit_errors, solana_kit_rpc_spec_types
+solana_kit_rpc_spec_types -> solana_kit_errors
+solana_kit_rpc_subscriptions -> solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_rpc_spec_types, solana_kit_rpc_subscriptions_api, solana_kit_rpc_subscriptions_channel_websocket, solana_kit_rpc_types, solana_kit_subscribable
+solana_kit_rpc_subscriptions_api -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_rpc_types
+solana_kit_rpc_subscriptions_channel_websocket -> solana_kit_errors, solana_kit_subscribable
+solana_kit_rpc_transformers -> solana_kit_errors, solana_kit_rpc_spec_types, solana_kit_rpc_types
+solana_kit_rpc_transport_http -> solana_kit_errors, solana_kit_rpc_spec, solana_kit_rpc_spec_types
+solana_kit_rpc_types -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_errors
+solana_kit_signers -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_transaction_messages, solana_kit_transactions
+solana_kit_subscribable -> solana_kit_errors
+solana_kit_sysvars -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_errors, solana_kit_rpc_spec, solana_kit_rpc_types
+solana_kit_test_matchers -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_transactions
+solana_kit_transaction_confirmation -> solana_kit_errors, solana_kit_rpc_subscriptions_channel_websocket, solana_kit_rpc_types, solana_kit_subscribable
+solana_kit_transaction_messages -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_errors, solana_kit_functional, solana_kit_instructions
+solana_kit_transactions -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_transaction_messages
+```
+
+<!-- workspace-dependency-graph:end -->
+
 ## Managing Release
 
 ### Creating a Changeset
@@ -68,7 +125,7 @@ When making changes to any package, create a changeset file:
 knope document-change
 ```
 
-This is a required step for PRs that modify files under `packages/*`. CI enforces this via the `Require changes to be documented` check.
+This is required for PRs that modify files under `packages/*` (CI enforces this with `Require changes to be documented`).
 
 This interactively creates a Markdown file in `.changeset/` with the affected package(s) and a description. Each changeset file uses YAML frontmatter to specify the package and version bump type:
 
@@ -132,7 +189,7 @@ knope publish-day-2
 knope publish-day-3
 ```
 
-All day workflows call the same Melos publish command. This is intentional so you can rerun on later days and let Melos continue publishing unpublished package versions.
+All day workflows call the same publish command sequence as `knope publish`. This is intentional so you can rerun on later days and let Melos continue publishing unpublished package versions.
 
 If limits are not a concern, publish everything in one pass:
 
@@ -208,12 +265,10 @@ The correct publishing order follows the layer table above:
 knope publish
 ```
 
-This workflow runs two Melos passes through `devenv`:
+This workflow currently runs:
 
-1. `melos publish --no-private --no-flutter --no-dry-run --yes`
-2. `melos publish --no-private --flutter --no-dry-run --yes`
-
-This keeps publishing non-interactive (`--yes`), uses the project SDK environment (`devenv`), and publishes the Flutter package separately after dependency packages.
+1. `melos publish`
+2. `pnpm -r publish`
 
 ### Dry Run
 
@@ -223,9 +278,10 @@ To verify all packages are ready to publish without actually publishing:
 # Full workflow dry run
 knope --dry-run publish
 
-# Or run Melos directly in two passes
-devenv shell -- bash -lc "melos publish --no-private --no-flutter --yes"
-devenv shell -- bash -lc "melos publish --no-private --flutter --yes"
+# Staged workflow dry runs
+knope --dry-run publish-day-1
+knope --dry-run publish-day-2
+knope --dry-run publish-day-3
 ```
 
 ## Known Issues and Considerations
@@ -277,13 +333,13 @@ Before the very first publish of any package:
 
 The recommended CI/CD workflow for publishing:
 
-1. **PR merged to main**: Triggers CI checks (analyze, test, format)
-2. **Release preparation**: Run `knope release` to bump versions and create GitHub release
-3. **Publishing**: Run `knope publish` to publish all packages to pub.dev
+1. **PR merged to main**: CI checks run (analyze, test, format, changeset enforcement, docs drift check)
+2. **Release preparation**: Trigger the `Release` GitHub Actions workflow (`workflow_dispatch`) to run `knope release`
+3. **Publishing**: Trigger the `Publish` GitHub Actions workflow (`workflow_dispatch`) to run `knope publish` or `knope publish-day-*`
 4. **Verification**: Check pub.dev for all packages with correct versions
 
 The GitHub Actions workflow should include:
 
-- A `release` job that runs `knope release` on push to main (when changesets exist)
-- A `publish` job that runs `knope publish` after the release job succeeds
-- The publish job needs `dart pub login` credentials (via `PUB_TOKEN` environment variable or `dart pub token add` with a service account)
+- A manually triggered `Release` workflow that runs `knope release`
+- A manually triggered `Publish` workflow that runs `knope publish` or one of the staged publish-day workflows
+- The publish job needs pub.dev credentials (`PUB_TOKEN`) and npm credentials (`NPM_TOKEN`) because `knope publish` runs both Dart and renderer publish commands

--- a/knope.toml
+++ b/knope.toml
@@ -425,3 +425,36 @@ command = "melos publish"
 [[workflows.steps]]
 type = "Command"
 command = "pnpm -r publish"
+
+[[workflows]]
+name = "publish-day-1"
+
+[[workflows.steps]]
+type = "Command"
+command = "melos publish"
+
+[[workflows.steps]]
+type = "Command"
+command = "pnpm -r publish"
+
+[[workflows]]
+name = "publish-day-2"
+
+[[workflows.steps]]
+type = "Command"
+command = "melos publish"
+
+[[workflows.steps]]
+type = "Command"
+command = "pnpm -r publish"
+
+[[workflows]]
+name = "publish-day-3"
+
+[[workflows.steps]]
+type = "Command"
+command = "melos publish"
+
+[[workflows.steps]]
+type = "Command"
+command = "pnpm -r publish"

--- a/packages/solana_kit_program_client_core/lib/solana_kit_program_client_core.dart
+++ b/packages/solana_kit_program_client_core/lib/solana_kit_program_client_core.dart
@@ -1,3 +1,4 @@
 export 'src/instruction_input_resolution.dart';
 export 'src/instructions.dart';
 export 'src/self_fetch_functions.dart';
+export 'src/self_plan_and_send_functions.dart';

--- a/packages/solana_kit_program_client_core/lib/src/self_plan_and_send_functions.dart
+++ b/packages/solana_kit_program_client_core/lib/src/self_plan_and_send_functions.dart
@@ -1,16 +1,92 @@
-// This is a stub file; TODO comments don't follow Flutter style intentionally.
-// ignore_for_file: flutter_style_todos
+/// Plans a single transaction input.
+typedef PlanTransactionFn<TInput, TPlan> =
+    Future<TPlan> Function(
+      TInput input,
+    );
 
-// TODO: Implement self-plan and send functions.
-//
-// This module depends on instruction_plans which is not yet implemented.
-// Once `solana_kit_instruction_plans` is available, port the TypeScript
-// `addSelfPlanAndSendFunctions` and `SelfPlanAndSendFunctions` from
-// `@solana/program-client-core/src/self-plan-and-send-functions.ts`.
-//
-// The TS implementation provides:
-// - `SelfPlanAndSendFunctions` type with planTransaction, planTransactions,
-//   sendTransaction, sendTransactions methods.
-// - `addSelfPlanAndSendFunctions()` that augments an Instruction or
-//   InstructionPlan with self-plan/send capabilities using a client that
-//   provides transaction planning and sending.
+/// Sends a single transaction input.
+typedef SendTransactionFn<TInput, TResult> =
+    Future<TResult> Function(
+      TInput input,
+    );
+
+/// Plans a batch of transaction inputs.
+typedef PlanTransactionsFn<TInput, TPlan> =
+    Future<List<TPlan>> Function(
+      List<TInput> inputs,
+    );
+
+/// Sends a batch of transaction inputs.
+typedef SendTransactionsFn<TInput, TResult> =
+    Future<List<TResult>> Function(
+      List<TInput> inputs,
+    );
+
+/// Minimal self-plan/send function bundle for generated program clients.
+///
+/// This keeps the API surface available while instruction planning packages
+/// are introduced incrementally in Dart.
+class SelfPlanAndSendFunctions<TInput, TPlan, TResult> {
+  /// Creates a [SelfPlanAndSendFunctions] wrapper.
+  ///
+  /// If [planTransactions] or [sendTransactions] are omitted, batch behavior
+  /// defaults to applying the single-item callback to each input and awaiting
+  /// all results.
+  SelfPlanAndSendFunctions({
+    required PlanTransactionFn<TInput, TPlan> planTransaction,
+    required SendTransactionFn<TInput, TResult> sendTransaction,
+    PlanTransactionsFn<TInput, TPlan>? planTransactions,
+    SendTransactionsFn<TInput, TResult>? sendTransactions,
+  }) : _planTransaction = planTransaction,
+       _sendTransaction = sendTransaction,
+       _planTransactions = planTransactions,
+       _sendTransactions = sendTransactions;
+
+  final PlanTransactionFn<TInput, TPlan> _planTransaction;
+  final SendTransactionFn<TInput, TResult> _sendTransaction;
+  final PlanTransactionsFn<TInput, TPlan>? _planTransactions;
+  final SendTransactionsFn<TInput, TResult>? _sendTransactions;
+
+  /// Plans one transaction input.
+  Future<TPlan> planTransaction(TInput input) {
+    return _planTransaction(input);
+  }
+
+  /// Plans multiple transaction inputs.
+  Future<List<TPlan>> planTransactions(List<TInput> inputs) async {
+    if (_planTransactions != null) {
+      return _planTransactions(inputs);
+    }
+    return Future.wait(inputs.map(_planTransaction));
+  }
+
+  /// Sends one transaction input.
+  Future<TResult> sendTransaction(TInput input) {
+    return _sendTransaction(input);
+  }
+
+  /// Sends multiple transaction inputs.
+  Future<List<TResult>> sendTransactions(List<TInput> inputs) async {
+    if (_sendTransactions != null) {
+      return _sendTransactions(inputs);
+    }
+    return Future.wait(inputs.map(_sendTransaction));
+  }
+}
+
+/// Creates a [SelfPlanAndSendFunctions] wrapper around planning/sending
+/// callbacks.
+SelfPlanAndSendFunctions<TInput, TPlan, TResult>
+addSelfPlanAndSendFunctions<TInput, TPlan, TResult>({
+  required PlanTransactionFn<TInput, TPlan> planTransaction,
+  required SendTransactionFn<TInput, TResult> sendTransaction,
+  PlanTransactionsFn<TInput, TPlan>? planTransactions,
+  SendTransactionsFn<TInput, TResult>? sendTransactions,
+}) {
+  return SelfPlanAndSendFunctions<TInput, TPlan, TResult>(
+    planTransaction: planTransaction,
+    sendTransaction: sendTransaction,
+    planTransactions: planTransactions,
+    sendTransactions: sendTransactions,
+  );
+}

--- a/packages/solana_kit_program_client_core/test/self_plan_and_send_functions_test.dart
+++ b/packages/solana_kit_program_client_core/test/self_plan_and_send_functions_test.dart
@@ -1,0 +1,54 @@
+import 'package:solana_kit_program_client_core/solana_kit_program_client_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SelfPlanAndSendFunctions', () {
+    test('delegates single-item planning and sending callbacks', () async {
+      final functions = SelfPlanAndSendFunctions<int, String, String>(
+        planTransaction: (input) async => 'plan:$input',
+        sendTransaction: (input) async => 'send:$input',
+      );
+
+      expect(await functions.planTransaction(3), 'plan:3');
+      expect(await functions.sendTransaction(3), 'send:3');
+    });
+
+    test(
+      'uses default batch behavior when batch callbacks are omitted',
+      () async {
+        final functions = SelfPlanAndSendFunctions<int, String, String>(
+          planTransaction: (input) async => 'plan:$input',
+          sendTransaction: (input) async => 'send:$input',
+        );
+
+        expect(await functions.planTransactions([1, 2]), ['plan:1', 'plan:2']);
+        expect(await functions.sendTransactions([1, 2]), ['send:1', 'send:2']);
+      },
+    );
+
+    test('uses explicit batch callbacks when provided', () async {
+      final functions = SelfPlanAndSendFunctions<int, String, String>(
+        planTransaction: (input) async => 'single-plan:$input',
+        sendTransaction: (input) async => 'single-send:$input',
+        planTransactions: (inputs) async => ['batch-plan:${inputs.length}'],
+        sendTransactions: (inputs) async => ['batch-send:${inputs.length}'],
+      );
+
+      expect(await functions.planTransactions([4, 5, 6]), ['batch-plan:3']);
+      expect(await functions.sendTransactions([4, 5, 6]), ['batch-send:3']);
+    });
+  });
+
+  group('addSelfPlanAndSendFunctions', () {
+    test('creates a configured SelfPlanAndSendFunctions wrapper', () async {
+      final functions = addSelfPlanAndSendFunctions<int, String, String>(
+        planTransaction: (input) async => 'plan:$input',
+        sendTransaction: (input) async => 'send:$input',
+      );
+
+      expect(functions, isA<SelfPlanAndSendFunctions<int, String, String>>());
+      expect(await functions.planTransaction(9), 'plan:9');
+      expect(await functions.sendTransaction(9), 'send:9');
+    });
+  });
+}

--- a/packages/solana_kit_rpc/lib/src/rpc.dart
+++ b/packages/solana_kit_rpc/lib/src/rpc.dart
@@ -13,13 +13,22 @@ import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
 /// final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
 /// final slot = await rpc.request('getSlot').send();
 /// ```
+///
+/// By default, only `https://` URLs are allowed. Set [allowInsecureHttp] to
+/// `true` to allow `http://` URLs for local development/testing.
 Rpc createSolanaRpc({
   required String url,
+  bool allowInsecureHttp = false,
   Map<String, String>? headers,
   http.Client? client,
 }) {
   return createSolanaRpcFromTransport(
-    createDefaultRpcTransport(url: url, headers: headers, client: client),
+    createDefaultRpcTransport(
+      url: url,
+      allowInsecureHttp: allowInsecureHttp,
+      headers: headers,
+      client: client,
+    ),
   );
 }
 

--- a/packages/solana_kit_rpc/lib/src/rpc_transport.dart
+++ b/packages/solana_kit_rpc/lib/src/rpc_transport.dart
@@ -11,11 +11,14 @@ import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart
 ///   version of the Dart SDK (cannot be overridden by user-supplied headers).
 /// - Logic that coalesces multiple calls in the same microtask, for the same
 ///   methods with the same arguments, into a single network request.
+/// - HTTPS-only endpoints by default. Set [allowInsecureHttp] to `true` to
+///   allow `http://` URLs for local development/testing.
 ///
 /// Optionally pass an [http.Client] via [client] to control the HTTP client
 /// used for requests (useful for testing).
 RpcTransport createDefaultRpcTransport({
   required String url,
+  bool allowInsecureHttp = false,
   Map<String, String>? headers,
   http.Client? client,
 }) {
@@ -28,6 +31,7 @@ RpcTransport createDefaultRpcTransport({
 
   final baseTransport = createHttpTransportForSolanaRpc(
     url: url,
+    allowInsecureHttp: allowInsecureHttp,
     headers: mergedHeaders,
     client: client,
   );

--- a/packages/solana_kit_rpc/test/rpc_transport_test.dart
+++ b/packages/solana_kit_rpc/test/rpc_transport_test.dart
@@ -23,6 +23,7 @@ void main() {
 
       transport = createDefaultRpcTransport(
         url: 'http://localhost',
+        allowInsecureHttp: true,
         client: mockClient,
       );
     });
@@ -44,6 +45,7 @@ void main() {
 
       final customTransport = createDefaultRpcTransport(
         url: 'http://localhost',
+        allowInsecureHttp: true,
         headers: {'Solana-Client': 'fakeversion'},
         client: mockClient,
       );
@@ -65,6 +67,7 @@ void main() {
 
       final customTransport = createDefaultRpcTransport(
         url: 'http://localhost',
+        allowInsecureHttp: true,
         headers: {'aUtHoRiZaTiOn': 'Picard, 4 7 Alpha Tango'},
         client: mockClient,
       );
@@ -91,6 +94,7 @@ void main() {
 
         final coalescedTransport = createDefaultRpcTransport(
           url: 'http://localhost',
+          allowInsecureHttp: true,
           client: mockClient,
         );
 

--- a/packages/solana_kit_rpc_api/test/rpc_params_contract_test.dart
+++ b/packages/solana_kit_rpc_api/test/rpc_params_contract_test.dart
@@ -1,0 +1,561 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+const _addressA = Address('11111111111111111111111111111111');
+const _addressB = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+const _signatureA = Signature(
+  '1111111111111111111111111111111111111111111111111111111111111111',
+);
+const _signatureB = Signature(
+  '2222222222222222222222222222222222222222222222222222222222222222',
+);
+const _blockhash = Blockhash('11111111111111111111111111111111');
+
+void main() {
+  group('RPC param builder contracts', () {
+    test('zero-parameter methods emit an empty params list', () {
+      final testCases = <({String method, List<Object?> params})>[
+        (method: 'getClusterNodes', params: getClusterNodesParams()),
+        (method: 'getEpochSchedule', params: getEpochScheduleParams()),
+        (
+          method: 'getFirstAvailableBlock',
+          params: getFirstAvailableBlockParams(),
+        ),
+        (method: 'getGenesisHash', params: getGenesisHashParams()),
+        (method: 'getHealth', params: getHealthParams()),
+        (
+          method: 'getHighestSnapshotSlot',
+          params: getHighestSnapshotSlotParams(),
+        ),
+        (method: 'getIdentity', params: getIdentityParams()),
+        (method: 'getInflationRate', params: getInflationRateParams()),
+        (method: 'getMaxRetransmitSlot', params: getMaxRetransmitSlotParams()),
+        (
+          method: 'getMaxShredInsertSlot',
+          params: getMaxShredInsertSlotParams(),
+        ),
+        (method: 'getVersion', params: getVersionParams()),
+        (method: 'minimumLedgerSlot', params: minimumLedgerSlotParams()),
+      ];
+
+      for (final testCase in testCases) {
+        expect(testCase.params, isEmpty, reason: testCase.method);
+      }
+    });
+
+    test('required positional arguments are preserved in-order', () {
+      final testCases =
+          <({String method, List<Object?> actual, List<Object?> expected})>[
+            (
+              method: 'getBlockCommitment',
+              actual: getBlockCommitmentParams(BigInt.from(10)),
+              expected: <Object?>[BigInt.from(10)],
+            ),
+            (
+              method: 'getBlockTime',
+              actual: getBlockTimeParams(BigInt.from(20)),
+              expected: <Object?>[BigInt.from(20)],
+            ),
+            (
+              method: 'getBlocksWithLimit',
+              actual: getBlocksWithLimitParams(BigInt.from(1), 25),
+              expected: <Object?>[BigInt.from(1), 25],
+            ),
+            (
+              method: 'getFeeForMessage',
+              actual: getFeeForMessageParams('AQID'),
+              expected: <Object?>['AQID'],
+            ),
+            (
+              method: 'getMinimumBalanceForRentExemption',
+              actual: getMinimumBalanceForRentExemptionParams(BigInt.from(165)),
+              expected: <Object?>[BigInt.from(165)],
+            ),
+            (
+              method: 'getProgramAccounts',
+              actual: getProgramAccountsParams(_addressB),
+              expected: <Object?>[_addressB.value],
+            ),
+            (
+              method: 'getSignaturesForAddress',
+              actual: getSignaturesForAddressParams(_addressA),
+              expected: <Object?>[_addressA.value],
+            ),
+            (
+              method: 'getSignatureStatuses',
+              actual: getSignatureStatusesParams([_signatureA, _signatureB]),
+              expected: <Object?>[
+                [_signatureA.value, _signatureB.value],
+              ],
+            ),
+            (
+              method: 'getSlotLeaders',
+              actual: getSlotLeadersParams(BigInt.from(100), 4),
+              expected: <Object?>[BigInt.from(100), 4],
+            ),
+            (
+              method: 'getTokenAccountBalance',
+              actual: getTokenAccountBalanceParams(_addressA),
+              expected: <Object?>[_addressA.value],
+            ),
+            (
+              method: 'getTokenLargestAccounts',
+              actual: getTokenLargestAccountsParams(_addressB),
+              expected: <Object?>[_addressB.value],
+            ),
+            (
+              method: 'getTokenSupply',
+              actual: getTokenSupplyParams(_addressB),
+              expected: <Object?>[_addressB.value],
+            ),
+            (
+              method: 'getTransaction',
+              actual: getTransactionParams(_signatureA),
+              expected: <Object?>[_signatureA.value],
+            ),
+            (
+              method: 'isBlockhashValid',
+              actual: isBlockhashValidParams(_blockhash),
+              expected: <Object?>[_blockhash.value],
+            ),
+            (
+              method: 'requestAirdrop',
+              actual: requestAirdropParams(
+                _addressA,
+                Lamports(BigInt.from(1_000_000_000)),
+              ),
+              expected: <Object?>[_addressA.value, BigInt.from(1_000_000_000)],
+            ),
+            (
+              method: 'getInflationReward',
+              actual: getInflationRewardParams([_addressA, _addressB]),
+              expected: <Object?>[
+                [_addressA.value, _addressB.value],
+              ],
+            ),
+            (
+              method: 'getMultipleAccounts',
+              actual: getMultipleAccountsParams([_addressA, _addressB]),
+              expected: <Object?>[
+                [_addressA.value, _addressB.value],
+              ],
+            ),
+          ];
+
+      for (final testCase in testCases) {
+        expect(testCase.actual, testCase.expected, reason: testCase.method);
+      }
+    });
+
+    test('optional positional arguments are omitted when null', () {
+      expect(getRecentPerformanceSamplesParams(), isEmpty);
+      expect(getRecentPerformanceSamplesParams(32), [32]);
+
+      expect(getRecentPrioritizationFeesParams(), isEmpty);
+      expect(
+        getRecentPrioritizationFeesParams([_addressA, _addressB]),
+        [
+          [_addressA.value, _addressB.value],
+        ],
+      );
+
+      expect(getBlocksParams(BigInt.from(1)), [BigInt.from(1)]);
+      expect(
+        getBlocksParams(BigInt.from(1), BigInt.from(2)),
+        [BigInt.from(1), BigInt.from(2)],
+      );
+
+      expect(getLeaderScheduleParams(), [null]);
+      expect(
+        getLeaderScheduleParams(BigInt.from(9)),
+        [BigInt.from(9)],
+      );
+    });
+
+    test('filter helpers serialize to RPC payload shape', () {
+      expect(
+        const TokenAccountMintFilter(mint: _addressB).toJson(),
+        {'mint': _addressB.value},
+      );
+      expect(
+        const TokenAccountProgramIdFilter(programId: _addressB).toJson(),
+        {'programId': _addressB.value},
+      );
+      expect(
+        getTokenAccountsByOwnerParams(
+          _addressA,
+          const TokenAccountMintFilter(mint: _addressB).toJson(),
+        ),
+        [
+          _addressA.value,
+          {'mint': _addressB.value},
+        ],
+      );
+      expect(
+        getTokenAccountsByDelegateParams(
+          _addressA,
+          const TokenAccountProgramIdFilter(programId: _addressB).toJson(),
+        ),
+        [
+          _addressA.value,
+          {'programId': _addressB.value},
+        ],
+      );
+    });
+  });
+
+  group('RPC config serializer contracts', () {
+    test(
+      'serializers include every non-null field with expected key names',
+      () {
+        final testCases =
+            <
+              ({
+                String type,
+                Map<String, Object?> actual,
+                Map<String, Object?> expected,
+              })
+            >[
+              (
+                type: 'GetBlockHeightConfig',
+                actual: GetBlockHeightConfig(
+                  commitment: Commitment.confirmed,
+                  minContextSlot: BigInt.from(7),
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'minContextSlot': BigInt.from(7),
+                },
+              ),
+              (
+                type: 'GetBlocksConfig',
+                actual: const GetBlocksConfig(
+                  commitment: Commitment.finalized,
+                ).toJson(),
+                expected: {'commitment': 'finalized'},
+              ),
+              (
+                type: 'GetBlocksWithLimitConfig',
+                actual: const GetBlocksWithLimitConfig(
+                  commitment: Commitment.confirmed,
+                ).toJson(),
+                expected: {'commitment': 'confirmed'},
+              ),
+              (
+                type: 'GetEpochInfoConfig',
+                actual: GetEpochInfoConfig(
+                  commitment: Commitment.finalized,
+                  minContextSlot: BigInt.from(99),
+                ).toJson(),
+                expected: {
+                  'commitment': 'finalized',
+                  'minContextSlot': BigInt.from(99),
+                },
+              ),
+              (
+                type: 'GetInflationRewardConfig',
+                actual: GetInflationRewardConfig(
+                  commitment: Commitment.confirmed,
+                  epoch: BigInt.from(3),
+                  minContextSlot: BigInt.from(4),
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'epoch': BigInt.from(3),
+                  'minContextSlot': BigInt.from(4),
+                },
+              ),
+              (
+                type: 'GetLatestBlockhashConfig',
+                actual: GetLatestBlockhashConfig(
+                  commitment: Commitment.processed,
+                  minContextSlot: BigInt.from(33),
+                ).toJson(),
+                expected: {
+                  'commitment': 'processed',
+                  'minContextSlot': BigInt.from(33),
+                },
+              ),
+              (
+                type: 'GetLeaderScheduleConfig',
+                actual: const GetLeaderScheduleConfig(
+                  commitment: Commitment.confirmed,
+                  identity: _addressA,
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'identity': _addressA.value,
+                },
+              ),
+              (
+                type: 'GetInflationGovernorConfig',
+                actual: const GetInflationGovernorConfig(
+                  commitment: Commitment.finalized,
+                ).toJson(),
+                expected: {'commitment': 'finalized'},
+              ),
+              (
+                type: 'SlotRange',
+                actual: SlotRange(
+                  firstSlot: BigInt.from(1),
+                  lastSlot: BigInt.from(2),
+                ).toJson(),
+                expected: {
+                  'firstSlot': BigInt.from(1),
+                  'lastSlot': BigInt.from(2),
+                },
+              ),
+              (
+                type: 'GetBlockProductionConfig',
+                actual: GetBlockProductionConfig(
+                  commitment: Commitment.confirmed,
+                  identity: _addressB,
+                  range: SlotRange(firstSlot: BigInt.from(11)),
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'identity': _addressB.value,
+                  'range': {'firstSlot': BigInt.from(11)},
+                },
+              ),
+              (
+                type: 'GetFeeForMessageConfig',
+                actual: GetFeeForMessageConfig(
+                  commitment: Commitment.finalized,
+                  minContextSlot: BigInt.from(5),
+                ).toJson(),
+                expected: {
+                  'commitment': 'finalized',
+                  'minContextSlot': BigInt.from(5),
+                },
+              ),
+              (
+                type: 'GetSignatureStatusesConfig',
+                actual: const GetSignatureStatusesConfig(
+                  searchTransactionHistory: true,
+                ).toJson(),
+                expected: {'searchTransactionHistory': true},
+              ),
+              (
+                type: 'GetLargestAccountsConfig',
+                actual: const GetLargestAccountsConfig(
+                  commitment: Commitment.confirmed,
+                  filter: 'circulating',
+                ).toJson(),
+                expected: {'commitment': 'confirmed', 'filter': 'circulating'},
+              ),
+              (
+                type: 'GetSignaturesForAddressConfig',
+                actual: GetSignaturesForAddressConfig(
+                  before: _signatureA,
+                  commitment: Commitment.finalized,
+                  limit: 10,
+                  minContextSlot: BigInt.from(55),
+                  until: _signatureB,
+                ).toJson(),
+                expected: {
+                  'before': _signatureA.value,
+                  'commitment': 'finalized',
+                  'limit': 10,
+                  'minContextSlot': BigInt.from(55),
+                  'until': _signatureB.value,
+                },
+              ),
+              (
+                type: 'GetSlotLeaderConfig',
+                actual: GetSlotLeaderConfig(
+                  commitment: Commitment.confirmed,
+                  minContextSlot: BigInt.from(22),
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'minContextSlot': BigInt.from(22),
+                },
+              ),
+              (
+                type: 'GetMinimumBalanceForRentExemptionConfig',
+                actual: const GetMinimumBalanceForRentExemptionConfig(
+                  commitment: Commitment.finalized,
+                ).toJson(),
+                expected: {'commitment': 'finalized'},
+              ),
+              (
+                type: 'GetSlotConfig',
+                actual: GetSlotConfig(
+                  commitment: Commitment.processed,
+                  minContextSlot: BigInt.from(8),
+                ).toJson(),
+                expected: {
+                  'commitment': 'processed',
+                  'minContextSlot': BigInt.from(8),
+                },
+              ),
+              (
+                type: 'IsBlockhashValidConfig',
+                actual: IsBlockhashValidConfig(
+                  commitment: Commitment.confirmed,
+                  minContextSlot: BigInt.from(9),
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'minContextSlot': BigInt.from(9),
+                },
+              ),
+              (
+                type: 'GetTokenSupplyConfig',
+                actual: const GetTokenSupplyConfig(
+                  commitment: Commitment.finalized,
+                ).toJson(),
+                expected: {'commitment': 'finalized'},
+              ),
+              (
+                type: 'GetVoteAccountsConfig',
+                actual: GetVoteAccountsConfig(
+                  commitment: Commitment.confirmed,
+                  delinquentSlotDistance: BigInt.from(3),
+                  keepUnstakedDelinquents: false,
+                  votePubkey: _addressA,
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'delinquentSlotDistance': BigInt.from(3),
+                  'keepUnstakedDelinquents': false,
+                  'votePubkey': _addressA.value,
+                },
+              ),
+              (
+                type: 'GetTransactionConfig',
+                actual: const GetTransactionConfig(
+                  commitment: Commitment.finalized,
+                  encoding: 'json',
+                  maxSupportedTransactionVersion: 0,
+                ).toJson(),
+                expected: {
+                  'commitment': 'finalized',
+                  'encoding': 'json',
+                  'maxSupportedTransactionVersion': 0,
+                },
+              ),
+              (
+                type: 'GetStakeMinimumDelegationConfig',
+                actual: const GetStakeMinimumDelegationConfig(
+                  commitment: Commitment.processed,
+                ).toJson(),
+                expected: {'commitment': 'processed'},
+              ),
+              (
+                type: 'GetProgramAccountsConfig',
+                actual: GetProgramAccountsConfig(
+                  commitment: Commitment.confirmed,
+                  encoding: 'base64',
+                  dataSlice: const DataSlice(offset: 10, length: 20),
+                  filters: const [
+                    {'dataSize': 165},
+                  ],
+                  minContextSlot: BigInt.from(123),
+                  withContext: true,
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'encoding': 'base64',
+                  'dataSlice': {'offset': 10, 'length': 20},
+                  'filters': const [
+                    {'dataSize': 165},
+                  ],
+                  'minContextSlot': BigInt.from(123),
+                  'withContext': true,
+                },
+              ),
+              (
+                type: 'GetTransactionCountConfig',
+                actual: GetTransactionCountConfig(
+                  commitment: Commitment.finalized,
+                  minContextSlot: BigInt.from(20),
+                ).toJson(),
+                expected: {
+                  'commitment': 'finalized',
+                  'minContextSlot': BigInt.from(20),
+                },
+              ),
+              (
+                type: 'GetTokenAccountsByDelegateConfig',
+                actual: GetTokenAccountsByDelegateConfig(
+                  commitment: Commitment.confirmed,
+                  encoding: 'base64',
+                  dataSlice: const DataSlice(offset: 4, length: 8),
+                  minContextSlot: BigInt.from(2),
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'encoding': 'base64',
+                  'dataSlice': {'offset': 4, 'length': 8},
+                  'minContextSlot': BigInt.from(2),
+                },
+              ),
+              (
+                type: 'GetMultipleAccountsConfig',
+                actual: GetMultipleAccountsConfig(
+                  commitment: Commitment.processed,
+                  encoding: 'base64',
+                  dataSlice: const DataSlice(offset: 0, length: 32),
+                  minContextSlot: BigInt.from(77),
+                ).toJson(),
+                expected: {
+                  'commitment': 'processed',
+                  'encoding': 'base64',
+                  'dataSlice': {'offset': 0, 'length': 32},
+                  'minContextSlot': BigInt.from(77),
+                },
+              ),
+              (
+                type: 'GetTokenAccountBalanceConfig',
+                actual: const GetTokenAccountBalanceConfig(
+                  commitment: Commitment.confirmed,
+                ).toJson(),
+                expected: {'commitment': 'confirmed'},
+              ),
+              (
+                type: 'GetTokenAccountsByOwnerConfig',
+                actual: GetTokenAccountsByOwnerConfig(
+                  commitment: Commitment.finalized,
+                  encoding: 'base64',
+                  dataSlice: const DataSlice(offset: 6, length: 12),
+                  minContextSlot: BigInt.from(44),
+                ).toJson(),
+                expected: {
+                  'commitment': 'finalized',
+                  'encoding': 'base64',
+                  'dataSlice': {'offset': 6, 'length': 12},
+                  'minContextSlot': BigInt.from(44),
+                },
+              ),
+              (
+                type: 'GetSupplyConfig',
+                actual: const GetSupplyConfig(
+                  commitment: Commitment.confirmed,
+                  excludeNonCirculatingAccountsList: true,
+                ).toJson(),
+                expected: {
+                  'commitment': 'confirmed',
+                  'excludeNonCirculatingAccountsList': true,
+                },
+              ),
+              (
+                type: 'GetTokenLargestAccountsConfig',
+                actual: const GetTokenLargestAccountsConfig(
+                  commitment: Commitment.finalized,
+                ).toJson(),
+                expected: {'commitment': 'finalized'},
+              ),
+            ];
+
+        for (final testCase in testCases) {
+          expect(testCase.actual, testCase.expected, reason: testCase.type);
+        }
+      },
+    );
+  });
+}

--- a/packages/solana_kit_rpc_subscriptions/lib/src/rpc_subscriptions_channel.dart
+++ b/packages/solana_kit_rpc_subscriptions/lib/src/rpc_subscriptions_channel.dart
@@ -10,6 +10,7 @@ class DefaultRpcSubscriptionsChannelConfig {
   /// Creates a [DefaultRpcSubscriptionsChannelConfig].
   const DefaultRpcSubscriptionsChannelConfig({
     required this.url,
+    this.allowInsecureWs = false,
     this.intervalMs = 5000,
     this.maxSubscriptionsPerChannel = 100,
     this.minChannels = 1,
@@ -18,6 +19,11 @@ class DefaultRpcSubscriptionsChannelConfig {
 
   /// The WebSocket server URL. Must use the `ws` or `wss` protocols.
   final String url;
+
+  /// Whether to allow insecure `ws://` URLs when connecting channels.
+  ///
+  /// Defaults to `false`, which enforces `wss://` URLs.
+  final bool allowInsecureWs;
 
   /// The number of milliseconds to wait since the last message sent or
   /// received over the channel before sending a ping message to keep the
@@ -103,6 +109,7 @@ RpcSubscriptionsChannelCreator _createDefaultRpcSubscriptionsChannelCreatorImpl(
     final channel = await createWebSocketChannel(
       WebSocketChannelConfig(
         url: Uri.parse(config.url),
+        allowInsecureWs: config.allowInsecureWs,
         sendBufferHighWatermark: config.sendBufferHighWatermark,
         signal: abortSignal,
       ),

--- a/packages/solana_kit_rpc_subscriptions/test/rpc_subscriptions_channel_test.dart
+++ b/packages/solana_kit_rpc_subscriptions/test/rpc_subscriptions_channel_test.dart
@@ -1,0 +1,77 @@
+import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DefaultRpcSubscriptionsChannelConfig', () {
+    test('uses documented default values', () {
+      const config = DefaultRpcSubscriptionsChannelConfig(
+        url: 'ws://localhost:8900',
+      );
+
+      expect(config.url, 'ws://localhost:8900');
+      expect(config.allowInsecureWs, isFalse);
+      expect(config.intervalMs, 5000);
+      expect(config.maxSubscriptionsPerChannel, 100);
+      expect(config.minChannels, 1);
+      expect(config.sendBufferHighWatermark, 131072);
+    });
+
+    test('stores insecure override flag', () {
+      const config = DefaultRpcSubscriptionsChannelConfig(
+        url: 'ws://localhost:8900',
+        allowInsecureWs: true,
+      );
+      expect(config.allowInsecureWs, isTrue);
+    });
+  });
+
+  group('channel creator factories', () {
+    test('accept ws/wss URLs (case-insensitive) and return creators', () {
+      final wsCreator = createDefaultRpcSubscriptionsChannelCreator(
+        const DefaultRpcSubscriptionsChannelConfig(url: 'ws://localhost:8900'),
+      );
+      final wssCreator = createDefaultSolanaRpcSubscriptionsChannelCreator(
+        const DefaultRpcSubscriptionsChannelConfig(
+          url: 'WSS://api.mainnet-beta.solana.com',
+        ),
+      );
+
+      expect(wsCreator, isA<Function>());
+      expect(wssCreator, isA<Function>());
+    });
+
+    test('rejects unsupported URL schemes', () {
+      expect(
+        () => createDefaultRpcSubscriptionsChannelCreator(
+          const DefaultRpcSubscriptionsChannelConfig(
+            url: 'https://api.mainnet-beta.solana.com',
+          ),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message.toString(),
+            'message',
+            allOf(contains("'ws'"), contains("'wss'"), contains('https')),
+          ),
+        ),
+      );
+    });
+
+    test('rejects malformed URLs with no protocol prefix', () {
+      expect(
+        () => createDefaultSolanaRpcSubscriptionsChannelCreator(
+          const DefaultRpcSubscriptionsChannelConfig(
+            url: 'localhost:8900/ws',
+          ),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message.toString(),
+            'message',
+            contains("must be either 'ws' or 'wss'"),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/solana_kit_rpc_subscriptions/test/rpc_subscriptions_factory_test.dart
+++ b/packages/solana_kit_rpc_subscriptions/test/rpc_subscriptions_factory_test.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
+import 'package:solana_kit_subscribable/solana_kit_subscribable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PendingRpcSubscriptionsRequest', () {
+    test('subscribe wires plan request/abort signal into transport', () async {
+      RpcSubscriptionsTransportConfig? capturedConfig;
+      final publisher = createDataPublisher();
+      Future<DataPublisher> transport(
+        RpcSubscriptionsTransportConfig config,
+      ) async {
+        capturedConfig = config;
+        return publisher;
+      }
+
+      final plan = RpcSubscriptionsPlan<Object?>(
+        execute: (_) async => createDataPublisher(),
+        request: const RpcSubscriptionsRequest(
+          methodName: 'accountNotifications',
+          params: ['11111111111111111111111111111111'],
+        ),
+      );
+
+      final pending = PendingRpcSubscriptionsRequest<Object?>(
+        transport: transport,
+        plan: plan,
+      );
+      final abortController = AbortController();
+      final stream = await pending.subscribe(
+        RpcSubscribeOptions(abortSignal: abortController.signal),
+      );
+
+      expect(capturedConfig, isNotNull);
+      expect(capturedConfig!.request.methodName, 'accountNotifications');
+      expect(
+        capturedConfig!.request.params,
+        ['11111111111111111111111111111111'],
+      );
+      expect(capturedConfig!.signal, same(abortController.signal));
+
+      final firstEvent = stream.first;
+      publisher.publish('notification', {'slot': 123});
+      expect(await firstEvent, {'slot': 123});
+    });
+
+    test('subscribe forwards error events from the data publisher', () async {
+      final publisher = createDataPublisher();
+      final pending = PendingRpcSubscriptionsRequest<Object?>(
+        transport: (_) async => publisher,
+        plan: RpcSubscriptionsPlan<Object?>(
+          execute: (_) async => createDataPublisher(),
+          request: const RpcSubscriptionsRequest(
+            methodName: 'logsNotifications',
+            params: [],
+          ),
+        ),
+      );
+
+      final stream = await pending.subscribe(
+        RpcSubscribeOptions(abortSignal: AbortController().signal),
+      );
+      final errorCompleter = Completer<Object?>();
+      final subscription = stream.listen(
+        (_) {},
+        onError: errorCompleter.complete,
+      );
+
+      publisher.publish('error', 'boom');
+      expect(await errorCompleter.future, 'boom');
+
+      await subscription.cancel();
+    });
+  });
+
+  group('RpcSubscriptions.request', () {
+    test('throws SolanaError when API cannot build a plan', () {
+      final subscriptions = RpcSubscriptions(
+        api: _TestApi(),
+        transport: (_) async => createDataPublisher(),
+      );
+
+      expect(
+        () => subscriptions.request('unknownNotifications'),
+        throwsA(
+          isA<SolanaError>()
+              .having(
+                (error) => error.code,
+                'code',
+                SolanaErrorCode.rpcSubscriptionsCannotCreateSubscriptionPlan,
+              )
+              .having(
+                (error) => error.context['notificationName'],
+                'notificationName',
+                'unknownNotifications',
+              ),
+        ),
+      );
+    });
+
+    test('returns a pending request when plan exists', () {
+      final subscriptions = RpcSubscriptions(
+        api: _TestApi(
+          plans: {
+            'slotNotifications': RpcSubscriptionsPlan<Object?>(
+              execute: (_) async => createDataPublisher(),
+              request: const RpcSubscriptionsRequest(
+                methodName: 'slotNotifications',
+                params: [],
+              ),
+            ),
+          },
+        ),
+        transport: (_) async => createDataPublisher(),
+      );
+
+      final pending = subscriptions.request('slotNotifications');
+      expect(pending, isA<PendingRpcSubscriptionsRequest<Object?>>());
+    });
+  });
+
+  group('factory functions', () {
+    test('createSubscriptionRpc preserves api and transport references', () {
+      final api = _TestApi();
+      Future<DataPublisher> transport(
+        RpcSubscriptionsTransportConfig _,
+      ) async => createDataPublisher();
+      final rpc = createSubscriptionRpc(
+        RpcSubscriptionsConfig(api: api, transport: transport),
+      );
+
+      expect(rpc.api, same(api));
+      expect(rpc.transport, same(transport));
+    });
+
+    test(
+      'createSolanaRpcSubscriptionsFromTransport builds passthrough plans',
+      () async {
+        RpcSubscriptionsTransportConfig? capturedConfig;
+        Future<DataPublisher> transport(
+          RpcSubscriptionsTransportConfig config,
+        ) async {
+          capturedConfig = config;
+          return createDataPublisher();
+        }
+
+        final rpc = createSolanaRpcSubscriptionsFromTransport(transport);
+        final pending = rpc.request('accountNotifications', ['pubkey', 'json']);
+        await pending.subscribe(
+          RpcSubscribeOptions(abortSignal: AbortController().signal),
+        );
+
+        expect(capturedConfig, isNotNull);
+        expect(capturedConfig!.request.methodName, 'accountNotifications');
+        expect(capturedConfig!.request.params, ['pubkey', 'json']);
+
+        final channel = _MockChannel();
+        final executeResult = await capturedConfig!.execute(
+          RpcSubscriptionsTransportExecuteConfig(
+            channel: channel,
+            signal: AbortController().signal,
+          ),
+        );
+        expect(executeResult, same(channel));
+      },
+    );
+
+    test('stable and unstable Solana factories return RpcSubscriptions', () {
+      final stable = createSolanaRpcSubscriptions('ws://localhost:8900');
+      final unstable = createSolanaRpcSubscriptionsUnstable(
+        'wss://api.devnet.solana.com',
+      );
+
+      expect(stable, isA<RpcSubscriptions>());
+      expect(unstable, isA<RpcSubscriptions>());
+      expect(
+        stable.request('accountNotifications', ['pubkey']),
+        isA<PendingRpcSubscriptionsRequest<Object?>>(),
+      );
+      expect(
+        unstable.request('voteNotifications'),
+        isA<PendingRpcSubscriptionsRequest<Object?>>(),
+      );
+    });
+  });
+}
+
+class _TestApi extends RpcSubscriptionsApi {
+  _TestApi({Map<String, RpcSubscriptionsPlan<Object?>>? plans})
+    : _plans = plans ?? const {};
+
+  final Map<String, RpcSubscriptionsPlan<Object?>> _plans;
+
+  @override
+  RpcSubscriptionsPlan<Object?>? getPlan(
+    String notificationName,
+    List<Object?> params,
+  ) {
+    return _plans[notificationName];
+  }
+}
+
+class _MockChannel implements RpcSubscriptionsChannel {
+  _MockChannel() : _publisher = createDataPublisher();
+
+  final WritableDataPublisher _publisher;
+
+  @override
+  UnsubscribeFn on(String channelName, Subscriber<Object?> subscriber) {
+    return _publisher.on(channelName, subscriber);
+  }
+
+  @override
+  Future<void> send(Object message) async {}
+}

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/lib/src/websocket_channel.dart
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/lib/src/websocket_channel.dart
@@ -52,14 +52,21 @@ class WebSocketChannelConfig {
   /// Creates a [WebSocketChannelConfig].
   const WebSocketChannelConfig({
     required this.url,
+    this.allowInsecureWs = false,
     this.sendBufferHighWatermark = 128 * 1024,
     this.signal,
   });
 
-  // TODO(security): Production usage should enforce `wss://` only. Not
-  // blocking because local development often uses `ws://`.
-  /// The WebSocket server URL (must use ws:// or wss:// protocol).
+  /// The WebSocket server URL.
+  ///
+  /// By default only `wss://` URLs are allowed. Set [allowInsecureWs] to
+  /// `true` to allow `ws://` URLs for local development and testing.
   final Uri url;
+
+  /// Whether to allow insecure `ws://` URLs.
+  ///
+  /// Defaults to `false`, which enforces `wss://` URLs.
+  final bool allowInsecureWs;
 
   /// The number of bytes to admit into the send buffer before queueing
   /// messages on the client.
@@ -137,6 +144,11 @@ Future<RpcSubscriptionsChannel> createWebSocketChannel(
     throw SolanaError(SolanaErrorCode.rpcSubscriptionsChannelConnectionClosed);
   }
 
+  _validateWebSocketUrl(
+    config.url,
+    allowInsecureWs: config.allowInsecureWs,
+  );
+
   final dataPublisher = createDataPublisher();
 
   WebSocketChannel webSocketChannel;
@@ -208,6 +220,44 @@ Future<RpcSubscriptionsChannel> createWebSocketChannel(
     dataPublisher: dataPublisher,
     webSocketChannel: webSocketChannel,
     isClosed: () => isClosed,
+  );
+}
+
+void _validateWebSocketUrl(
+  Uri url, {
+  required bool allowInsecureWs,
+}) {
+  final scheme = url.scheme.toLowerCase();
+
+  if (!url.isAbsolute || url.host.isEmpty) {
+    throw ArgumentError.value(
+      url.toString(),
+      'url',
+      'WebSocket URL must be an absolute URL.',
+    );
+  }
+
+  if (scheme == 'wss') {
+    return;
+  }
+
+  if (scheme == 'ws' && allowInsecureWs) {
+    return;
+  }
+
+  if (scheme == 'ws') {
+    throw ArgumentError.value(
+      url.toString(),
+      'url',
+      'Insecure WebSocket endpoints are disabled by default. '
+          'Use a wss:// URL or set allowInsecureWs: true for development.',
+    );
+  }
+
+  throw ArgumentError.value(
+    url.toString(),
+    'url',
+    "WebSocket URL must use either 'wss' or 'ws'.",
   );
 }
 

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/test/websocket_channel_test.dart
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/test/websocket_channel_test.dart
@@ -58,6 +58,13 @@ void main() {
   });
 
   group('WebSocketChannelConfig', () {
+    test('disallows insecure ws:// URLs by default', () {
+      final config = WebSocketChannelConfig(
+        url: Uri.parse('ws://example.com'),
+      );
+      expect(config.allowInsecureWs, isFalse);
+    });
+
     test('has default sendBufferHighWatermark of 128KB', () {
       final config = WebSocketChannelConfig(
         url: Uri.parse('wss://example.com'),
@@ -77,10 +84,12 @@ void main() {
       final url = Uri.parse('wss://example.com');
       final config = WebSocketChannelConfig(
         url: url,
+        allowInsecureWs: true,
         sendBufferHighWatermark: 42069,
         signal: signal,
       );
       expect(config.url, url);
+      expect(config.allowInsecureWs, isTrue);
       expect(config.sendBufferHighWatermark, 42069);
       expect(config.signal, same(signal));
     });
@@ -93,6 +102,7 @@ void main() {
         createWebSocketChannel(
           WebSocketChannelConfig(
             url: Uri.parse('ws://localhost:0'),
+            allowInsecureWs: true,
             signal: controller.signal,
           ),
         ),
@@ -115,6 +125,7 @@ void main() {
         createWebSocketChannel(
           WebSocketChannelConfig(
             url: Uri.parse('ws://localhost:0'),
+            allowInsecureWs: true,
             signal: controller.signal,
           ),
         ),
@@ -122,21 +133,36 @@ void main() {
       );
     });
 
-    test('throws when the connection fails', () async {
-      // Use a URL that will fail to connect (port 0 is not valid).
+    test('rejects insecure ws:// URLs by default', () async {
       await expectLater(
         createWebSocketChannel(
           WebSocketChannelConfig(url: Uri.parse('ws://localhost:1')),
         ),
-        throwsA(
-          isA<SolanaError>().having(
-            (e) => e.code,
-            'code',
-            SolanaErrorCode.rpcSubscriptionsChannelFailedToConnect,
-          ),
-        ),
+        throwsArgumentError,
       );
     });
+
+    test(
+      'throws when the connection fails with insecure ws:// enabled',
+      () async {
+        // Use a URL that will fail to connect.
+        await expectLater(
+          createWebSocketChannel(
+            WebSocketChannelConfig(
+              url: Uri.parse('ws://localhost:1'),
+              allowInsecureWs: true,
+            ),
+          ),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.rpcSubscriptionsChannelFailedToConnect,
+            ),
+          ),
+        );
+      },
+    );
   });
 
   group('a websocket channel', () {
@@ -162,7 +188,7 @@ void main() {
 
     test('resolves to a channel when the connection is established', () async {
       final channel = await createWebSocketChannel(
-        WebSocketChannelConfig(url: serverUrl),
+        WebSocketChannelConfig(url: serverUrl, allowInsecureWs: true),
       );
       expect(channel, isNotNull);
     });
@@ -170,7 +196,11 @@ void main() {
     test('publishes messages to message listeners', () async {
       final controller = AbortController();
       final channel = await createWebSocketChannel(
-        WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+        WebSocketChannelConfig(
+          url: serverUrl,
+          allowInsecureWs: true,
+          signal: controller.signal,
+        ),
       );
 
       final messages = <Object?>[];
@@ -190,7 +220,11 @@ void main() {
     test('publishes to multiple message listeners', () async {
       final controller = AbortController();
       final channel = await createWebSocketChannel(
-        WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+        WebSocketChannelConfig(
+          url: serverUrl,
+          allowInsecureWs: true,
+          signal: controller.signal,
+        ),
       );
 
       final messagesA = <Object?>[];
@@ -212,7 +246,11 @@ void main() {
     test('does not publish messages after abort', () async {
       final controller = AbortController();
       final channel = await createWebSocketChannel(
-        WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+        WebSocketChannelConfig(
+          url: serverUrl,
+          allowInsecureWs: true,
+          signal: controller.signal,
+        ),
       );
 
       final messages = <Object?>[];
@@ -231,7 +269,11 @@ void main() {
     test('sends a message to the websocket', () async {
       final controller = AbortController();
       final channel = await createWebSocketChannel(
-        WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+        WebSocketChannelConfig(
+          url: serverUrl,
+          allowInsecureWs: true,
+          signal: controller.signal,
+        ),
       );
 
       await _waitFor(() => serverSockets.isNotEmpty);
@@ -252,7 +294,11 @@ void main() {
       () async {
         final controller = AbortController();
         final channel = await createWebSocketChannel(
-          WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+          WebSocketChannelConfig(
+            url: serverUrl,
+            allowInsecureWs: true,
+            signal: controller.signal,
+          ),
         );
 
         final errors = <Object?>[];
@@ -282,7 +328,11 @@ void main() {
       () async {
         final controller = AbortController();
         final channel = await createWebSocketChannel(
-          WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+          WebSocketChannelConfig(
+            url: serverUrl,
+            allowInsecureWs: true,
+            signal: controller.signal,
+          ),
         );
 
         final errors = <Object?>[];
@@ -302,7 +352,11 @@ void main() {
     test('does not publish errors after abort', () async {
       final controller = AbortController();
       final channel = await createWebSocketChannel(
-        WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+        WebSocketChannelConfig(
+          url: serverUrl,
+          allowInsecureWs: true,
+          signal: controller.signal,
+        ),
       );
 
       final errors = <Object?>[];
@@ -322,7 +376,11 @@ void main() {
     test('throws when sending on a closed channel', () async {
       final controller = AbortController();
       final channel = await createWebSocketChannel(
-        WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+        WebSocketChannelConfig(
+          url: serverUrl,
+          allowInsecureWs: true,
+          signal: controller.signal,
+        ),
       );
 
       await _waitFor(() => serverSockets.isNotEmpty);
@@ -346,7 +404,11 @@ void main() {
     test('abort closes the websocket connection', () async {
       final controller = AbortController();
       await createWebSocketChannel(
-        WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+        WebSocketChannelConfig(
+          url: serverUrl,
+          allowInsecureWs: true,
+          signal: controller.signal,
+        ),
       );
 
       await _waitFor(() => serverSockets.isNotEmpty);
@@ -368,7 +430,11 @@ void main() {
     test('unsubscribing stops message delivery', () async {
       final controller = AbortController();
       final channel = await createWebSocketChannel(
-        WebSocketChannelConfig(url: serverUrl, signal: controller.signal),
+        WebSocketChannelConfig(
+          url: serverUrl,
+          allowInsecureWs: true,
+          signal: controller.signal,
+        ),
       );
 
       final messages = <Object?>[];

--- a/packages/solana_kit_rpc_transport_http/lib/src/http_transport.dart
+++ b/packages/solana_kit_rpc_transport_http/lib/src/http_transport.dart
@@ -30,7 +30,17 @@ RpcTransport createHttpTransport(
   HttpTransportConfig config, {
   http.Client? client,
 }) {
-  final HttpTransportConfig(:fromJson, :headers, :toJson, :url) = config;
+  final HttpTransportConfig(
+    :allowInsecureHttp,
+    :fromJson,
+    :headers,
+    :toJson,
+    :url,
+  ) = config;
+  final endpointUrl = _validateAndNormalizeHttpEndpoint(
+    url,
+    allowInsecureHttp: allowInsecureHttp,
+  );
 
   // Validate headers unconditionally to prevent forbidden headers in all
   // build modes (debug and release).
@@ -54,10 +64,8 @@ RpcTransport createHttpTransport(
       'content-type': 'application/json; charset=utf-8',
     };
 
-    // TODO(security): Production usage should enforce `https://` only. Not
-    // blocking because local development often uses `http://`.
     final response = await effectiveClient.post(
-      Uri.parse(url),
+      endpointUrl,
       headers: mergedHeaders,
       body: body,
     );
@@ -75,4 +83,44 @@ RpcTransport createHttpTransport(
 
     return jsonDecode(response.body);
   };
+}
+
+Uri _validateAndNormalizeHttpEndpoint(
+  String url, {
+  required bool allowInsecureHttp,
+}) {
+  final parsedUrl = Uri.parse(url);
+  final scheme = parsedUrl.scheme.toLowerCase();
+
+  if (!parsedUrl.isAbsolute || parsedUrl.host.isEmpty) {
+    throw ArgumentError.value(
+      url,
+      'url',
+      'HTTP transport URL must be an absolute URL.',
+    );
+  }
+
+  if (scheme == 'https') {
+    return parsedUrl;
+  }
+
+  if (scheme == 'http' && allowInsecureHttp) {
+    return parsedUrl;
+  }
+
+  if (scheme == 'http') {
+    throw ArgumentError.value(
+      url,
+      'url',
+      'Insecure HTTP endpoints are disabled by default. '
+          'Use an https:// URL or set allowInsecureHttp: true for '
+          'development.',
+    );
+  }
+
+  throw ArgumentError.value(
+    url,
+    'url',
+    "HTTP transport URL must use either 'https' or 'http'.",
+  );
 }

--- a/packages/solana_kit_rpc_transport_http/lib/src/http_transport_config.dart
+++ b/packages/solana_kit_rpc_transport_http/lib/src/http_transport_config.dart
@@ -8,6 +8,7 @@ class HttpTransportConfig {
   /// The [url] parameter is required and must be a valid HTTP or HTTPS URL.
   const HttpTransportConfig({
     required this.url,
+    this.allowInsecureHttp = false,
     this.fromJson,
     this.headers,
     this.toJson,
@@ -15,8 +16,16 @@ class HttpTransportConfig {
 
   /// A string representing the target endpoint.
   ///
-  /// Must be an absolute URL using the `http` or `https` protocol.
+  /// Must be an absolute URL.
+  ///
+  /// By default only `https://` URLs are allowed. Set [allowInsecureHttp] to
+  /// `true` to allow `http://` URLs for local development and testing.
   final String url;
+
+  /// Whether to allow insecure `http://` URLs.
+  ///
+  /// Defaults to `false`, which enforces `https://` URLs.
+  final bool allowInsecureHttp;
 
   /// An optional function that takes the response as a JSON string and
   /// converts it to a JSON value.

--- a/packages/solana_kit_rpc_transport_http/lib/src/http_transport_for_solana_rpc.dart
+++ b/packages/solana_kit_rpc_transport_http/lib/src/http_transport_for_solana_rpc.dart
@@ -31,12 +31,14 @@ import 'package:solana_kit_rpc_transport_http/src/is_solana_request.dart';
 /// used for requests (useful for testing).
 RpcTransport createHttpTransportForSolanaRpc({
   required String url,
+  bool allowInsecureHttp = false,
   Map<String, String>? headers,
   http.Client? client,
 }) {
   return createHttpTransport(
     HttpTransportConfig(
       url: url,
+      allowInsecureHttp: allowInsecureHttp,
       headers: headers,
       fromJson: (rawResponse, payload) =>
           isSolanaRequest(payload)

--- a/packages/solana_kit_rpc_transport_http/test/http_transport_for_solana_rpc_test.dart
+++ b/packages/solana_kit_rpc_transport_http/test/http_transport_for_solana_rpc_test.dart
@@ -8,6 +8,44 @@ import 'package:test/test.dart';
 
 void main() {
   group('createHttpTransportForSolanaRpc', () {
+    group('URL security', () {
+      test('rejects insecure http URLs by default', () {
+        expect(
+          () => createHttpTransportForSolanaRpc(url: 'http://localhost'),
+          throwsArgumentError,
+        );
+      });
+
+      test('allows insecure http URLs when explicitly enabled', () async {
+        late http.Request capturedRequest;
+        final mockClient = MockClient((request) async {
+          capturedRequest = request;
+          return http.Response(
+            '{"ok":true}',
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final transport = createHttpTransportForSolanaRpc(
+          url: 'http://localhost',
+          allowInsecureHttp: true,
+          client: mockClient,
+        );
+
+        await transport(
+          const RpcTransportConfig(
+            payload: <String, Object?>{
+              'jsonrpc': '2.0',
+              'method': 'getSlot',
+            },
+          ),
+        );
+
+        expect(capturedRequest.url.toString(), 'http://localhost');
+      });
+    });
+
     group('when the request is from the Solana RPC API', () {
       test(
         'passes all BigInts as large numerical values in the request body',
@@ -23,7 +61,7 @@ void main() {
           });
 
           final transport = createHttpTransportForSolanaRpc(
-            url: 'http://localhost',
+            url: 'https://localhost',
             client: mockClient,
           );
 
@@ -76,7 +114,7 @@ void main() {
         );
 
         final transport = createHttpTransportForSolanaRpc(
-          url: 'http://localhost',
+          url: 'https://localhost',
           client: mockClient,
         );
 
@@ -108,7 +146,7 @@ void main() {
         );
 
         final transport = createHttpTransportForSolanaRpc(
-          url: 'http://localhost',
+          url: 'https://localhost',
           client: mockClient,
         );
 
@@ -144,7 +182,7 @@ void main() {
         );
 
         final transport = createHttpTransportForSolanaRpc(
-          url: 'http://localhost',
+          url: 'https://localhost',
           client: mockClient,
         );
 

--- a/packages/solana_kit_rpc_transport_http/test/http_transport_test.dart
+++ b/packages/solana_kit_rpc_transport_http/test/http_transport_test.dart
@@ -9,6 +9,41 @@ import 'package:test/test.dart';
 
 void main() {
   group('createHttpTransport', () {
+    group('URL security', () {
+      test('rejects insecure http URLs by default', () {
+        expect(
+          () => createHttpTransport(
+            const HttpTransportConfig(url: 'http://localhost'),
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('allows insecure http URLs when explicitly enabled', () async {
+        late http.Request capturedRequest;
+        final mockClient = MockClient((request) async {
+          capturedRequest = request;
+          return http.Response(
+            jsonEncode({'ok': true}),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final transport = createHttpTransport(
+          const HttpTransportConfig(
+            url: 'http://localhost',
+            allowInsecureHttp: true,
+          ),
+          client: mockClient,
+        );
+
+        await transport(const RpcTransportConfig(payload: 123));
+
+        expect(capturedRequest.url.toString(), 'http://localhost');
+      });
+    });
+
     group('when the endpoint returns a well-formed JSON response', () {
       late http.Request capturedRequest;
       late RpcTransport transport;
@@ -24,14 +59,14 @@ void main() {
         });
 
         transport = createHttpTransport(
-          const HttpTransportConfig(url: 'http://localhost'),
+          const HttpTransportConfig(url: 'https://localhost'),
           client: mockClient,
         );
       });
 
       test('calls the specified URL', () async {
         await transport(const RpcTransportConfig(payload: 123));
-        expect(capturedRequest.url.toString(), 'http://localhost');
+        expect(capturedRequest.url.toString(), 'https://localhost');
       });
 
       test(
@@ -88,7 +123,7 @@ void main() {
 
         final transport = createHttpTransport(
           const HttpTransportConfig(
-            url: 'http://localhost',
+            url: 'https://localhost',
             headers: {'Authorization': 'Bearer token123'},
           ),
           client: mockClient,
@@ -111,7 +146,7 @@ void main() {
         expect(
           () => createHttpTransport(
             const HttpTransportConfig(
-              url: 'http://localhost',
+              url: 'https://localhost',
               headers: {'aCcEpT': 'text/html'},
             ),
             client: mockClient,
@@ -139,7 +174,7 @@ void main() {
         expect(
           () => createHttpTransport(
             const HttpTransportConfig(
-              url: 'http://localhost',
+              url: 'https://localhost',
               headers: {'Host': 'evil.example.com'},
             ),
             client: mockClient,
@@ -169,7 +204,7 @@ void main() {
 
           final transport = createHttpTransport(
             const HttpTransportConfig(
-              url: 'http://localhost',
+              url: 'https://localhost',
               headers: {'X-Custom-Header': 'custom-value'},
             ),
             client: mockClient,
@@ -196,7 +231,7 @@ void main() {
         );
 
         final transport = createHttpTransport(
-          const HttpTransportConfig(url: 'http://localhost'),
+          const HttpTransportConfig(url: 'https://localhost'),
           client: mockClient,
         );
 
@@ -224,7 +259,7 @@ void main() {
         );
 
         final transport = createHttpTransport(
-          const HttpTransportConfig(url: 'http://localhost'),
+          const HttpTransportConfig(url: 'https://localhost'),
           client: mockClient,
         );
 
@@ -253,7 +288,7 @@ void main() {
 
         final transport = createHttpTransport(
           HttpTransportConfig(
-            url: 'http://localhost',
+            url: 'https://localhost',
             toJson: (payload) => '{"someAugmented":"jsonString"}',
           ),
           client: mockClient,
@@ -276,7 +311,7 @@ void main() {
 
         final transport = createHttpTransport(
           HttpTransportConfig(
-            url: 'http://localhost',
+            url: 'https://localhost',
             toJson: (payload) {
               receivedPayload = payload;
               return jsonEncode(payload);
@@ -306,7 +341,7 @@ void main() {
 
         final transport = createHttpTransport(
           HttpTransportConfig(
-            url: 'http://localhost',
+            url: 'https://localhost',
             fromJson: (rawResponse, payload) {
               receivedRawResponse = rawResponse;
               receivedPayload = payload;
@@ -333,7 +368,7 @@ void main() {
 
         final transport = createHttpTransport(
           HttpTransportConfig(
-            url: 'http://localhost',
+            url: 'https://localhost',
             fromJson: (rawResponse, payload) => {'result': 456},
           ),
           client: mockClient,
@@ -360,7 +395,7 @@ void main() {
         });
 
         final transport = createHttpTransport(
-          const HttpTransportConfig(url: 'http://localhost'),
+          const HttpTransportConfig(url: 'https://localhost'),
           client: mockClient,
         );
 

--- a/packages/solana_kit_rpc_types/test/model_types_test.dart
+++ b/packages/solana_kit_rpc_types/test/model_types_test.dart
@@ -1,0 +1,228 @@
+// This file validates deprecated model compatibility while migration is active.
+// ignore_for_file: deprecated_member_use_from_same_package
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+const _addressA = Address('11111111111111111111111111111111');
+const _addressB = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+void main() {
+  group('Account filter models', () {
+    test('DataSlice stores offset/length', () {
+      const slice = DataSlice(offset: 12, length: 64);
+      expect(slice.offset, 12);
+      expect(slice.length, 64);
+    });
+
+    test('MemcmpFilterBase58 exposes encoding and fields', () {
+      final filter = MemcmpFilterBase58(
+        bytes: const Base58EncodedBytes('1111111111'),
+        offset: BigInt.from(8),
+      );
+      expect(filter.bytes, const Base58EncodedBytes('1111111111'));
+      expect(filter.offset, BigInt.from(8));
+      expect(filter.encoding, 'base58');
+    });
+
+    test('MemcmpFilterBase64 exposes encoding and fields', () {
+      final filter = MemcmpFilterBase64(
+        bytes: const Base64EncodedBytes('AQIDBA=='),
+        offset: BigInt.from(4),
+      );
+      expect(filter.bytes, const Base64EncodedBytes('AQIDBA=='));
+      expect(filter.offset, BigInt.from(4));
+      expect(filter.encoding, 'base64');
+    });
+
+    test('program account filters preserve payload objects', () {
+      final memcmpFilter = GetProgramAccountsMemcmpFilter(
+        memcmp: MemcmpFilterBase58(
+          bytes: const Base58EncodedBytes('11111111'),
+          offset: BigInt.zero,
+        ),
+      );
+      final dataSizeFilter = GetProgramAccountsDatasizeFilter(
+        dataSize: BigInt.from(165),
+      );
+
+      expect(memcmpFilter.memcmp, isA<MemcmpFilterBase58>());
+      expect(dataSizeFilter.dataSize, BigInt.from(165));
+    });
+  });
+
+  group('Account info models', () {
+    test('AccountInfoBase stores common account fields', () {
+      final accountInfo = AccountInfoBase(
+        executable: true,
+        lamports: lamports(BigInt.from(5000)),
+        owner: _addressA,
+        space: BigInt.from(128),
+      );
+
+      expect(accountInfo.executable, isTrue);
+      expect(accountInfo.lamports, lamports(BigInt.from(5000)));
+      expect(accountInfo.owner, _addressA);
+      expect(accountInfo.space, BigInt.from(128));
+    });
+
+    test('deprecated base58 wrappers preserve encoded tuple data', () {
+      const bytes = AccountInfoWithBase58Bytes(
+        data: Base58EncodedBytes('1111111111'),
+      );
+      const encoded = AccountInfoWithBase58EncodedData(
+        data: (Base58EncodedBytes('1111111111'), 'base58'),
+      );
+
+      expect(bytes.data, const Base58EncodedBytes('1111111111'));
+      expect(encoded.data.$1, const Base58EncodedBytes('1111111111'));
+      expect(encoded.data.$2, 'base58');
+    });
+
+    test('base64 wrappers preserve encoded tuple data', () {
+      const base64 = AccountInfoWithBase64EncodedData(
+        data: (Base64EncodedBytes('AQID'), 'base64'),
+      );
+      const zstd = AccountInfoWithBase64EncodedZStdCompressedData(
+        data: (
+          Base64EncodedZStdCompressedBytes('AQIDBA=='),
+          'base64+zstd',
+        ),
+      );
+
+      expect(base64.data.$1, const Base64EncodedBytes('AQID'));
+      expect(base64.data.$2, 'base64');
+      expect(
+        zstd.data.$1,
+        const Base64EncodedZStdCompressedBytes('AQIDBA=='),
+      );
+      expect(zstd.data.$2, 'base64+zstd');
+    });
+
+    test('json account data supports parsed and fallback variants', () {
+      final parsed = ParsedAccountData(
+        type: 'mint',
+        program: 'spl-token',
+        space: BigInt.from(82),
+        info: {'decimals': 9},
+      );
+      final parsedVariant = AccountInfoJsonDataParsed(parsed: parsed);
+      const fallbackVariant = AccountInfoJsonDataBase64(
+        data: (Base64EncodedBytes('AQID'), 'base64'),
+      );
+
+      final parsedWrapper = AccountInfoWithJsonData(data: parsedVariant);
+      const fallbackWrapper = AccountInfoWithJsonData(data: fallbackVariant);
+
+      expect((parsedWrapper.data as AccountInfoJsonDataParsed).parsed, parsed);
+      expect(
+        (fallbackWrapper.data as AccountInfoJsonDataBase64).data.$1,
+        const Base64EncodedBytes('AQID'),
+      );
+    });
+
+    test('AccountInfoWithPubkey keeps generic account value and pubkey', () {
+      final base = AccountInfoBase(
+        executable: false,
+        lamports: lamports(BigInt.from(1)),
+        owner: _addressA,
+        space: BigInt.from(0),
+      );
+      final wrapper = AccountInfoWithPubkey<AccountInfoBase>(
+        account: base,
+        pubkey: _addressB,
+      );
+
+      expect(wrapper.account, base);
+      expect(wrapper.pubkey, _addressB);
+    });
+  });
+
+  group('Primitive wrapper and response models', () {
+    test('cluster URL wrappers preserve original values', () {
+      final mainnetUrl = mainnet('https://api.mainnet-beta.solana.com');
+      final devnetUrl = devnet('https://api.devnet.solana.com');
+      final testnetUrl = testnet('https://api.testnet.solana.com');
+
+      expect(mainnetUrl, 'https://api.mainnet-beta.solana.com');
+      expect(devnetUrl, 'https://api.devnet.solana.com');
+      expect(testnetUrl, 'https://api.testnet.solana.com');
+
+      final ClusterUrl clusterUrl = mainnetUrl;
+      expect(clusterUrl, 'https://api.mainnet-beta.solana.com');
+    });
+
+    test('encoded byte wrappers and tuple responses keep labels', () {
+      const base58 = Base58EncodedBytes('11111111');
+      const base64 = Base64EncodedBytes('AQID');
+      const zstd = Base64EncodedZStdCompressedBytes('AQIDBA==');
+
+      const base58Response = (base58, 'base58');
+      const base64Response = (base64, 'base64');
+      const zstdResponse = (zstd, 'base64+zstd');
+
+      expect(base58Response.$1, base58);
+      expect(base58Response.$2, 'base58');
+      expect(base64Response.$1, base64);
+      expect(base64Response.$2, 'base64');
+      expect(zstdResponse.$1, zstd);
+      expect(zstdResponse.$2, 'base64+zstd');
+    });
+
+    test('rpc response wrappers preserve context and value type', () {
+      final response = SolanaRpcResponse<TokenAmount>(
+        context: RpcResponseContext(slot: BigInt.from(12345)),
+        value: const TokenAmount(
+          amount: StringifiedBigInt('1000'),
+          decimals: 6,
+          uiAmountString: StringifiedNumber('0.001'),
+        ),
+      );
+
+      expect(response.context.slot, BigInt.from(12345));
+      expect(response.value.amount, const StringifiedBigInt('1000'));
+      expect(response.value.uiAmountString, const StringifiedNumber('0.001'));
+    });
+
+    test('token amount and token balance retain all fields', () {
+      const amount = TokenAmount(
+        amount: StringifiedBigInt('4200'),
+        decimals: 2,
+        uiAmount: 42,
+        uiAmountString: StringifiedNumber('42'),
+      );
+      const balance = TokenBalance(
+        accountIndex: 3,
+        mint: _addressB,
+        owner: _addressA,
+        programId: _addressB,
+        uiTokenAmount: amount,
+      );
+
+      expect(amount.amount, const StringifiedBigInt('4200'));
+      expect(amount.decimals, 2);
+      expect(amount.uiAmount, 42.0);
+      expect(amount.uiAmountString, const StringifiedNumber('42'));
+      expect(balance.accountIndex, 3);
+      expect(balance.mint, _addressB);
+      expect(balance.owner, _addressA);
+      expect(balance.programId, _addressB);
+      expect(balance.uiTokenAmount, amount);
+    });
+
+    test('typed numeric aliases and wrappers preserve values', () {
+      final slot = BigInt.from(50);
+      final epoch = BigInt.from(7);
+      final microLamports = MicroLamports(BigInt.from(2500));
+      final signedLamports = -BigInt.from(5);
+      const ratio = 1.5;
+
+      expect(slot, BigInt.from(50));
+      expect(epoch, BigInt.from(7));
+      expect(microLamports.value, BigInt.from(2500));
+      expect(signedLamports, -BigInt.from(5));
+      expect(ratio, 1.5);
+    });
+  });
+}

--- a/packages/solana_kit_rpc_types/test/transaction_error_models_test.dart
+++ b/packages/solana_kit_rpc_types/test/transaction_error_models_test.dart
@@ -1,0 +1,71 @@
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('InstructionError models', () {
+    test('custom variant exposes label and code', () {
+      const error = InstructionErrorCustom(7012);
+      expect(error.label, 'Custom');
+      expect(error.code, 7012);
+    });
+
+    test('simple variant stores label directly', () {
+      const error = InstructionErrorSimple('InvalidInstructionData');
+      expect(error.label, 'InvalidInstructionData');
+    });
+
+    test('known labels remain available', () {
+      expect(InstructionErrorLabel.genericError, 'GenericError');
+      expect(
+        InstructionErrorLabel.computationalBudgetExceeded,
+        'ComputationalBudgetExceeded',
+      );
+      expect(
+        InstructionErrorLabel.maxInstructionTraceLengthExceeded,
+        'MaxInstructionTraceLengthExceeded',
+      );
+    });
+  });
+
+  group('TransactionError models', () {
+    test('simple variant stores label directly', () {
+      const error = TransactionErrorSimple('AccountInUse');
+      expect(error.label, 'AccountInUse');
+    });
+
+    test('DuplicateInstruction variant stores index and label', () {
+      const error = TransactionErrorDuplicateInstruction(2);
+      expect(error.label, 'DuplicateInstruction');
+      expect(error.instructionIndex, 2);
+    });
+
+    test('InstructionError variant stores nested instruction error', () {
+      const nested = InstructionErrorSimple('InvalidArgument');
+      const error = TransactionErrorInstructionError(5, nested);
+      expect(error.label, 'InstructionError');
+      expect(error.instructionIndex, 5);
+      expect(error.instructionError, nested);
+    });
+
+    test('InsufficientFundsForRent variant stores account index', () {
+      const error = TransactionErrorInsufficientFundsForRent(7);
+      expect(error.label, 'InsufficientFundsForRent');
+      expect(error.accountIndex, 7);
+    });
+
+    test('ProgramExecutionTemporarilyRestricted stores account index', () {
+      const error = TransactionErrorProgramExecutionTemporarilyRestricted(9);
+      expect(error.label, 'ProgramExecutionTemporarilyRestricted');
+      expect(error.accountIndex, 9);
+    });
+
+    test('known transaction labels remain available', () {
+      expect(TransactionErrorLabel.accountInUse, 'AccountInUse');
+      expect(TransactionErrorLabel.blockhashNotFound, 'BlockhashNotFound');
+      expect(
+        TransactionErrorLabel.wouldExceedMaxVoteCostLimit,
+        'WouldExceedMaxVoteCostLimit',
+      );
+    });
+  });
+}

--- a/packages/solana_kit_rpc_types/test/transaction_types_models_test.dart
+++ b/packages/solana_kit_rpc_types/test/transaction_types_models_test.dart
@@ -1,0 +1,133 @@
+// This file verifies deprecated status model compatibility during transition.
+// ignore_for_file: deprecated_member_use_from_same_package
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+const _accountA = Address('11111111111111111111111111111111');
+const _accountB = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+void main() {
+  group('Transaction version and lookup models', () {
+    test('version variants expose stable string forms', () {
+      expect(const TransactionVersionLegacy().toString(), 'legacy');
+      expect(const TransactionVersionV0().toString(), '0');
+    });
+
+    test('AddressTableLookup retains keys and index sets', () {
+      const lookup = AddressTableLookup(
+        accountKey: _accountA,
+        readonlyIndexes: [0, 2],
+        writableIndexes: [1, 3],
+      );
+
+      expect(lookup.accountKey, _accountA);
+      expect(lookup.readonlyIndexes, [0, 2]);
+      expect(lookup.writableIndexes, [1, 3]);
+    });
+  });
+
+  group('Reward models', () {
+    test('RewardFeeOrRent stores all shared reward fields', () {
+      final reward = RewardFeeOrRent(
+        rewardLamports: -BigInt.from(1000),
+        postBalance: lamports(BigInt.from(50_000)),
+        pubkey: _accountA,
+        rewardType: 'rent',
+      );
+
+      expect(reward.rewardLamports, -BigInt.from(1000));
+      expect(reward.postBalance, lamports(BigInt.from(50_000)));
+      expect(reward.pubkey, _accountA);
+      expect(reward.rewardType, 'rent');
+    });
+
+    test('RewardVotingOrStaking includes commission', () {
+      final reward = RewardVotingOrStaking(
+        rewardLamports: BigInt.from(2_500),
+        postBalance: lamports(BigInt.from(100_000)),
+        pubkey: _accountB,
+        rewardType: 'voting',
+        commission: 8,
+      );
+
+      expect(reward.rewardLamports, BigInt.from(2_500));
+      expect(reward.postBalance, lamports(BigInt.from(100_000)));
+      expect(reward.pubkey, _accountB);
+      expect(reward.rewardType, 'voting');
+      expect(reward.commission, 8);
+    });
+  });
+
+  group('Transaction status and metadata models', () {
+    test('deprecated TransactionStatus variants are constructible', () {
+      const ok = TransactionStatusOk();
+      const err = TransactionStatusErr(
+        TransactionErrorSimple('AccountInUse'),
+      );
+
+      expect(ok, isA<TransactionStatus>());
+      expect(err, isA<TransactionStatus>());
+      expect(err.error.label, 'AccountInUse');
+    });
+
+    test('TransactionForAccountsMetaBase stores balance/token metadata', () {
+      const tokenAmount = TokenAmount(
+        amount: StringifiedBigInt('100'),
+        decimals: 2,
+        uiAmountString: StringifiedNumber('1'),
+      );
+      const tokenBalance = TokenBalance(
+        accountIndex: 1,
+        mint: _accountB,
+        owner: _accountA,
+        programId: _accountB,
+        uiTokenAmount: tokenAmount,
+      );
+
+      final meta = TransactionForAccountsMetaBase(
+        err: const TransactionErrorSimple('SignatureFailure'),
+        fee: lamports(BigInt.from(5000)),
+        preBalances: [lamports(BigInt.from(10_000))],
+        postBalances: [lamports(BigInt.from(5_000))],
+        preTokenBalances: const [tokenBalance],
+        postTokenBalances: const [tokenBalance],
+      );
+
+      expect(meta.err?.label, 'SignatureFailure');
+      expect(meta.fee, lamports(BigInt.from(5000)));
+      expect(meta.preBalances.first, lamports(BigInt.from(10_000)));
+      expect(meta.postBalances.first, lamports(BigInt.from(5_000)));
+      expect(meta.preTokenBalances?.first, tokenBalance);
+      expect(meta.postTokenBalances?.first, tokenBalance);
+    });
+  });
+
+  group('Return and parsed account models', () {
+    test('ReturnData stores program id and encoded tuple', () {
+      const returnData = ReturnData(
+        data: (Base64EncodedBytes('AQID'), 'base64'),
+        programId: _accountA,
+      );
+
+      expect(returnData.programId, _accountA);
+      expect(returnData.data.$1, const Base64EncodedBytes('AQID'));
+      expect(returnData.data.$2, 'base64');
+    });
+
+    test('TransactionParsedAccount stores parsed account metadata', () {
+      const parsedAccount = TransactionParsedAccount(
+        pubkey: _accountB,
+        signer: true,
+        writable: false,
+        source: 'lookupTable',
+      );
+
+      expect(parsedAccount.pubkey, _accountB);
+      expect(parsedAccount.signer, isTrue);
+      expect(parsedAccount.writable, isFalse);
+      expect(parsedAccount.source, 'lookupTable');
+    });
+  });
+}

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
 
-A Dart port of the [Solana TypeScript SDK](https://github.com/anza-xyz/kit) (`@solana/kit`). This monorepo contains 39 packages that mirror the upstream TS package structure, built with modern Dart 3.10+ features including sealed classes, extension types, records, and patterns.
+A Dart port of the [Solana TypeScript SDK](https://github.com/anza-xyz/kit) (`@solana/kit`). This monorepo mirrors the upstream TS package structure, built with modern Dart 3.10+ features including sealed classes, extension types, records, and patterns.
 
 ## Quick Start
 
@@ -60,7 +60,7 @@ lint:all
 test:all
 
 # Generate merged test coverage across all packages
-melos run coverage
+test:coverage
 
 # Fix formatting and lint issues
 fix:all
@@ -70,7 +70,13 @@ The merged LCOV report is written to `coverage/lcov.info`.
 
 ## Packages
 
-The SDK is organized into 39 packages under `packages/`. Most users only need the umbrella package `solana_kit`, but each sub-package can be imported independently for smaller dependency footprints.
+<!-- workspace-summary:start -->
+
+This monorepo contains **40 packages** under `packages/`: **38 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
+
+<!-- workspace-summary:end -->
+
+Most users only need the umbrella package `solana_kit`, but each sub-package can be imported independently for smaller dependency footprints.
 
 ### Umbrella Packages
 
@@ -599,54 +605,54 @@ Exists because: MWA requires platform-specific transport (Android Intents for wa
 
 ### Package Dependency Graph
 
+Generated from package `pubspec.yaml` files with `scripts/workspace-doc-drift.sh --write`.
+
+<!-- workspace-dependency-graph:start -->
+
+```text
+solana_kit -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs, solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_functional, solana_kit_instruction_plans, solana_kit_instructions, solana_kit_keys, solana_kit_offchain_messages, solana_kit_options, solana_kit_program_client_core, solana_kit_programs, solana_kit_rpc, solana_kit_rpc_parsed_types, solana_kit_rpc_spec_types, solana_kit_rpc_subscriptions, solana_kit_rpc_transport_http, solana_kit_rpc_types, solana_kit_signers, solana_kit_subscribable, solana_kit_sysvars, solana_kit_transaction_confirmation, solana_kit_transaction_messages, solana_kit_transactions
+solana_kit_accounts -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors, solana_kit_rpc_spec, solana_kit_rpc_types
+solana_kit_addresses -> solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
+solana_kit_codecs -> solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_options
+solana_kit_codecs_core -> solana_kit_errors
+solana_kit_codecs_data_structures -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
+solana_kit_codecs_numbers -> solana_kit_codecs_core, solana_kit_errors
+solana_kit_codecs_strings -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
+solana_kit_errors -> (none)
+solana_kit_fast_stable_stringify -> (none)
+solana_kit_functional -> (none)
+solana_kit_helius -> solana_kit_errors
+solana_kit_instruction_plans -> solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_transaction_messages, solana_kit_transactions
+solana_kit_instructions -> solana_kit_addresses, solana_kit_errors
+solana_kit_keys -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
+solana_kit_lints -> (none)
+solana_kit_mobile_wallet_adapter -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_mobile_wallet_adapter_protocol, solana_kit_transactions
+solana_kit_mobile_wallet_adapter_protocol -> solana_kit_codecs_strings, solana_kit_errors
+solana_kit_offchain_messages -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_errors, solana_kit_keys
+solana_kit_options -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
+solana_kit_program_client_core -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_errors, solana_kit_instructions, solana_kit_rpc_spec, solana_kit_rpc_types, solana_kit_signers
+solana_kit_programs -> solana_kit_addresses, solana_kit_errors
+solana_kit_rpc -> solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_transport_http, solana_kit_rpc_types
+solana_kit_rpc_api -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_rpc_parsed_types, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_types, solana_kit_transaction_messages, solana_kit_transactions
+solana_kit_rpc_parsed_types -> solana_kit_addresses, solana_kit_errors, solana_kit_rpc_types
+solana_kit_rpc_spec -> solana_kit_errors, solana_kit_rpc_spec_types
+solana_kit_rpc_spec_types -> solana_kit_errors
+solana_kit_rpc_subscriptions -> solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_rpc_spec_types, solana_kit_rpc_subscriptions_api, solana_kit_rpc_subscriptions_channel_websocket, solana_kit_rpc_types, solana_kit_subscribable
+solana_kit_rpc_subscriptions_api -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_rpc_types
+solana_kit_rpc_subscriptions_channel_websocket -> solana_kit_errors, solana_kit_subscribable
+solana_kit_rpc_transformers -> solana_kit_errors, solana_kit_rpc_spec_types, solana_kit_rpc_types
+solana_kit_rpc_transport_http -> solana_kit_errors, solana_kit_rpc_spec, solana_kit_rpc_spec_types
+solana_kit_rpc_types -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_errors
+solana_kit_signers -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_transaction_messages, solana_kit_transactions
+solana_kit_subscribable -> solana_kit_errors
+solana_kit_sysvars -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_errors, solana_kit_rpc_spec, solana_kit_rpc_types
+solana_kit_test_matchers -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_transactions
+solana_kit_transaction_confirmation -> solana_kit_errors, solana_kit_rpc_subscriptions_channel_websocket, solana_kit_rpc_types, solana_kit_subscribable
+solana_kit_transaction_messages -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_errors, solana_kit_functional, solana_kit_instructions
+solana_kit_transactions -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_transaction_messages
 ```
-solana_kit_errors (foundation — no deps)
-├── solana_kit_addresses
-│   └── solana_kit_keys
-│       └── solana_kit_signers
-│
-├── solana_kit_codecs_core
-│   ├── solana_kit_codecs_numbers
-│   ├── solana_kit_codecs_strings
-│   └── solana_kit_codecs_data_structures
-│       └── solana_kit_codecs (umbrella)
-│           └── solana_kit_options
-│
-├── solana_kit_instructions
-│   └── solana_kit_transaction_messages
-│       └── solana_kit_transactions
-│
-├── solana_kit_rpc_spec_types
-│   ├── solana_kit_rpc_spec
-│   │   ├── solana_kit_rpc_transport_http
-│   │   └── solana_kit_rpc_transformers
-│   ├── solana_kit_rpc_types
-│   ├── solana_kit_rpc_parsed_types
-│   └── solana_kit_rpc_api
-│       └── solana_kit_rpc (main client)
-│
-├── solana_kit_subscribable
-│   ├── solana_kit_rpc_subscriptions_channel_websocket
-│   ├── solana_kit_rpc_subscriptions_api
-│   └── solana_kit_rpc_subscriptions (subscription client)
-│
-├── solana_kit_accounts
-│   ├── solana_kit_sysvars
-│   └── solana_kit_program_client_core
-│
-├── solana_kit_transaction_confirmation
-├── solana_kit_instruction_plans
-├── solana_kit_offchain_messages
-├── solana_kit_programs
-│
-├── solana_kit_functional (utility — no deps)
-├── solana_kit_fast_stable_stringify (utility — no deps)
-│
-├── solana_kit_mobile_wallet_adapter_protocol (pure Dart MWA protocol)
-│   └── solana_kit_mobile_wallet_adapter (Flutter MWA plugin)
-│
-└── solana_kit (umbrella — re-exports everything)
-```
+
+<!-- workspace-dependency-graph:end -->
 
 ### Design Principles
 

--- a/scripts/check-pr-changeset.sh
+++ b/scripts/check-pr-changeset.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+base_sha="${BASE_SHA:-}"
+head_sha="${HEAD_SHA:-}"
+
+if [[ -z "$base_sha" || -z "$head_sha" ]]; then
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    base_sha="$(git merge-base origin/main HEAD)"
+    head_sha="HEAD"
+  else
+    echo "BASE_SHA/HEAD_SHA are required when origin/main is unavailable." >&2
+    exit 2
+  fi
+fi
+
+changed_files="$(git diff --name-only "$base_sha...$head_sha")"
+
+if [[ -z "$changed_files" ]]; then
+  echo "No changed files detected."
+  exit 0
+fi
+
+package_changes="$(printf '%s\n' "$changed_files" | grep '^packages/' || true)"
+if [[ -z "$package_changes" ]]; then
+  echo "No package changes detected; changeset not required."
+  exit 0
+fi
+
+changeset_changes="$(printf '%s\n' "$changed_files" | grep '^\.changeset/.*\.md$' || true)"
+if [[ -n "$changeset_changes" ]]; then
+  echo "Changeset requirement satisfied."
+  exit 0
+fi
+
+echo "Package changes were detected without a changeset file under .changeset/*.md." >&2
+echo "Run 'knope document-change' and commit the generated changeset." >&2
+echo "Changed package files:" >&2
+printf '%s\n' "$package_changes" >&2
+exit 1

--- a/scripts/workspace-doc-drift.sh
+++ b/scripts/workspace-doc-drift.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/workspace-doc-drift.sh [--check|--write]
+
+  --check  Validate generated workspace summary/graph blocks in docs (default)
+  --write  Regenerate workspace summary/graph blocks in docs
+USAGE
+}
+
+mode="${1:---check}"
+if [[ "$mode" != "--check" && "$mode" != "--write" ]]; then
+  usage
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readme_file="$repo_root/readme.md"
+publishing_guide_file="$repo_root/docs/publishing-guide.md"
+
+for file in "$readme_file" "$publishing_guide_file"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing required file: $file" >&2
+    exit 2
+  fi
+done
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+packages_file="$tmp_dir/packages.txt"
+internal_packages_file="$tmp_dir/internal-packages.txt"
+graph_lines_file="$tmp_dir/graph-lines.txt"
+pubspecs_file="$tmp_dir/pubspecs.txt"
+
+find "$repo_root/packages" -mindepth 2 -maxdepth 2 -name pubspec.yaml | sort > "$pubspecs_file"
+
+while IFS= read -r pubspec; do
+  package_name="$(awk '/^name:[[:space:]]*/ { print $2; exit }' "$pubspec")"
+  if [[ -z "$package_name" ]]; then
+    echo "Failed to parse package name from $pubspec" >&2
+    exit 2
+  fi
+
+  printf '%s\n' "$package_name" >> "$packages_file"
+
+  if grep -Eq '^publish_to:[[:space:]]*none[[:space:]]*$' "$pubspec"; then
+    printf '%s\n' "$package_name" >> "$internal_packages_file"
+  fi
+done < "$pubspecs_file"
+
+sort -u -o "$packages_file" "$packages_file"
+
+while IFS= read -r pubspec; do
+  package_name="$(awk '/^name:[[:space:]]*/ { print $2; exit }' "$pubspec")"
+  deps_file="$tmp_dir/${package_name}.deps"
+
+  awk '
+    /^dependencies:[[:space:]]*$/ { in_dependencies = 1; next }
+    in_dependencies == 1 {
+      if ($0 ~ /^[^[:space:]]/) {
+        in_dependencies = 0
+        next
+      }
+      if ($0 ~ /^[[:space:]][[:space:]][A-Za-z0-9_]+:/) {
+        dependency = $1
+        sub(":", "", dependency)
+        print dependency
+      }
+    }
+  ' "$pubspec" | sort -u > "$deps_file"
+
+  filtered_deps_file="$tmp_dir/${package_name}.workspace-deps"
+  grep -xFf "$packages_file" "$deps_file" | sort -u > "$filtered_deps_file" || true
+
+  deps_line="$(awk 'NF { if (count++) printf ", "; printf "%s", $0 } END { if (count == 0) printf "(none)" }' "$filtered_deps_file")"
+  printf '%s -> %s\n' "$package_name" "$deps_line" >> "$graph_lines_file"
+done < "$pubspecs_file"
+
+if [[ -s "$internal_packages_file" ]]; then
+  sort -u -o "$internal_packages_file" "$internal_packages_file"
+else
+  : > "$internal_packages_file"
+fi
+sort -u -o "$graph_lines_file" "$graph_lines_file"
+
+total_packages="$(wc -l < "$packages_file" | tr -d '[:space:]')"
+internal_packages="$(wc -l < "$internal_packages_file" | tr -d '[:space:]')"
+publishable_packages="$((total_packages - internal_packages))"
+
+internal_packages_list="$(awk 'NF { if (count++) printf ", "; printf "`%s`", $0 } END { if (count == 0) printf "(none)" }' "$internal_packages_file")"
+
+summary_content_file="$tmp_dir/summary.md"
+cat > "$summary_content_file" <<EOF_SUMMARY
+
+This monorepo contains **$total_packages packages** under \`packages/\`: **$publishable_packages publishable** and **$internal_packages internal** ($internal_packages_list).
+
+EOF_SUMMARY
+
+graph_content_file="$tmp_dir/graph.md"
+{
+  echo
+  echo '```text'
+  cat "$graph_lines_file"
+  echo '```'
+  echo
+} > "$graph_content_file"
+
+replace_block() {
+  local input_file="$1"
+  local output_file="$2"
+  local start_marker="$3"
+  local end_marker="$4"
+  local content_file="$5"
+
+  awk \
+    -v start_marker="$start_marker" \
+    -v end_marker="$end_marker" \
+    -v content_file="$content_file" '
+      BEGIN {
+        inside = 0
+        found_start = 0
+        found_end = 0
+      }
+      $0 == start_marker {
+        print
+        while ((getline new_line < content_file) > 0) {
+          print new_line
+        }
+        close(content_file)
+        inside = 1
+        found_start = 1
+        next
+      }
+      $0 == end_marker && inside == 1 {
+        inside = 0
+        found_end = 1
+        print
+        next
+      }
+      inside == 0 {
+        print
+      }
+      END {
+        if (inside == 1 || found_start == 0 || found_end == 0) {
+          exit 3
+        }
+      }
+    ' "$input_file" > "$output_file"
+}
+
+apply_or_check_file() {
+  local file="$1"
+  local updated_file="$tmp_dir/$(basename "$file").updated"
+
+  cp "$file" "$updated_file.base"
+
+  replace_block \
+    "$updated_file.base" \
+    "$updated_file.step1" \
+    '<!-- workspace-summary:start -->' \
+    '<!-- workspace-summary:end -->' \
+    "$summary_content_file"
+
+  replace_block \
+    "$updated_file.step1" \
+    "$updated_file" \
+    '<!-- workspace-dependency-graph:start -->' \
+    '<!-- workspace-dependency-graph:end -->' \
+    "$graph_content_file"
+
+  if [[ "$mode" == "--write" ]]; then
+    mv "$updated_file" "$file"
+  else
+    if ! diff -u "$file" "$updated_file" >/dev/null; then
+      echo "Workspace documentation drift detected in $file" >&2
+      diff -u "$file" "$updated_file" >&2 || true
+      return 1
+    fi
+  fi
+}
+
+apply_or_check_file "$readme_file"
+apply_or_check_file "$publishing_guide_file"
+
+if [[ "$mode" == "--write" ]]; then
+  echo "Updated workspace summary and dependency graph blocks."
+else
+  echo "Workspace documentation blocks are up to date."
+fi


### PR DESCRIPTION
## Summary
- harden HTTP and WebSocket defaults to secure-only schemes with explicit opt-in for insecure transport
- add CI guards for PR changesets and workspace docs drift, plus release/publish workflow scaffolding
- implement missing program client core self-plan/send utility and add focused RPC/subscription/model coverage
- enforce changeset presence and workspace docs drift via scripts
- add repo changeset for modified publishable packages

## Validation
- test:all
- devenv shell -- test:coverage
- scripts/workspace-doc-drift.sh --check
- scripts/check-pr-changeset.sh
- targeted flutter test runs for modified packages

## Notes
- lint:analyze still reports existing repo-wide baseline infos/warnings outside this PR scope.
