### PR TITLE
feat: phase 2 typed rpc convenience facade

### DIFF
--- a/.changeset/feat_phase2_typed_rpc_facade.md
+++ b/.changeset/feat_phase2_typed_rpc_facade.md
@@ -1,0 +1,10 @@
+---
+solana_kit_rpc: minor
+solana_kit_rpc_spec: minor
+---
+
+Add a typed RPC convenience facade for common Solana JSON-RPC calls.
+
+- Add generic `Rpc.request<TResponse>()` support in `solana_kit_rpc_spec`.
+- Add `SolanaRpcMethods` extension helpers in `solana_kit_rpc` for common RPC methods.
+- Expand docs with reusable markdown templates (`mdt`) and reusable Dart doc templates.

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -93,7 +93,7 @@ solana_kit_offchain_messages -> solana_kit_addresses, solana_kit_codecs_core, so
 solana_kit_options -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
 solana_kit_program_client_core -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_errors, solana_kit_instructions, solana_kit_rpc_spec, solana_kit_rpc_types, solana_kit_signers
 solana_kit_programs -> solana_kit_addresses, solana_kit_errors
-solana_kit_rpc -> solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_transport_http, solana_kit_rpc_types
+solana_kit_rpc -> solana_kit_addresses, solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_keys, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_transport_http, solana_kit_rpc_types
 solana_kit_rpc_api -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_rpc_parsed_types, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_types, solana_kit_transaction_messages, solana_kit_transactions
 solana_kit_rpc_parsed_types -> solana_kit_addresses, solana_kit_errors, solana_kit_rpc_types
 solana_kit_rpc_spec -> solana_kit_errors, solana_kit_rpc_spec_types

--- a/packages/solana_kit/README.md
+++ b/packages/solana_kit/README.md
@@ -9,6 +9,15 @@ The Solana Kit Dart SDK -- a comprehensive, modular Dart port of the [Solana Typ
 
 This is the umbrella package that re-exports all 35 public packages in the SDK, giving you a single import for the entire Solana development toolkit.
 
+<!-- {=upstreamSupportSection|replace:"__SOLANA_KIT_VERSION__":"6.1.0"} -->
+
+## Upstream Compatibility
+
+- Latest supported `@solana/kit` version: `6.1.0`
+- This Dart port tracks upstream APIs and behavior through `v6.1.0`.
+
+<!-- {/upstreamSupportSection} -->
+
 ## Installation
 
 Add `solana_kit` to your `pubspec.yaml`:
@@ -31,7 +40,7 @@ import 'package:solana_kit/solana_kit.dart';
 
 Future<void> main() async {
   // 1. Create an RPC client.
-  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+  final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
 
   // 2. Generate a new Ed25519 key pair.
   final keyPair = await generateKeyPair();
@@ -39,10 +48,10 @@ Future<void> main() async {
   print('Address: ${signer.address}');
 
   // 3. Check the balance.
-  final balanceResponse = await rpc.request('getBalance', [
-    signer.address.value,
-    {'commitment': 'confirmed'},
-  ]).send();
+  final balanceResponse = await rpc.getBalance(
+    signer.address,
+    const GetBalanceConfig(commitment: Commitment.confirmed),
+  ).send();
   print('Balance: $balanceResponse');
 
   // 4. Fetch an account.
@@ -112,16 +121,34 @@ Future<void> main() async {
 
 Make JSON-RPC calls to a Solana node.
 
+<!-- {=typedRpcMethodsSection|replace:"__RPC_IMPORT_PATH__":"package:solana_kit/solana_kit.dart"|replace:"__RPC_URL__":"https://api.devnet.solana.com"} -->
+
+### Typed RPC methods
+
+When working with an `Rpc`, prefer typed convenience helpers over stringly method calls:
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+final slot = await rpc.getSlot().send();
+final blockHeight = await rpc.getBlockHeight().send();
+```
+
+These helpers forward to canonical params builders in `solana_kit_rpc_api` and return lazy `PendingRpcRequest<T>` values.
+
+<!-- {/typedRpcMethodsSection} -->
+
 ```dart
 import 'package:solana_kit/solana_kit.dart';
 
 Future<void> main() async {
-  final rpc = createSolanaRpc('https://api.devnet.solana.com');
+  final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
 
   // Get the latest blockhash.
-  final blockhashResponse = await rpc.request('getLatestBlockhash', [
-    {'commitment': 'confirmed'},
-  ]).send();
+  final blockhashResponse = await rpc.getLatestBlockhash(
+    const GetLatestBlockhashConfig(commitment: Commitment.confirmed),
+  ).send();
   print('Blockhash: $blockhashResponse');
 
   // Get the minimum balance for rent exemption.

--- a/packages/solana_kit_rpc/README.md
+++ b/packages/solana_kit_rpc/README.md
@@ -31,20 +31,39 @@ If you are working within the `solana_kit` monorepo, the package resolves throug
 The simplest way to create an RPC client is with `createSolanaRpc`, which sets up a fully configured client with sensible defaults -- including request coalescing, BigInt handling, and a `solana-client` header.
 
 ```dart
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
 import 'package:solana_kit_rpc/solana_kit_rpc.dart';
 
 final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
 
 // Make an RPC call.
-final slot = await rpc.request('getSlot').send();
+final slot = await rpc.getSlot().send();
 print('Current slot: $slot');
 
 // Query an account balance.
-final balance = await rpc.request('getBalance', [
-  '83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK',
-]).send();
+final balance = await rpc.getBalance(
+  const Address('83astBRguLMdt2h5U1Tbd4hU5SkfAWRkzG2HPM88BREAK'),
+).send();
 print('Balance: $balance');
 ```
+
+<!-- {=typedRpcMethodsSection|replace:"__RPC_IMPORT_PATH__":"package:solana_kit_rpc/solana_kit_rpc.dart"|replace:"__RPC_URL__":"https://api.mainnet-beta.solana.com"} -->
+
+### Typed RPC methods
+
+When working with an `Rpc`, prefer typed convenience helpers over stringly method calls:
+
+```dart
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
+final slot = await rpc.getSlot().send();
+final blockHeight = await rpc.getBlockHeight().send();
+```
+
+These helpers forward to canonical params builders in `solana_kit_rpc_api` and return lazy `PendingRpcRequest<T>` values.
+
+<!-- {/typedRpcMethodsSection} -->
 
 You can pass custom headers and an `http.Client` instance:
 

--- a/packages/solana_kit_rpc/lib/solana_kit_rpc.dart
+++ b/packages/solana_kit_rpc/lib/solana_kit_rpc.dart
@@ -12,6 +12,7 @@ library;
 export 'src/rpc.dart';
 export 'src/rpc_default_config.dart';
 export 'src/rpc_integer_overflow_error.dart';
+export 'src/rpc_methods.dart';
 export 'src/rpc_request_coalescer.dart';
 export 'src/rpc_request_deduplication.dart';
 export 'src/rpc_transport.dart';

--- a/packages/solana_kit_rpc/lib/src/rpc.dart
+++ b/packages/solana_kit_rpc/lib/src/rpc.dart
@@ -11,7 +11,7 @@ import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
 ///
 /// ```dart
 /// final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
-/// final slot = await rpc.request('getSlot').send();
+/// final slot = await rpc.getSlot().send();
 /// ```
 ///
 /// By default, only `https://` URLs are allowed. Set [allowInsecureHttp] to

--- a/packages/solana_kit_rpc/lib/src/rpc_methods.dart
+++ b/packages/solana_kit_rpc/lib/src/rpc_methods.dart
@@ -1,0 +1,173 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+
+/// Typed convenience methods for common Solana JSON-RPC calls.
+///
+/// These helpers wrap [Rpc.request] and method-specific params builders from
+/// `solana_kit_rpc_api`, so callers do not need to manually assemble RPC
+/// method names and positional params arrays.
+extension SolanaRpcMethods on Rpc {
+  /// {@template solanaKitRpcMethodPendingRequest}
+  /// Returns a lazy [PendingRpcRequest].
+  ///
+  /// No network call is made until [PendingRpcRequest.send] is called.
+  /// {@endtemplate}
+  ///
+  /// {@template solanaKitRpcMethodRawResponseShape}
+  /// Response values preserve Solana JSON-RPC result shapes after default
+  /// transformers are applied (error handling, `result` extraction, and BigInt
+  /// upcasting).
+  /// {@endtemplate}
+  ///
+  /// Fetches details for an account.
+  ///
+  /// This wraps the `getAccountInfo` RPC method.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  /// {@macro solanaKitRpcMethodRawResponseShape}
+  PendingRpcRequest<Map<String, Object?>> getAccountInfo(
+    Address address, [
+    GetAccountInfoConfig? config,
+  ]) {
+    return request<Map<String, Object?>>(
+      'getAccountInfo',
+      getAccountInfoParams(address, config),
+    );
+  }
+
+  /// Fetches account balance with context metadata.
+  ///
+  /// This wraps the `getBalance` RPC method.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  /// {@macro solanaKitRpcMethodRawResponseShape}
+  PendingRpcRequest<Map<String, Object?>> getBalance(
+    Address address, [
+    GetBalanceConfig? config,
+  ]) {
+    return request<Map<String, Object?>>(
+      'getBalance',
+      getBalanceParams(address, config),
+    );
+  }
+
+  /// Fetches the current block height.
+  ///
+  /// This wraps the `getBlockHeight` RPC method.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  PendingRpcRequest<Slot> getBlockHeight([GetBlockHeightConfig? config]) {
+    return request<Slot>('getBlockHeight', getBlockHeightParams(config));
+  }
+
+  /// Fetches the fee for a serialized transaction message.
+  ///
+  /// This wraps the `getFeeForMessage` RPC method.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  /// {@macro solanaKitRpcMethodRawResponseShape}
+  PendingRpcRequest<Map<String, Object?>> getFeeForMessage(
+    String message, [
+    GetFeeForMessageConfig? config,
+  ]) {
+    return request<Map<String, Object?>>(
+      'getFeeForMessage',
+      getFeeForMessageParams(message, config),
+    );
+  }
+
+  /// Fetches the latest blockhash and expiry metadata.
+  ///
+  /// This wraps the `getLatestBlockhash` RPC method.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  /// {@macro solanaKitRpcMethodRawResponseShape}
+  PendingRpcRequest<Map<String, Object?>> getLatestBlockhash([
+    GetLatestBlockhashConfig? config,
+  ]) {
+    return request<Map<String, Object?>>(
+      'getLatestBlockhash',
+      getLatestBlockhashParams(config),
+    );
+  }
+
+  /// Fetches status details for one or more signatures.
+  ///
+  /// This wraps the `getSignatureStatuses` RPC method.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  /// {@macro solanaKitRpcMethodRawResponseShape}
+  PendingRpcRequest<Map<String, Object?>> getSignatureStatuses(
+    List<Signature> signatures, [
+    GetSignatureStatusesConfig? config,
+  ]) {
+    return request<Map<String, Object?>>(
+      'getSignatureStatuses',
+      getSignatureStatusesParams(signatures, config),
+    );
+  }
+
+  /// Fetches the current slot.
+  ///
+  /// This wraps the `getSlot` RPC method.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  PendingRpcRequest<Slot> getSlot([GetSlotConfig? config]) {
+    return request<Slot>('getSlot', getSlotParams(config));
+  }
+
+  /// Fetches transaction details for [signature].
+  ///
+  /// This wraps the `getTransaction` RPC method.
+  ///
+  /// Returns `null` when the transaction cannot be found.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  /// {@macro solanaKitRpcMethodRawResponseShape}
+  PendingRpcRequest<Map<String, Object?>?> getTransaction(
+    Signature signature, [
+    GetTransactionConfig? config,
+  ]) {
+    return request<Map<String, Object?>?>(
+      'getTransaction',
+      getTransactionParams(signature, config),
+    );
+  }
+
+  /// Requests an airdrop and returns the submitted transaction signature.
+  ///
+  /// This wraps the `requestAirdrop` RPC method.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  PendingRpcRequest<String> requestAirdrop(
+    Address recipientAccount,
+    Lamports lamports, [
+    RequestAirdropConfig? config,
+  ]) {
+    return request<String>(
+      'requestAirdrop',
+      requestAirdropParams(recipientAccount, lamports, config),
+    );
+  }
+
+  /// Sends a wire transaction and returns the transaction signature.
+  ///
+  /// This wraps the `sendTransaction` RPC method.
+  ///
+  /// [base64EncodedWireTransaction] should be a serialized transaction encoded
+  /// as base64.
+  ///
+  /// {@macro solanaKitRpcMethodPendingRequest}
+  PendingRpcRequest<String> sendTransaction(
+    String base64EncodedWireTransaction, [
+    SendTransactionConfig? config,
+  ]) {
+    return request<String>(
+      'sendTransaction',
+      sendTransactionParams(base64EncodedWireTransaction, config),
+    );
+  }
+}

--- a/packages/solana_kit_rpc/pubspec.yaml
+++ b/packages/solana_kit_rpc/pubspec.yaml
@@ -11,8 +11,10 @@ resolution: workspace
 
 dependencies:
   http: ^1.4.0
+  solana_kit_addresses: ^0.2.0
   solana_kit_errors: ^0.2.0
   solana_kit_fast_stable_stringify: ^0.2.0
+  solana_kit_keys: ^0.2.0
   solana_kit_rpc_api: ^0.2.0
   solana_kit_rpc_spec: ^0.2.0
   solana_kit_rpc_spec_types: ^0.2.0

--- a/packages/solana_kit_rpc/test/rpc_methods_test.dart
+++ b/packages/solana_kit_rpc/test/rpc_methods_test.dart
@@ -1,0 +1,221 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
+import 'package:solana_kit_rpc/solana_kit_rpc.dart';
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SolanaRpcMethods', () {
+    const testAddress = Address('11111111111111111111111111111111');
+    const testSignature = Signature('test-signature');
+
+    test('getAccountInfo sends method-specific params', () async {
+      final response = await _captureCall(
+        (rpc) => rpc
+            .getAccountInfo(
+              testAddress,
+              const GetAccountInfoConfig(encoding: 'base64'),
+            )
+            .send(),
+        rpcResult: {
+          'context': {'slot': 1},
+          'value': null,
+        },
+      );
+
+      expect(response.payload['method'], 'getAccountInfo');
+      expect(response.payload['params'], [
+        testAddress.value,
+        {'encoding': 'base64', 'commitment': 'confirmed'},
+      ]);
+      expect(response.result, isA<Map<String, Object?>>());
+    });
+
+    test('getBalance sends method-specific params', () async {
+      final response = await _captureCall(
+        (rpc) => rpc
+            .getBalance(
+              testAddress,
+              const GetBalanceConfig(commitment: Commitment.confirmed),
+            )
+            .send(),
+        rpcResult: {
+          'context': {'slot': 1},
+          'value': 1000,
+        },
+      );
+
+      expect(response.payload['method'], 'getBalance');
+      expect(response.payload['params'], [
+        testAddress.value,
+        {'commitment': 'confirmed'},
+      ]);
+      expect(response.result, isA<Map<String, Object?>>());
+    });
+
+    test('getBlockHeight returns a typed slot', () async {
+      final response = await _captureCall(
+        (rpc) => rpc
+            .getBlockHeight(
+              const GetBlockHeightConfig(commitment: Commitment.finalized),
+            )
+            .send(),
+        rpcResult: 42,
+      );
+
+      expect(response.payload['method'], 'getBlockHeight');
+      // `finalized` is server default and is stripped by request transformers.
+      expect(response.payload['params'], <Object?>[]);
+      expect(response.result, BigInt.from(42));
+    });
+
+    test('getFeeForMessage sends method-specific params', () async {
+      final response = await _captureCall(
+        (rpc) => rpc
+            .getFeeForMessage(
+              'base64-message',
+              const GetFeeForMessageConfig(commitment: Commitment.processed),
+            )
+            .send(),
+        rpcResult: {
+          'context': {'slot': 1},
+          'value': 5000,
+        },
+      );
+
+      expect(response.payload['method'], 'getFeeForMessage');
+      expect(response.payload['params'], [
+        'base64-message',
+        {'commitment': 'processed'},
+      ]);
+      expect(response.result, isA<Map<String, Object?>>());
+    });
+
+    test('getLatestBlockhash sends method-specific params', () async {
+      final response = await _captureCall(
+        (rpc) => rpc
+            .getLatestBlockhash(
+              const GetLatestBlockhashConfig(commitment: Commitment.confirmed),
+            )
+            .send(),
+        rpcResult: {
+          'context': {'slot': 1},
+          'value': {
+            'blockhash': 'J4yED2jcMAHyQUg61DBmm4njmEydUr2WqrV9cdEcDDgL',
+            'lastValidBlockHeight': 10,
+          },
+        },
+      );
+
+      expect(response.payload['method'], 'getLatestBlockhash');
+      expect(response.payload['params'], [
+        {'commitment': 'confirmed'},
+      ]);
+      expect(response.result, isA<Map<String, Object?>>());
+    });
+
+    test('getSignatureStatuses sends method-specific params', () async {
+      final response = await _captureCall(
+        (rpc) => rpc.getSignatureStatuses(
+          [testSignature],
+          const GetSignatureStatusesConfig(searchTransactionHistory: true),
+        ).send(),
+        rpcResult: {
+          'context': {'slot': 1},
+          'value': [null],
+        },
+      );
+
+      expect(response.payload['method'], 'getSignatureStatuses');
+      expect(response.payload['params'], [
+        [testSignature.value],
+        {'searchTransactionHistory': true},
+      ]);
+      expect(response.result, isA<Map<String, Object?>>());
+    });
+
+    test('getSlot returns a typed slot', () async {
+      final response = await _captureCall(
+        (rpc) => rpc.getSlot(const GetSlotConfig()).send(),
+        rpcResult: 99,
+      );
+
+      expect(response.payload['method'], 'getSlot');
+      expect(response.payload['params'], [
+        {'commitment': 'confirmed'},
+      ]);
+      expect(response.result, BigInt.from(99));
+    });
+
+    test('getTransaction returns null when result is missing', () async {
+      final response = await _captureCall<Map<String, Object?>?>(
+        (rpc) => rpc.getTransaction(testSignature).send(),
+        rpcResult: null,
+      );
+
+      expect(response.payload['method'], 'getTransaction');
+      expect(response.payload['params'], [
+        testSignature.value,
+        {'commitment': 'confirmed'},
+      ]);
+      expect(response.result, isNull);
+    });
+
+    test('requestAirdrop returns transaction signature', () async {
+      final response = await _captureCall(
+        (rpc) => rpc
+            .requestAirdrop(
+              testAddress,
+              Lamports(BigInt.from(5000)),
+              const RequestAirdropConfig(commitment: Commitment.confirmed),
+            )
+            .send(),
+        rpcResult: 'airdrop-signature',
+      );
+
+      expect(response.payload['method'], 'requestAirdrop');
+      final params = response.payload['params']! as List<Object?>;
+      expect(params.first, testAddress.value);
+      expect(params[1], anyOf(BigInt.from(5000), 5000));
+      expect(params[2], {'commitment': 'confirmed'});
+      expect(response.result, 'airdrop-signature');
+    });
+
+    test('sendTransaction returns transaction signature', () async {
+      final response = await _captureCall(
+        (rpc) => rpc
+            .sendTransaction(
+              'AQIDBA==',
+              const SendTransactionConfig(skipPreflight: true),
+            )
+            .send(),
+        rpcResult: 'send-signature',
+      );
+
+      expect(response.payload['method'], 'sendTransaction');
+      expect(response.payload['params'], [
+        'AQIDBA==',
+        {'skipPreflight': true, 'preflightCommitment': 'confirmed'},
+      ]);
+      expect(response.result, 'send-signature');
+    });
+  });
+}
+
+Future<({T result, Map<String, Object?> payload})> _captureCall<
+  T extends Object?
+>(Future<T> Function(Rpc rpc) invoke, {required Object? rpcResult}) async {
+  late Map<String, Object?> payload;
+
+  final rpc = createSolanaRpcFromTransport((config) async {
+    payload = Map<String, Object?>.from(
+      config.payload! as Map<String, Object?>,
+    );
+    return {'jsonrpc': '2.0', 'id': '1', 'result': rpcResult};
+  });
+
+  final result = await invoke(rpc);
+  return (result: result, payload: payload);
+}

--- a/packages/solana_kit_rpc_spec/lib/src/rpc.dart
+++ b/packages/solana_kit_rpc_spec/lib/src/rpc.dart
@@ -133,12 +133,26 @@ class Rpc {
   /// The transport used to send RPC requests.
   final RpcTransport transport;
 
-  /// Creates a [PendingRpcRequest] for the given [methodName] and [params].
+  /// {@template solanaKitRpcSpecRequestSummary}
+  /// Creates a [PendingRpcRequest] for [methodName] and [params].
+  ///
+  /// The request is lazy. No network call happens until [PendingRpcRequest.send]
+  /// is invoked.
+  /// {@endtemplate}
+  ///
+  /// {@template solanaKitRpcSpecTypedRequest}
+  /// Use the optional generic [TResponse] to express the expected response type.
+  /// This helps downstream APIs expose typed convenience wrappers while
+  /// preserving the dynamic escape hatch.
+  /// {@endtemplate}
+  ///
+  /// {@macro solanaKitRpcSpecRequestSummary}
+  /// {@macro solanaKitRpcSpecTypedRequest}
   ///
   /// Throws a [SolanaError] with code
   /// [SolanaErrorCode.rpcApiPlanMissingForRpcMethod] if no API plan is
   /// available for the given method.
-  PendingRpcRequest<Object?> request(
+  PendingRpcRequest<TResponse> request<TResponse extends Object?>(
     String methodName, [
     List<Object?> params = const [],
   ]) {
@@ -149,7 +163,14 @@ class Rpc {
         'params': params,
       });
     }
-    return PendingRpcRequest<Object?>(plan: plan, transport: transport);
+    return PendingRpcRequest<TResponse>(
+      plan: RpcPlan<TResponse>(
+        execute: (config) async {
+          return await plan.execute(config) as TResponse;
+        },
+      ),
+      transport: transport,
+    );
   }
 }
 

--- a/packages/solana_kit_rpc_spec/test/rpc_test.dart
+++ b/packages/solana_kit_rpc_spec/test/rpc_test.dart
@@ -69,6 +69,24 @@ void main() {
         expect(result, 123);
       });
 
+      test('supports typed requests', () async {
+        makeHttpRequest = (config) async => 123;
+        rpc = createRpc(
+          RpcConfig(api: _ProxyRpcApi(), transport: makeHttpRequest),
+        );
+        final result = await rpc.request<int>('someMethod').send();
+        expect(result, 123);
+      });
+
+      test('throws when typed request cast is invalid', () async {
+        makeHttpRequest = (config) async => 123;
+        rpc = createRpc(
+          RpcConfig(api: _ProxyRpcApi(), transport: makeHttpRequest),
+        );
+        final sendFuture = rpc.request<String>('someMethod').send();
+        await expectLater(sendFuture, throwsA(isA<TypeError>()));
+      });
+
       test('throws errors from the transport', () async {
         final transportError = Exception('o no');
         makeHttpRequest = (config) async => throw transportError;

--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,14 @@ A Dart port of the [Solana TypeScript SDK](https://github.com/anza-xyz/kit) (`@s
 
 ## Upstream Compatibility
 
+<!-- {=upstreamSupportSection|replace:"__SOLANA_KIT_VERSION__":"6.1.0"} -->
+
+## Upstream Compatibility
+
 - Latest supported `@solana/kit` version: `6.1.0`
 - This Dart port tracks upstream APIs and behavior through `v6.1.0`.
+
+<!-- {/upstreamSupportSection} -->
 
 ## Quick Start
 
@@ -16,7 +22,7 @@ A Dart port of the [Solana TypeScript SDK](https://github.com/anza-xyz/kit) (`@s
 import 'package:solana_kit/solana_kit.dart';
 
 // Create an RPC client
-final rpc = createSolanaRpc('https://api.mainnet-beta.solana.com');
+final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
 
 // Generate a key pair
 final keyPair = await generateKeyPair();
@@ -27,6 +33,24 @@ final message = createTransactionMessage()
   .pipe(setTransactionMessageLifetimeUsingBlockhash(blockhash))
   .pipe(appendTransactionMessageInstruction(instruction));
 ```
+
+<!-- {=typedRpcMethodsSection|replace:"__RPC_IMPORT_PATH__":"package:solana_kit/solana_kit.dart"|replace:"__RPC_URL__":"https://api.mainnet-beta.solana.com"} -->
+
+### Typed RPC methods
+
+When working with an `Rpc`, prefer typed convenience helpers over stringly method calls:
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
+final slot = await rpc.getSlot().send();
+final blockHeight = await rpc.getBlockHeight().send();
+```
+
+These helpers forward to canonical params builders in `solana_kit_rpc_api` and return lazy `PendingRpcRequest<T>` values.
+
+<!-- {/typedRpcMethodsSection} -->
 
 ## Getting Started
 
@@ -643,7 +667,7 @@ solana_kit_offchain_messages -> solana_kit_addresses, solana_kit_codecs_core, so
 solana_kit_options -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
 solana_kit_program_client_core -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_errors, solana_kit_instructions, solana_kit_rpc_spec, solana_kit_rpc_types, solana_kit_signers
 solana_kit_programs -> solana_kit_addresses, solana_kit_errors
-solana_kit_rpc -> solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_transport_http, solana_kit_rpc_types
+solana_kit_rpc -> solana_kit_addresses, solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_keys, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_transport_http, solana_kit_rpc_types
 solana_kit_rpc_api -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_rpc_parsed_types, solana_kit_rpc_spec, solana_kit_rpc_spec_types, solana_kit_rpc_transformers, solana_kit_rpc_types, solana_kit_transaction_messages, solana_kit_transactions
 solana_kit_rpc_parsed_types -> solana_kit_addresses, solana_kit_errors, solana_kit_rpc_types
 solana_kit_rpc_spec -> solana_kit_errors, solana_kit_rpc_spec_types

--- a/template.t.md
+++ b/template.t.md
@@ -14,3 +14,30 @@ Use [`__EXAMPLE_PATH__`](./__EXAMPLE_PATH__) as a runnable starting point for `_
 - Keep examples focused on one workflow and reference package README sections for deeper API details.
 
 <!-- {/packageExampleSection} -->
+
+<!-- {@upstreamSupportSection} -->
+
+## Upstream Compatibility
+
+- Latest supported `@solana/kit` version: `__SOLANA_KIT_VERSION__`
+- This Dart port tracks upstream APIs and behavior through `v__SOLANA_KIT_VERSION__`.
+
+<!-- {/upstreamSupportSection} -->
+
+<!-- {@typedRpcMethodsSection} -->
+
+### Typed RPC methods
+
+When working with an `Rpc`, prefer typed convenience helpers over stringly method calls:
+
+```dart
+import '__RPC_IMPORT_PATH__';
+
+final rpc = createSolanaRpc(url: '__RPC_URL__');
+final slot = await rpc.getSlot().send();
+final blockHeight = await rpc.getBlockHeight().send();
+```
+
+These helpers forward to canonical params builders in `solana_kit_rpc_api` and return lazy `PendingRpcRequest<T>` values.
+
+<!-- {/typedRpcMethodsSection} -->


### PR DESCRIPTION
## Summary

This PR delivers **Phase 2** of the idiomatic Dart API roadmap by adding a typed RPC convenience surface on top of the existing `request()` escape hatch.

### What changed

- Add generic typed requests in `solana_kit_rpc_spec`:
  - `Rpc.request<TResponse>()`
- Add typed convenience RPC helpers in `solana_kit_rpc`:
  - `getAccountInfo`
  - `getBalance`
  - `getBlockHeight`
  - `getFeeForMessage`
  - `getLatestBlockhash`
  - `getSignatureStatuses`
  - `getSlot`
  - `getTransaction`
  - `requestAirdrop`
  - `sendTransaction`
- Export new helper extension from `solana_kit_rpc`.
- Add package dependencies required by typed helper method signatures (`solana_kit_addresses`, `solana_kit_keys`).
- Add reusable docs templates:
  - Markdown templates via `mdt` (`upstreamSupportSection`, `typedRpcMethodsSection`)
  - Dart doc templates/macros for repeated public API docs.
- Update README docs (workspace + package-level) to demonstrate typed helper usage.
- Add and update tests for typed request behavior and typed helper methods.
- Add changeset:
  - `.changeset/feat_phase2_typed_rpc_facade.md`

## Validation

- `dart analyze packages/solana_kit_rpc_spec`
- `dart analyze packages/solana_kit_rpc`
- `dart test packages/solana_kit_rpc_spec/test`
- `dart test packages/solana_kit_rpc/test`
- `mdt update`
- `mdt check`
- `scripts/workspace-doc-drift.sh --write`
- `scripts/workspace-doc-drift.sh --check`

## Notes

- Behavior is additive; existing string-based `rpc.request('method', params)` usage remains supported.
- Request transformer behavior (default commitment injection/removal) is preserved and explicitly covered in helper-method tests.
