### PR TITLE
fix: unblock lint and android plugin compile on main

### DIFF
--- a/.changeset/fix_mwa_ci_lint_android_compile.md
+++ b/.changeset/fix_mwa_ci_lint_android_compile.md
@@ -1,0 +1,8 @@
+---
+"solana_kit_mobile_wallet_adapter": patch
+---
+
+Fixes CI regressions in the mobile wallet adapter example and Android compile check.
+
+- Renames the Android example package namespace to satisfy `ktlint` package-name rules.
+- Hardens `check-mobile-wallet-adapter-android-compile.sh` to use local workspace `solana_kit_*` dependency overrides during temp-app resolution.

--- a/packages/solana_kit_mobile_wallet_adapter/example/android/app/build.gradle.kts
+++ b/packages/solana_kit_mobile_wallet_adapter/example/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.solana.solanakit.solana_kit_mobile_wallet_adapter_example"
+    namespace = "com.solana.solanakit.mobilewalletadapterexample"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.solana.solanakit.solana_kit_mobile_wallet_adapter_example"
+        applicationId = "com.solana.solanakit.mobilewalletadapterexample"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/packages/solana_kit_mobile_wallet_adapter/example/android/app/src/main/kotlin/com/solana/solanakit/mobilewalletadapterexample/MainActivity.kt
+++ b/packages/solana_kit_mobile_wallet_adapter/example/android/app/src/main/kotlin/com/solana/solanakit/mobilewalletadapterexample/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.solana.solanakit.solana_kit_mobile_wallet_adapter_example
+package com.solana.solanakit.mobilewalletadapterexample
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/scripts/check-mobile-wallet-adapter-android-compile.sh
+++ b/scripts/check-mobile-wallet-adapter-android-compile.sh
@@ -30,6 +30,28 @@ pushd "$TMP_APP" >/dev/null
 echo "Adding local plugin dependency from $PLUGIN_PATH"
 dart pub add solana_kit_mobile_wallet_adapter --path "$PLUGIN_PATH" >/dev/null
 
+echo "Adding local overrides for workspace solana_kit_* dependencies"
+{
+  echo
+  echo "dependency_overrides:"
+  while IFS= read -r package_pubspec; do
+    package_name="$(awk '/^name:[[:space:]]*/ { print $2; exit }' "$package_pubspec")"
+    if [[ "$package_name" == solana_kit_* ]]; then
+      package_dir="$(dirname "$package_pubspec")"
+      echo "  $package_name:"
+      echo "    path: $package_dir"
+    fi
+  done < <(find "$ROOT_DIR/packages" -mindepth 2 -maxdepth 2 -name pubspec.yaml | sort)
+} >> pubspec.yaml
+
+dartsdk_path="$(command -v dart || true)"
+if [[ -z "$dartsdk_path" ]]; then
+  echo "dart executable not found in PATH" >&2
+  exit 1
+fi
+
+"$dartsdk_path" pub get >/dev/null
+
 cat > lib/main.dart <<'DART'
 import 'package:flutter/material.dart';
 import 'package:solana_kit_mobile_wallet_adapter/solana_kit_mobile_wallet_adapter.dart';


### PR DESCRIPTION
## Summary
- fix MWA example Android package namespace/applicationId to remove underscores and satisfy ktlint package-name rule
- move MainActivity package path to match the new namespace
- update scripts/check-mobile-wallet-adapter-android-compile.sh to add local dependency_overrides for workspace solana_kit_* packages before resolving deps in the temporary app

## Why
- lint failed on standard:package-name for MainActivity.kt
- android-plugin-compile failed because temporary app resolution could not find newly bumped local package versions on pub.dev

## Validation
- devenv shell -- lint:kotlin ✅
- ./scripts/check-mobile-wallet-adapter-android-compile.sh ✅ (builds debug APK and reports success)
