### PR TITLE
fix: dedupe renderer devDependencies to root workspace

### DIFF
--- a/.changeset/fix_remove_duplicate_renderer_dev_dependencies.md
+++ b/.changeset/fix_remove_duplicate_renderer_dev_dependencies.md
@@ -1,0 +1,5 @@
+---
+codama_renderers: patch
+---
+
+Remove duplicate renderer devDependencies that are already provided by the root workspace, and update renderer scripts to invoke shared tools via `pnpm exec`.

--- a/packages/codama-renderers-dart/package.json
+++ b/packages/codama-renderers-dart/package.json
@@ -23,11 +23,11 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && tsup && tsc -p tsconfig.declarations.json",
+    "build": "pnpm exec rimraf dist && pnpm exec tsup && pnpm exec tsc -p tsconfig.declarations.json",
     "lint": "eslint --ext .ts src",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "test": "pnpm exec vitest run",
+    "test:watch": "pnpm exec vitest",
+    "typecheck": "pnpm exec tsc --noEmit"
   },
   "keywords": [
     "codama",
@@ -45,12 +45,7 @@
   },
   "devDependencies": {
     "@codama/nodes-from-anchor": "^1.3.9",
-    "@codama/renderers-js": "^2.0.2",
-    "@types/node": "^25.3.0",
-    "rimraf": "^6.0.1",
-    "tsup": "^8.4.0",
-    "typescript": "^5.7.3",
-    "vitest": "^3.2.1"
+    "@codama/renderers-js": "^2.0.2"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,21 +44,6 @@ importers:
       "@codama/renderers-js":
         specifier: ^2.0.2
         version: 2.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      "@types/node":
-        specifier: ^25.3.0
-        version: 25.3.0
-      rimraf:
-        specifier: ^6.0.1
-        version: 6.1.3
-      tsup:
-        specifier: ^8.4.0
-        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-      vitest:
-        specifier: ^3.2.1
-        version: 3.2.4(@types/node@25.3.0)
 
 packages:
   "@codama/errors@1.5.1":


### PR DESCRIPTION
## Summary
Remove duplicated renderer devDependencies that are already provided by the root workspace, and keep renderer scripts functional by running shared tools through `pnpm exec`.

## Changes
- `packages/codama-renderers-dart/package.json`
  - remove duplicated devDependencies: `@types/node`, `rimraf`, `tsup`, `typescript`, `vitest`
  - keep renderer-specific devDependencies only (`@codama/nodes-from-anchor`, `@codama/renderers-js`)
  - update scripts to use workspace tools via `pnpm exec`:
    - `build`
    - `test`
    - `test:watch`
    - `typecheck`
- `pnpm-lock.yaml`
  - remove the same duplicated renderer importer devDependency entries
- `.changeset/fix_remove_duplicate_renderer_dev_dependencies.md`
  - add release note metadata required by repository checks

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter codama-renderers-dart typecheck`
- `pnpm --filter codama-renderers-dart test`
- `pnpm --filter codama-renderers-dart build`
- `BASE_SHA=$(git merge-base origin/main HEAD) HEAD_SHA=HEAD scripts/check-pr-changeset.sh`

All commands passed locally.
