### PR TITLE
📝 docs: integrate mdt and expand workspace docs

### DIFF
--- a/.changeset/docs_integrate_mdt_and_expand_docs.md
+++ b/.changeset/docs_integrate_mdt_and_expand_docs.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improve workspace documentation with richer getting-started guides, stronger docs-site coverage, expanded package library doc comments, and deeper mdt integration for shared README and site content.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,17 +10,19 @@ Solana Kit is a multi-package Dart workspace that ports `@solana/kit` and relate
 
 Common workspace commands:
 
-| Command           | Purpose                                                                      |
-| ----------------- | ---------------------------------------------------------------------------- |
-| `install:all`     | Install workspace tooling and Dart dependencies.                             |
-| `fix:all`         | Apply sync, docs, formatting, and lint fixes.                                |
-| `lint:all`        | Run workspace sync, docs, formatting, Kotlin lint, and Dart analysis checks. |
-| `test:all`        | Run all workspace tests.                                                     |
-| `test:coverage`   | Generate merged LCOV coverage.                                               |
-| `docs:check`      | Validate generated docs blocks and workspace metadata.                       |
-| `docs:update`     | Refresh generated docs blocks.                                               |
-| `docs:site:smoke` | Build and smoke test the docs site.                                          |
-| `upstream:check`  | Validate tracked upstream compatibility metadata.                            |
+| Command           | Purpose                                                                           |
+| ----------------- | --------------------------------------------------------------------------------- |
+| `install:all`     | Install workspace tooling and Dart dependencies.                                  |
+| `fix:all`         | Apply sync, docs, formatting, and lint fixes.                                     |
+| `lint:all`        | Run workspace sync, docs, formatting, Kotlin lint, and Dart analysis checks.      |
+| `test:all`        | Run all workspace tests.                                                          |
+| `test:coverage`   | Generate merged LCOV coverage.                                                    |
+| `docs:check`      | Validate generated docs blocks, source comment consumers, and workspace metadata. |
+| `docs:update`     | Refresh generated docs blocks and print mdt diagnostics.                          |
+| `mdt:info`        | Inspect mdt providers/consumers and cache reuse telemetry.                        |
+| `mdt:doctor`      | Run actionable mdt health checks.                                                 |
+| `docs:site:smoke` | Build and smoke test the docs site.                                               |
+| `upstream:check`  | Validate tracked upstream compatibility metadata.                                 |
 
 ## Global rules
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -37,6 +37,7 @@
       },
       "locked": {
         "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
@@ -92,13 +93,16 @@
     "ifiokjr-nixpkgs": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1772179197,
+        "lastModified": 1774765190,
+        "narHash": "sha256-OsFRKKtCql+/yvvllcpKlPoC8W5b+UXjjKtiVkbmXaI=",
         "owner": "ifiokjr",
         "repo": "nixpkgs",
-        "rev": "9ed0d978d5c6dc0ce6165fde5f37ee209d3fac97",
+        "rev": "39a30edd238ab040d6fe5acf94e348362871f3aa",
         "type": "github"
       },
       "original": {
@@ -122,35 +126,18 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1772082373,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "26eaeac4e409d7b5a6bf6f90a2a2dc223c78d915",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "git-hooks": "git-hooks",
         "ifiokjr-nixpkgs": "ifiokjr-nixpkgs",
-        "nixpkgs": "nixpkgs_2",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
         "repo": "default",
         "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",

--- a/devenv.nix
+++ b/devenv.nix
@@ -257,24 +257,44 @@ in
       description = "Check packages sync.";
       binary = "bash";
     };
+    "mdt:info" = {
+      exec = ''
+        set -e
+        mkdir -p .mdt/cache
+        mdt info
+      '';
+      description = "Inspect discovered mdt providers/consumers and cache reuse telemetry.";
+      binary = "bash";
+    };
+    "mdt:doctor" = {
+      exec = ''
+        set -e
+        mkdir -p .mdt/cache
+        mdt doctor --format text
+      '';
+      description = "Run mdt health checks with actionable remediation hints.";
+      binary = "bash";
+    };
     "docs:check" = {
       exec = ''
         set -e
         mkdir -p .mdt/cache
-        mdt check
+        mdt check --verbose
+        mdt doctor --format text
         scripts/workspace-doc-drift.sh --check
       '';
-      description = "Check documentation consistency with mdt and workspace metadata.";
+      description = "Check documentation consistency with mdt, workspace metadata, and source comment consumers.";
       binary = "bash";
     };
     "docs:update" = {
       exec = ''
         set -e
         mkdir -p .mdt/cache
-        mdt update
+        mdt update --verbose
         scripts/workspace-doc-drift.sh --write
+        mdt info
       '';
-      description = "Update generated documentation blocks across the workspace.";
+      description = "Update generated documentation blocks across the workspace and print mdt diagnostics.";
       binary = "bash";
     };
     "docs:site:serve" = {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -7,6 +7,9 @@ inputs:
         follows: nixpkgs
   ifiokjr-nixpkgs:
     url: github:ifiokjr/nixpkgs
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
   nixpkgs:
     url: github:NixOS/nixpkgs/nixpkgs-unstable
 allowUnfree: true

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -10,31 +10,33 @@ devenv shell -- bash -lc '<command>'
 
 ## Common workspace commands
 
-| Command           | Purpose                                                                          |
-| ----------------- | -------------------------------------------------------------------------------- |
-| `install:all`     | Install local tooling and resolve Dart dependencies.                             |
-| `install:dart`    | Run `flutter pub get` for the workspace.                                         |
-| `install:eget`    | Install local binaries declared in `.eget/.eget.toml`.                           |
-| `fix:all`         | Run sync, docs updates, formatting, and lint fixes.                              |
-| `fix:format`      | Format tracked files.                                                            |
-| `fix:lint`        | Apply Dart fixes.                                                                |
-| `lint:all`        | Run sync checks, docs checks, formatting checks, Kotlin lint, and Dart analysis. |
-| `lint:format`     | Run `dprint check`.                                                              |
-| `lint:analyze`    | Run `dart analyze --fatal-infos .`.                                              |
-| `lint:kotlin`     | Run `ktlint` against tracked Kotlin files.                                       |
-| `test:all`        | Run all workspace tests.                                                         |
-| `test:coverage`   | Generate merged LCOV coverage.                                                   |
-| `bench:all`       | Run local benchmark scripts across workspace packages.                           |
-| `docs:check`      | Verify generated docs blocks and workspace metadata are up to date.              |
-| `docs:update`     | Refresh generated docs blocks.                                                   |
-| `docs:site:build` | Build the Jaspr docs site.                                                       |
-| `docs:site:serve` | Serve the Jaspr docs site locally.                                               |
-| `docs:site:smoke` | Build and smoke test the docs site.                                              |
-| `sync:check`      | Validate synced dependency versions and changelog outputs.                       |
-| `sync:write`      | Rewrite synced dependency versions and changelog outputs.                        |
-| `clone:repos`     | Clone or update reference repositories into `.repos/`.                           |
-| `upstream:check`  | Check tracked upstream compatibility metadata and local drift.                   |
-| `update:deps`     | Update `devenv` and pub dependencies.                                            |
+| Command           | Purpose                                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------------------- |
+| `install:all`     | Install local tooling and resolve Dart dependencies.                                           |
+| `install:dart`    | Run `flutter pub get` for the workspace.                                                       |
+| `install:eget`    | Install local binaries declared in `.eget/.eget.toml`.                                         |
+| `fix:all`         | Run sync, docs updates, formatting, and lint fixes.                                            |
+| `fix:format`      | Format tracked files.                                                                          |
+| `fix:lint`        | Apply Dart fixes.                                                                              |
+| `lint:all`        | Run sync checks, docs checks, formatting checks, Kotlin lint, and Dart analysis.               |
+| `lint:format`     | Run `dprint check`.                                                                            |
+| `lint:analyze`    | Run `dart analyze --fatal-infos .`.                                                            |
+| `lint:kotlin`     | Run `ktlint` against tracked Kotlin files.                                                     |
+| `test:all`        | Run all workspace tests.                                                                       |
+| `test:coverage`   | Generate merged LCOV coverage.                                                                 |
+| `bench:all`       | Run local benchmark scripts across workspace packages.                                         |
+| `docs:check`      | Verify generated docs blocks, source comment consumers, and workspace metadata are up to date. |
+| `docs:update`     | Refresh generated docs blocks and print mdt diagnostics.                                       |
+| `mdt:info`        | Inspect mdt providers/consumers and cache reuse telemetry.                                     |
+| `mdt:doctor`      | Run actionable mdt health checks.                                                              |
+| `docs:site:build` | Build the Jaspr docs site.                                                                     |
+| `docs:site:serve` | Serve the Jaspr docs site locally.                                                             |
+| `docs:site:smoke` | Build and smoke test the docs site.                                                            |
+| `sync:check`      | Validate synced dependency versions and changelog outputs.                                     |
+| `sync:write`      | Rewrite synced dependency versions and changelog outputs.                                      |
+| `clone:repos`     | Clone or update reference repositories into `.repos/`.                                         |
+| `upstream:check`  | Check tracked upstream compatibility metadata and local drift.                                 |
+| `update:deps`     | Update `devenv` and pub dependencies.                                                          |
 
 ## Raw tool entrypoints
 

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -2,11 +2,14 @@
 
 Jaspr Content documentation site for the Solana Kit workspace.
 
+The site reuses shared Markdown template blocks via `mdt`, so run `docs:update` from the repository root whenever you change shared docs snippets.
+
 ## Run Locally
 
 From the repository root:
 
 ```bash
+docs:update
 docs:site:serve
 ```
 

--- a/docs/site/content/contributing.md
+++ b/docs/site/content/contributing.md
@@ -36,11 +36,30 @@ lint:all
 # Run all package tests
 test:all
 
+# Generate merged test coverage across all packages
+test:coverage
+
 # Validate markdown templates and generated docs
+# (also runs mdt doctor and workspace docs drift checks)
 docs:check
 
 # Regenerate documentation template consumers and workspace docs
 docs:update
+
+# Inspect mdt provider/consumer state and cache reuse
+mdt:info
+
+# Run actionable mdt health checks
+mdt:doctor
+
+# Check tracked upstream compatibility metadata
+upstream:check
+
+# Run local benchmark scripts across benchmark-enabled packages
+bench:all
+
+# Fix formatting and lint issues where possible
+fix:all
 ```
 
 <!-- {/docsWorkspaceDevCommandsSection} -->

--- a/docs/site/content/core/accounts.md
+++ b/docs/site/content/core/accounts.md
@@ -1,0 +1,96 @@
+---
+title: Accounts
+description: Understand encoded accounts, maybe-account wrappers, jsonParsed reads, and decode flows.
+---
+
+Accounts are where most Solana application state lives. Solana Kit gives you a few distinct layers so you can choose the right boundary for your use case.
+
+## Core account models
+
+### `Account<TData>`
+
+Represents an existing account with:
+
+- `address`
+- `data`
+- `lamports`
+- `programAddress`
+- `space`
+- `executable`
+
+### `MaybeAccount<TData>`
+
+A sealed result type for “this account may or may not exist”.
+
+Pattern matching keeps the control flow explicit:
+
+```dart
+switch (maybeAccount) {
+  case ExistingAccount<Uint8List>(:final account):
+    print(account.address);
+  case NonExistingAccount(:final address):
+    print('Missing: $address');
+}
+```
+
+## Encoded vs parsed reads
+
+### Encoded reads
+
+Use encoded reads when:
+
+- the account belongs to a custom program
+- you need byte-perfect control over decoding
+- you already have codecs/decoders for the layout
+
+Helpers:
+
+- `fetchEncodedAccount`
+- `fetchEncodedAccounts`
+- `decodeAccount`
+- `decodeMaybeAccount`
+
+### Parsed reads
+
+Use parsed reads when:
+
+- the RPC supports `jsonParsed` for the account type
+- you want a human-readable result quickly
+- you are working with common system or SPL account types
+
+Helpers:
+
+- `fetchJsonParsedAccount`
+- `fetchJsonParsedAccounts`
+
+## Typical decode flow
+
+```dart
+final maybeEncoded = await fetchEncodedAccount(rpc, address);
+final maybeDecoded = decodeMaybeAccount(maybeEncoded, myDecoder);
+```
+
+This split is intentional:
+
+- transport and RPC behavior stay in the fetch layer
+- binary-layout knowledge stays in your decoder or codec layer
+
+## Account assertions
+
+The package also provides assertion helpers for workflows that expect an account to exist or decode successfully.
+
+These helpers are useful when you want domain-specific errors instead of open-ended nullable control flow.
+
+## Related packages
+
+- `solana_kit_accounts` — fetch, parse, and decode helpers
+- `solana_kit_rpc_types` — shared account response models
+- `solana_kit_rpc_parsed_types` — typed parsed-account models for known programs
+- `solana_kit_codecs_*` — custom binary layouts
+- `solana_kit_program_client_core` — higher-level patterns for typed program clients
+
+## Read next
+
+- [Fetch an Account](../getting-started/fetch-an-account)
+- [Codecs](codecs)
+- [Build a Program Client](../guides/build-program-client)

--- a/docs/site/content/core/codecs.md
+++ b/docs/site/content/core/codecs.md
@@ -1,0 +1,92 @@
+---
+title: Codecs
+description: Build deterministic binary layouts with Solana Kit codecs for numbers, strings, structs, tuples, unions, and options.
+---
+
+Codecs are the foundation for instruction data, account layouts, sysvar schemas, and many protocol-level payloads.
+
+The codec layer is split into focused packages so you can keep dependencies small while still composing rich layouts.
+
+## Core concepts
+
+### `Encoder<T>`
+
+Turns a value into bytes.
+
+### `Decoder<T>`
+
+Turns bytes into a value.
+
+### `Codec<TFrom, TTo>`
+
+Combines both directions.
+
+## Package map
+
+- `solana_kit_codecs_core` — base abstractions and composition helpers
+- `solana_kit_codecs_numbers` — little-endian integers and floats
+- `solana_kit_codecs_strings` — base16/base58/base64/utf8/baseX encoders
+- `solana_kit_codecs_data_structures` — structs, tuples, arrays, maps, unions, nullable values, and more
+- `solana_kit_options` — Rust-style `Option<T>` modeling and codec support
+
+## Example: build a simple struct codec
+
+```dart
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+final transferLayout = getStructCodec({
+  'discriminator': getU8Codec(),
+  'amount': getU64Codec(),
+});
+
+final bytes = transferLayout.encode({
+  'discriminator': 2,
+  'amount': BigInt.from(1_000_000),
+});
+
+final decoded = transferLayout.decode(bytes);
+print(decoded['amount']);
+```
+
+## Example: choose among variants
+
+<!-- {=typedUnionHelpersSection} -->
+
+### Typed Union Helpers
+
+Prefer typed union helpers when a codec has a fixed, small number of variants.
+They improve IDE type inference and reduce downstream casting.
+
+```dart
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+final codec = getUnion2Codec(
+  getU8Codec(),
+  getU32Codec(),
+  (bytes, offset) => bytes.length - offset > 1 ? 1 : 0,
+);
+
+final encoded = codec.encode(const Union2Variant1<int, int>(1000));
+final decoded = codec.decode(encoded);
+```
+
+<!-- {/typedUnionHelpersSection} -->
+
+## When to use codecs
+
+Use codecs when you need:
+
+- deterministic byte layouts
+- testable encode/decode logic
+- reuse across program clients and account decoders
+- confidence that a Dart representation matches an upstream wire format
+
+Avoid ad hoc `Uint8List` slicing once a layout becomes non-trivial. A codec pays for itself quickly.
+
+## Read next
+
+- [Create Instructions](../getting-started/create-instructions)
+- [Accounts](accounts)
+- [Build a Program Client](../guides/build-program-client)

--- a/docs/site/content/core/errors-and-diagnostics.md
+++ b/docs/site/content/core/errors-and-diagnostics.md
@@ -1,9 +1,19 @@
 ---
 title: Errors and Diagnostics
-description: Use structured Solana Kit errors and domain helpers.
+description: Handle structured Solana errors, preserve context, and build recoverable failure flows.
 ---
 
-Solana Kit favors typed/structured errors over string parsing.
+Solana Kit favors structured errors over string parsing.
+
+That means you can reason about failures by:
+
+- error code
+- error domain
+- attached structured context
+
+instead of brittle substring matching against user-facing messages.
+
+## Domain helpers
 
 <!-- {=errorDomainHelpersSection} -->
 
@@ -26,8 +36,34 @@ try {
 
 <!-- {/errorDomainHelpersSection} -->
 
-## Practical Guidance
+## Practical guidance
 
-- Catch `SolanaError` at service boundaries and map codes to domain responses.
-- Preserve `context` when rethrowing to keep diagnostics actionable.
-- Avoid broad `catch (e)` handlers in core transaction or RPC flows unless you reclassify to typed errors.
+### Catch `SolanaError` at service boundaries
+
+Boundary layers such as repositories, API services, or command handlers are good places to classify and map errors.
+
+### Preserve context when rethrowing
+
+If you convert one failure into another, keep the original structured information whenever possible.
+
+### Avoid broad untyped catches in core flows
+
+Catching `Object` too early can erase useful domain information.
+
+## Why this matters
+
+Typed diagnostics help you answer questions like:
+
+- was this an RPC transport failure?
+- was the account data malformed?
+- was the transaction missing a signer?
+- did a lifetime constraint expire?
+- did a program-specific error occur during execution?
+
+That is much easier than parsing free-form strings downstream.
+
+## Read next
+
+- [Transactions](transactions)
+- [RPC and Subscriptions](rpc-and-subscriptions)
+- [Package Catalog](../reference/package-catalog)

--- a/docs/site/content/core/rpc-and-subscriptions.md
+++ b/docs/site/content/core/rpc-and-subscriptions.md
@@ -1,9 +1,16 @@
 ---
 title: RPC and Subscriptions
-description: Typed RPC methods, subscriptions, and transport guidance.
+description: Typed RPC methods, transport choices, websocket subscriptions, and production guidance.
 ---
 
-Use `solana_kit_rpc` for request orchestration and `solana_kit_rpc_subscriptions` for websocket notifications.
+`solana_kit_rpc` and `solana_kit_rpc_subscriptions` are the backbone of most application-facing Solana I/O.
+
+Use them together when you need both:
+
+- **request/response flows** over JSON-RPC HTTP
+- **realtime notifications** over websockets
+
+## Typed RPC requests
 
 <!-- {=docsTypedRpcSolanaKitSection} -->
 
@@ -23,13 +30,33 @@ These helpers forward to canonical params builders in `solana_kit_rpc_api` and r
 
 <!-- {/docsTypedRpcSolanaKitSection} -->
 
-## Subscription Clients
+## Why typed RPC matters
 
-Use websocket subscriptions for account updates, logs, and slot notifications.
+Typed RPC methods give you:
 
-- `solana_kit_rpc_subscriptions`: high-level subscription client.
-- `solana_kit_rpc_subscriptions_api`: typed subscription method definitions.
-- `solana_kit_rpc_subscriptions_channel_websocket`: websocket transport implementation.
+- discoverable method names in IDE autocomplete
+- compile-time parameter shapes
+- fewer raw `Map<String, Object?>` escape hatches in application code
+- reusable request logic across services and tests
+
+## Subscription clients
+
+Use websocket subscriptions for account changes, signature updates, program logs, and slot notifications.
+
+Packages involved:
+
+- `solana_kit_rpc_subscriptions` — high-level orchestration
+- `solana_kit_rpc_subscriptions_api` — typed subscription method builders
+- `solana_kit_rpc_subscriptions_channel_websocket` — websocket transport/channel implementation
+- `solana_kit_subscribable` — stream-friendly subscription primitives
+
+## Typical split of responsibilities
+
+- use `rpc` for reads, writes, and transaction submission
+- use `rpcSubscriptions` for realtime updates
+- keep transport setup at your app boundary so you can tune timeouts, headers, or connection reuse centrally
+
+## Large payload handling
 
 <!-- {=docsIsolateJsonDecodeHttpSection} -->
 
@@ -52,3 +79,11 @@ For direct parsing, use `parseJsonWithBigIntsAsync(...)` with
 `runInIsolate: true`.
 
 <!-- {/docsIsolateJsonDecodeHttpSection} -->
+
+## Read next
+
+- [Quick Start](../getting-started/quick-start)
+- [Accounts](accounts)
+- [Transactions](transactions)
+- [Build an RPC Service](../guides/build-rpc-service)
+- [Build a Realtime Observer](../guides/build-realtime-observer)

--- a/docs/site/content/core/signers.md
+++ b/docs/site/content/core/signers.md
@@ -1,0 +1,63 @@
+---
+title: Signers
+description: Model fee payers, partial signers, modifying signers, and sending signers explicitly.
+---
+
+Solana Kit treats signers as capabilities, not just as key material. That gives you a better fit for real-world flows involving wallets, mobile adapters, remote signers, and multi-party signing.
+
+## Why the signer model matters
+
+In many SDKs, “a signer” is just a private key. In production Solana apps, that is often not enough.
+
+You may need to represent:
+
+- a local key pair that signs directly
+- a wallet that signs and sends in one step
+- a system that mutates the transaction before signing
+- a fee payer that differs from another signing authority
+- a partially signed transaction that must be completed later
+
+## Common signer interfaces
+
+- **`KeyPairSigner`** — local Ed25519 key pair plus signing methods
+- **`FeePayerSigner`** — signer designated as the fee payer
+- **`TransactionPartialSigner`** — can contribute one or more transaction signatures
+- **`TransactionModifyingSigner`** — can edit a transaction before signature application
+- **`TransactionSendingSigner`** — can sign and submit a transaction
+- **`MessagePartialSigner`** — signs off-chain messages instead of transactions
+
+## Build a transaction around signers
+
+```dart
+final signer = await generateKeyPair();
+
+final message = createTransactionMessage()
+    .pipe(setTransactionMessageFeePayerSigner(signer));
+```
+
+Once the message contains the required signers, use the higher-level helpers:
+
+```dart
+final signedTransaction = await signTransactionMessageWithSigners(message);
+```
+
+Or, when a sending signer is embedded in the message:
+
+```dart
+final signature = await signAndSendTransactionMessageWithSigners(message);
+```
+
+## Why explicit roles help
+
+This separation gives you:
+
+- better modeling for wallet integrations
+- more honest test seams
+- cleaner handling of partial signatures
+- safer transaction pipelines for complex orchestration
+
+## Read next
+
+- [Generate a Signer](../getting-started/generate-a-signer)
+- [First Transaction](../getting-started/first-transaction)
+- [Transactions](transactions)

--- a/docs/site/content/core/transactions.md
+++ b/docs/site/content/core/transactions.md
@@ -1,29 +1,81 @@
 ---
 title: Transactions
-description: Compose transaction messages and manage signing.
+description: Compose messages, attach signers, compile transactions, and confirm results with explicit typed steps.
 ---
 
-The transaction pipeline is intentionally modular:
+Solana Kit intentionally splits the transaction stack into a few focused layers.
 
-- `solana_kit_instructions` defines `Instruction` and account metadata.
-- `solana_kit_transaction_messages` builds and mutates message state.
-- `solana_kit_transactions` compiles and serializes signed transactions.
+- `solana_kit_instructions` models program invocations.
+- `solana_kit_transaction_messages` builds immutable message state.
+- `solana_kit_signers` models who can authorize, mutate, or submit a transaction.
+- `solana_kit_transactions` handles wire-format transactions and signatures.
+- `solana_kit_transaction_confirmation` handles confirmation strategies.
 
-## Recommended Flow
+## Recommended mental model
 
-1. Build a message with fee payer and lifetime.
-2. Append instructions in deterministic order.
-3. Compile to wire format.
-4. Sign with required signers.
-5. Send and confirm with strategy-based confirmation utilities.
+Think in four phases:
 
-For the most common signed-transaction flow, use the additive helper:
+1. **Describe intent** — create instructions.
+2. **Build message state** — set fee payer, lifetime, and instruction order.
+3. **Authorize** — attach signers and produce signatures.
+4. **Submit and confirm** — send the signed transaction and wait for a final outcome.
+
+## Message construction
+
+Use immutable message transforms:
 
 ```dart
+final message = createTransactionMessage()
+    .pipe(setTransactionMessageFeePayer(feePayerAddress))
+    .pipe(setTransactionMessageLifetimeUsingBlockhash(blockhashConstraint))
+    .pipe(appendTransactionMessageInstruction(instruction));
+```
+
+This style makes transaction assembly predictable and easy to test.
+
+## Signing strategies
+
+Use `signTransactionMessageWithSigners(...)` when all required signers are attached to the message and you want a fully signed transaction.
+
+Use `partiallySignTransactionMessageWithSigners(...)` when a transaction will move through multiple signing stages.
+
+Use `signAndSendTransactionMessageWithSigners(...)` when the message contains a `TransactionSendingSigner`, such as a wallet adapter.
+
+## Confirmation strategies
+
+<!-- {=docsSendAndConfirmSection} -->
+
+## Send and confirm a signed transaction
+
+Once you have a signed `Transaction`, use the additive confirmation helper for
+an end-to-end “send then wait for confirmation” flow.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
 final signature = await sendAndConfirmTransaction(
   rpc: rpc,
   transaction: signedTransaction,
 );
+
+print('Confirmed signature: ${signature.value}');
 ```
 
-For lower-level confirmation tactics, see `solana_kit_transaction_confirmation`.
+For lower-level control, `solana_kit_transaction_confirmation` also exposes
+strategy factories for block-height expiry, durable nonce invalidation,
+signature notifications, and timeout racing.
+
+<!-- {/docsSendAndConfirmSection} -->
+
+## When to use instruction plans
+
+If your operation spans multiple transactions or has parallel/sequential structure, move up to `solana_kit_instruction_plans`.
+
+That package helps you model transaction orchestration explicitly instead of hiding it in ad hoc control flow.
+
+## Read next
+
+- [Create Instructions](../getting-started/create-instructions)
+- [Build a Transaction](../getting-started/build-a-transaction)
+- [Signers](signers)
+- [Build a Token Transfer Flow](../guides/build-token-transfer-flow)

--- a/docs/site/content/getting-started/build-a-transaction.md
+++ b/docs/site/content/getting-started/build-a-transaction.md
@@ -1,0 +1,80 @@
+---
+title: Build a Transaction
+description: Assemble a transaction message with a fee payer, a lifetime, and one or more instructions.
+---
+
+Solana Kit models transaction construction as a sequence of immutable transformations. This keeps the transaction pipeline easy to inspect and test.
+
+<!-- {=docsBuildTransactionSection} -->
+
+## Build a transaction message
+
+Transaction messages are assembled incrementally. The most common pattern is:
+
+1. Create an empty message.
+2. Set the fee payer.
+3. Set a lifetime constraint using a recent blockhash.
+4. Append one or more instructions.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+final feePayer = await generateKeyPair();
+final latestBlockhash = await rpc.getLatestBlockhash().send();
+
+final instruction = Instruction(
+  programAddress: const Address('11111111111111111111111111111111'),
+  accounts: [
+    AccountMeta(address: feePayer.address, role: AccountRole.writableSigner),
+  ],
+  data: Uint8List(0),
+);
+
+final message = createTransactionMessage()
+    .pipe(setTransactionMessageFeePayer(feePayer.address))
+    .pipe(
+      setTransactionMessageLifetimeUsingBlockhash(
+        BlockhashLifetimeConstraint(
+          blockhash: latestBlockhash.value.blockhash,
+          lastValidBlockHeight: latestBlockhash.value.lastValidBlockHeight,
+        ),
+      ),
+    )
+    .pipe(appendTransactionMessageInstruction(instruction));
+```
+
+This separation keeps transaction construction explicit and makes it easier to
+reason about fee payment, expiry, and instruction ordering.
+
+<!-- {/docsBuildTransactionSection} -->
+
+## Why the lifetime constraint matters
+
+Without a recent blockhash or a durable nonce, the network cannot determine whether a transaction is still valid. Solana Kit makes lifetime setup explicit so expiry handling is not hidden behind a large helper.
+
+### Blockhash-based lifetime
+
+Use `BlockhashLifetimeConstraint` for the common case.
+
+### Durable nonce lifetime
+
+Use `setTransactionMessageLifetimeUsingDurableNonce(...)` when the transaction must remain valid until a nonce account changes.
+
+## Compile the message
+
+Once the message is fully assembled, compile it into the wire-level message representation:
+
+```dart
+final compiledMessage = compileTransactionMessage(message);
+```
+
+At this stage you have a canonical message layout that can be signed and serialized.
+
+## Next steps
+
+- [First Transaction](first-transaction)
+- [Send and confirm a transaction](../core/transactions)
+- [Signers](../core/signers)

--- a/docs/site/content/getting-started/create-instructions.md
+++ b/docs/site/content/getting-started/create-instructions.md
@@ -1,0 +1,92 @@
+---
+title: Create Instructions
+description: Model Solana instructions explicitly with program addresses, account roles, and binary payloads.
+---
+
+An instruction is the smallest unit of program interaction on Solana. It answers three questions:
+
+1. **Which program should execute?**
+2. **Which accounts should the program read or write?**
+3. **What binary payload should the program receive?**
+
+## Minimal instruction
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit/solana_kit.dart';
+
+final instruction = Instruction(
+  programAddress: const Address('11111111111111111111111111111111'),
+  accounts: const [],
+  data: Uint8List(0),
+);
+```
+
+This is valid as a model, though most real program interactions require one or more accounts and a structured data payload.
+
+## Instruction with account metadata
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit/solana_kit.dart';
+
+const feePayer = Address('11111111111111111111111111111111');
+const recipient = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+final instruction = Instruction(
+  programAddress: const Address('11111111111111111111111111111111'),
+  accounts: const [
+    AccountMeta(address: feePayer, role: AccountRole.writableSigner),
+    AccountMeta(address: recipient, role: AccountRole.writable),
+  ],
+  data: Uint8List.fromList([1, 2, 3]),
+);
+```
+
+## Choosing the right account role
+
+Use account roles to express exactly how the runtime should treat each account.
+
+- **`readonly`** — read-only, not a signer
+- **`writable`** — mutable, not a signer
+- **`readonlySigner`** — signer, but not writable
+- **`writableSigner`** — signer and writable
+
+A wrong role can cause transaction failures even when the program address and data payload are correct.
+
+## Encoding instruction data
+
+In simple examples, `Uint8List.fromList(...)` is enough. In real applications, prefer codecs so your instruction layouts are:
+
+- deterministic
+- testable
+- reusable across encode/decode flows
+
+See [Codecs](../core/codecs) for the recommended approach.
+
+## Where instructions go next
+
+Instructions are usually appended to a transaction message:
+
+```dart
+final messageWithInstruction = appendTransactionMessageInstruction(
+  instruction,
+  message,
+);
+```
+
+Or combined in a pipeline:
+
+```dart
+final message = createTransactionMessage()
+    .pipe(setTransactionMessageFeePayer(feePayer))
+    .pipe(appendTransactionMessageInstruction(instruction));
+```
+
+## Next steps
+
+- [Build a Transaction](build-a-transaction)
+- [Transactions](../core/transactions)
+- [Codecs](../core/codecs)

--- a/docs/site/content/getting-started/fetch-an-account.md
+++ b/docs/site/content/getting-started/fetch-an-account.md
@@ -1,0 +1,84 @@
+---
+title: Fetch an Account
+description: Read encoded or jsonParsed account data and handle missing accounts safely.
+---
+
+Solana account reads usually fall into two categories:
+
+- **encoded reads** — get the raw bytes and decode them yourself
+- **jsonParsed reads** — let the RPC return a structured representation for known programs
+
+In Solana Kit, both paths return explicit result models so you can distinguish an account that is present from an account that does not exist.
+
+<!-- {=docsFetchAccountSection} -->
+
+## Fetch an account
+
+Use `fetchEncodedAccount` when you want the raw account bytes plus its Solana
+metadata. Decode it later with the codec or parser that matches your program.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+const address = Address('11111111111111111111111111111111');
+
+final maybeAccount = await fetchEncodedAccount(rpc, address);
+
+switch (maybeAccount) {
+  case ExistingAccount<Uint8List>(:final account):
+    print('Owner: ${account.programAddress}');
+    print('Bytes: ${account.data.length}');
+  case NonExistingAccount():
+    print('No account exists at $address');
+}
+```
+
+Use `fetchJsonParsedAccount` when the RPC can return a structured
+`jsonParsed` representation for a well-known program.
+
+<!-- {/docsFetchAccountSection} -->
+
+## Fetch multiple accounts
+
+```dart
+final accounts = await fetchEncodedAccounts(
+  rpc,
+  const [
+    Address('11111111111111111111111111111111'),
+    Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+  ],
+);
+
+print('Fetched ${accounts.length} accounts');
+```
+
+Batch reads are especially useful when building dashboards, indexer workers, and program clients that need to hydrate several related accounts at once.
+
+## Decode after fetching
+
+For custom programs, fetch encoded bytes first and then decode them with a codec or decoder:
+
+```dart
+final decodedAccount = decodeAccount(myEncodedAccount, myDecoder);
+```
+
+This keeps transport concerns and binary-layout concerns separate.
+
+## When to use jsonParsed
+
+Use `fetchJsonParsedAccount` or `fetchJsonParsedAccounts` when:
+
+- the RPC already knows how to structure the account data
+- you are reading a well-known system/SPL account type
+- you prefer a human-readable response over a byte-oriented decode flow
+
+Use encoded reads when you need full control over the layout or you are interacting with custom program data.
+
+## Next steps
+
+- [Accounts](../core/accounts)
+- [Codecs](../core/codecs)
+- [Build a Program Client](../guides/build-program-client)

--- a/docs/site/content/getting-started/first-transaction.md
+++ b/docs/site/content/getting-started/first-transaction.md
@@ -1,33 +1,107 @@
 ---
 title: First Transaction
-description: Build, compile, and sign a Solana transaction message.
+description: Build, sign, send, and confirm a Solana transaction with explicit typed steps.
 ---
 
-A typical transaction flow:
+A production-grade transaction flow usually has these phases:
 
-1. Fetch a recent blockhash.
-2. Build a transaction message.
-3. Append one or more instructions.
-4. Compile to a transaction and sign with a `TransactionSigner`.
+1. create or obtain the required signers
+2. fetch a recent blockhash
+3. build a transaction message
+4. compile and sign the transaction
+5. send the signed transaction
+6. confirm the result
+
+This guide focuses on the shape of the workflow rather than a specific on-chain program client.
+
+## 1. Create the dependencies
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+final signer = await generateKeyPair();
+final latestBlockhash = await rpc.getLatestBlockhash().send();
+```
+
+## 2. Build an instruction
+
+```dart
+final instruction = Instruction(
+  programAddress: const Address('11111111111111111111111111111111'),
+  accounts: [
+    AccountMeta(address: signer.address, role: AccountRole.writableSigner),
+  ],
+  data: Uint8List(0),
+);
+```
+
+For a real application, this would usually come from a typed program client or an instruction builder backed by codecs.
+
+## 3. Build the transaction message
+
+```dart
+final message = createTransactionMessage()
+    .pipe(setTransactionMessageFeePayerSigner(signer))
+    .pipe(
+      setTransactionMessageLifetimeUsingBlockhash(
+        BlockhashLifetimeConstraint(
+          blockhash: latestBlockhash.value.blockhash,
+          lastValidBlockHeight: latestBlockhash.value.lastValidBlockHeight,
+        ),
+      ),
+    )
+    .pipe(appendTransactionMessageInstruction(instruction));
+```
+
+## 4. Sign the message
+
+```dart
+final signedTransaction = await signTransactionMessageWithSigners(message);
+```
+
+This high-level helper resolves the signers attached to the message, compiles the transaction, and asserts that every required signature is present.
+
+## 5. Send and confirm
+
+<!-- {=docsSendAndConfirmSection} -->
+
+## Send and confirm a signed transaction
+
+Once you have a signed `Transaction`, use the additive confirmation helper for
+an end-to-end “send then wait for confirmation” flow.
 
 ```dart
 import 'package:solana_kit/solana_kit.dart';
 
-final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
-final feePayer = await generateKeyPair();
+final signature = await sendAndConfirmTransaction(
+  rpc: rpc,
+  transaction: signedTransaction,
+);
 
-final latestBlockhash = await rpc.getLatestBlockhash().send();
-
-final message = createTransactionMessage()
-    .pipe(setTransactionMessageFeePayer(feePayer.address))
-    .pipe(
-      setTransactionMessageLifetimeUsingBlockhash(
-        latestBlockhash.value.blockhash,
-      ),
-    );
-
-// Add instructions with appendTransactionMessageInstruction(...)
-// and compile/sign as needed for your program interaction.
+print('Confirmed signature: ${signature.value}');
 ```
 
-See [Transactions](../core/transactions) for composition patterns and size constraints.
+For lower-level control, `solana_kit_transaction_confirmation` also exposes
+strategy factories for block-height expiry, durable nonce invalidation,
+signature notifications, and timeout racing.
+
+<!-- {/docsSendAndConfirmSection} -->
+
+## Why this explicit flow is useful
+
+The workflow may look more verbose than a single convenience function, but it gives you strong control over:
+
+- signer attachment and signer role modeling
+- blockhash expiry handling
+- instruction ordering
+- testability of each step
+- substitution of wallet/mobile/remote signing behavior
+
+## Next steps
+
+- [Transactions](../core/transactions)
+- [Signers](../core/signers)
+- [Build a Token Transfer Flow](../guides/build-token-transfer-flow)

--- a/docs/site/content/getting-started/generate-a-signer.md
+++ b/docs/site/content/getting-started/generate-a-signer.md
@@ -1,0 +1,74 @@
+---
+title: Generate a Signer
+description: Create local key-pair signers and understand the signer roles used across the SDK.
+---
+
+Signers are the bridge between transaction intent and cryptographic authorization.
+
+In Solana Kit, the signer model is intentionally more expressive than “just a key pair” because real applications often need to distinguish:
+
+- a fee payer
+- a partial signer
+- a signer that can modify a transaction before signing
+- a signer that can also send a transaction
+
+## Start with a key-pair signer
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+final signer = await generateKeyPair();
+
+print('Signer address: ${signer.address}');
+```
+
+A generated key pair is useful for:
+
+- local testing
+- backend automation
+- server-side services
+- examples and fixtures
+
+## Sign a message
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+final signer = await generateKeyPair();
+final message = createSignableMessage('hello from Solana Kit');
+
+final signatures = await signer.signMessages([message]);
+print('Produced ${signatures.length} signature map(s)');
+```
+
+## Attach a signer to a transaction message
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+final signer = await generateKeyPair();
+
+final message = createTransactionMessage()
+    .pipe(setTransactionMessageFeePayerSigner(signer));
+```
+
+This is the most common starting point for building a signable transaction.
+
+## Understand signer roles
+
+`solana_kit_signers` separates roles so transaction pipelines stay explicit.
+
+- **`KeyPairSigner`** — local Ed25519 key pair plus signing methods
+- **`MessagePartialSigner`** — can sign signable off-chain messages
+- **`TransactionPartialSigner`** — can sign a compiled transaction
+- **`TransactionModifyingSigner`** — can mutate a transaction before signing
+- **`TransactionSendingSigner`** — can sign and immediately submit a transaction
+- **`FeePayerSigner`** — indicates the signer is also the transaction fee payer
+
+This modeling matters when integrating wallets, mobile adapters, remote signers, or multi-party signing flows.
+
+## Next steps
+
+- [Create Instructions](create-instructions)
+- [Build a Transaction](build-a-transaction)
+- [Signers](../core/signers)

--- a/docs/site/content/getting-started/installation.md
+++ b/docs/site/content/getting-started/installation.md
@@ -1,21 +1,47 @@
 ---
 title: Installation
-description: Set up Solana Kit in a Dart or Flutter project.
+description: Install Solana Kit in an application or set up the full workspace for contribution.
 ---
 
-Install the umbrella package:
+Solana Kit supports two common setups:
+
+1. **Application usage** — install `solana_kit` or a smaller sub-package in your Dart or Flutter app.
+2. **Workspace contribution** — clone the monorepo and use `devenv` to get the full toolchain, docs tooling, and reference repos.
+
+## Install in an app
+
+If you want the full SDK surface, install the umbrella package:
 
 ```bash
 dart pub add solana_kit
 ```
 
-Then import it from your app code:
+Then import it in your application code:
 
 ```dart
 import 'package:solana_kit/solana_kit.dart';
 ```
 
-## Workspace Setup
+### When to install a smaller package instead
+
+Prefer a smaller package when:
+
+- you only need one feature area, such as addresses, codecs, RPC, or signers
+- you are building a library and want a narrower dependency surface
+- you want your package imports to reflect a specific architectural boundary
+
+Examples:
+
+```bash
+dart pub add solana_kit_accounts
+dart pub add solana_kit_codecs_core
+dart pub add solana_kit_rpc
+dart pub add solana_kit_signers
+```
+
+## Set up the workspace for contribution
+
+Use the monorepo when you want to run tests, update docs, compare against upstream `@solana/kit`, or contribute changes across packages.
 
 <!-- {=docsWorkspaceSetupSection} -->
 
@@ -37,14 +63,63 @@ clone:repos
 
 <!-- {/docsWorkspaceSetupSection} -->
 
-## Verify the Toolchain
+## Verify the toolchain
 
-Run these commands at the workspace root:
+Run these commands from the repository root:
+
+<!-- {=docsWorkspaceDevCommandsSection} -->
 
 ```bash
+# Lint, docs drift, formatting, and analysis checks
 lint:all
+
+# Run all package tests
 test:all
+
+# Generate merged test coverage across all packages
+test:coverage
+
+# Validate markdown templates and generated docs
+# (also runs mdt doctor and workspace docs drift checks)
 docs:check
+
+# Regenerate documentation template consumers and workspace docs
+docs:update
+
+# Inspect mdt provider/consumer state and cache reuse
+mdt:info
+
+# Run actionable mdt health checks
+mdt:doctor
+
+# Check tracked upstream compatibility metadata
+upstream:check
+
+# Run local benchmark scripts across benchmark-enabled packages
+bench:all
+
+# Fix formatting and lint issues where possible
+fix:all
 ```
 
-If your work requires generated docs updates, run `docs:update` before committing.
+<!-- {/docsWorkspaceDevCommandsSection} -->
+
+For day-to-day contribution work, the most important commands are `lint:all`, `test:all`, `docs:check`, and `docs:update`.
+
+## Documentation tooling
+
+This workspace uses [`mdt`](https://github.com/ifiokjr/mdt) to keep shared README blocks, site snippets, and selected source doc comments synchronized.
+
+Use:
+
+- `docs:update` to regenerate all consumer blocks
+- `docs:check` to verify everything is current in CI or before committing
+- `mdt:info` to inspect providers, consumers, and cache reuse
+- `mdt:doctor` to diagnose template drift or config problems
+
+## Next steps
+
+- [Quick Start](quick-start)
+- [Generate a Signer](generate-a-signer)
+- [Fetch an Account](fetch-an-account)
+- [First Transaction](first-transaction)

--- a/docs/site/content/getting-started/quick-start.md
+++ b/docs/site/content/getting-started/quick-start.md
@@ -1,41 +1,95 @@
 ---
 title: Quick Start
-description: Connect to RPC and execute your first typed Solana calls.
+description: Connect to RPC, create a signer, and read your first typed Solana data.
 ---
 
-Create an RPC client and run strongly typed requests:
+This page gives you a fast tour of the three building blocks most apps start with:
+
+1. a typed RPC client
+2. a signer
+3. an account read
+
+<!-- {=docsCreateRpcClientSection} -->
+
+## Create an RPC client
+
+Start with a typed RPC client. It gives you method-specific helpers instead of
+building raw JSON-RPC requests by hand.
 
 ```dart
 import 'package:solana_kit/solana_kit.dart';
 
-final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+
 final slot = await rpc.getSlot().send();
+final latestBlockhash = await rpc.getLatestBlockhash().send();
+
 print('Current slot: $slot');
+print('Latest blockhash: ${latestBlockhash.value.blockhash}');
 ```
 
-<!-- {=docsTypedRpcSolanaKitSection} -->
+Use `solana_kit_rpc_subscriptions` alongside `solana_kit_rpc` when you also
+need websocket notifications for accounts, signatures, logs, or slots.
 
-### Typed RPC methods
+<!-- {/docsCreateRpcClientSection} -->
 
-When working with an `Rpc`, prefer typed convenience helpers over stringly method calls:
+<!-- {=docsGenerateSignerSection} -->
+
+## Generate a signer
+
+Most app flows need a signer for fee payment, message signing, or transaction
+submission. `generateKeyPair()` creates a new Ed25519 key pair and returns a
+`KeyPairSigner`.
 
 ```dart
 import 'package:solana_kit/solana_kit.dart';
 
-final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
-final slot = await rpc.getSlot().send();
-final blockHeight = await rpc.getBlockHeight().send();
+final signer = await generateKeyPair();
+
+print('Address: ${signer.address}');
 ```
 
-These helpers forward to canonical params builders in `solana_kit_rpc_api` and return lazy `PendingRpcRequest<T>` values.
+Use key-pair signers for local development, testing, and server-side flows.
+For wallet-driven applications, you can also model fee-payer, partial, and
+sending signers explicitly with `solana_kit_signers`.
 
-<!-- {/docsTypedRpcSolanaKitSection} -->
+<!-- {/docsGenerateSignerSection} -->
 
-## Generate a Key Pair
+<!-- {=docsFetchAccountSection} -->
+
+## Fetch an account
+
+Use `fetchEncodedAccount` when you want the raw account bytes plus its Solana
+metadata. Decode it later with the codec or parser that matches your program.
 
 ```dart
-final keyPair = await generateKeyPair();
-print('Generated address: ${keyPair.address}');
+import 'dart:typed_data';
+
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+const address = Address('11111111111111111111111111111111');
+
+final maybeAccount = await fetchEncodedAccount(rpc, address);
+
+switch (maybeAccount) {
+  case ExistingAccount<Uint8List>(:final account):
+    print('Owner: ${account.programAddress}');
+    print('Bytes: ${account.data.length}');
+  case NonExistingAccount():
+    print('No account exists at $address');
+}
 ```
 
-Continue with [First Transaction](first-transaction) to build and sign a message.
+Use `fetchJsonParsedAccount` when the RPC can return a structured
+`jsonParsed` representation for a well-known program.
+
+<!-- {/docsFetchAccountSection} -->
+
+## What to read next
+
+- [Create Instructions](create-instructions)
+- [Build a Transaction](build-a-transaction)
+- [First Transaction](first-transaction)
+- [RPC and Subscriptions](../core/rpc-and-subscriptions)
+- [Accounts](../core/accounts)

--- a/docs/site/content/guides/build-program-client.md
+++ b/docs/site/content/guides/build-program-client.md
@@ -1,53 +1,110 @@
 ---
 title: Build a Program Client
-description: Step-by-step guide for creating a typed Solana program client in Dart.
+description: Combine codecs, instructions, and account decoding into a reusable typed client for a Solana program.
 ---
 
-Typed program clients reduce repeated boilerplate and make on-chain interactions safer.
+A program client packages three things together:
 
-## Why Program Clients Matter
+1. **instruction builders**
+2. **account decoders**
+3. **task-oriented helper methods**
 
-- instruction payloads become typed inputs.
-- account parsing becomes centralized and reusable.
-- teams avoid duplicating protocol assumptions.
+That gives the rest of your app one coherent boundary for interacting with a program.
 
-## Step 1: Define Domain Types
+## Step 1: define the instruction layout
 
-- model instruction inputs.
-- model decoded account state.
+```dart
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
 
-Reason: typed models provide compile-time guarantees.
+final incrementInstructionCodec = getStructCodec({
+  'discriminator': getU8Codec(),
+  'amount': getU64Codec(),
+});
+```
 
-## Step 2: Build Codecs for Program Data
+## Step 2: create an instruction builder
 
-- use `solana_kit_codecs_core` and `solana_kit_codecs_data_structures`.
-- encode instruction data and decode account state.
+```dart
+import 'package:solana_kit/solana_kit.dart';
 
-Reason: on-chain bytes must round-trip predictably.
+Instruction buildIncrementInstruction({
+  required Address programAddress,
+  required Address counterAddress,
+  required Address authority,
+  required BigInt amount,
+}) {
+  return Instruction(
+    programAddress: programAddress,
+    accounts: [
+      AccountMeta(address: counterAddress, role: AccountRole.writable),
+      AccountMeta(address: authority, role: AccountRole.readonlySigner),
+    ],
+    data: incrementInstructionCodec.encode({
+      'discriminator': 1,
+      'amount': amount,
+    }),
+  );
+}
+```
 
-## Step 3: Build Instruction Factories
+## Step 3: create an account decoder
 
-- use `solana_kit_instructions` types.
-- return typed instruction builders.
+```dart
+final counterAccountCodec = getStructCodec({
+  'count': getU64Codec(),
+});
+```
 
-Reason: keep account-role correctness in one place.
+Then decode fetched bytes:
 
-## Step 4: Add Account Fetch Helpers
+```dart
+final decoded = counterAccountCodec.decode(encodedAccount.data);
+print(decoded['count']);
+```
 
-- leverage `solana_kit_accounts` for typed fetch/decode wrappers.
-- add convenience helpers for key account types.
+## Step 4: wrap it in a client boundary
 
-Reason: data access consistency prevents decoder drift.
+```dart
+class CounterProgramClient {
+  const CounterProgramClient({required this.rpc, required this.programAddress});
 
-## Step 5: Add Error Mapping
+  final Rpc rpc;
+  final Address programAddress;
 
-- map `ProgramError` and `SolanaError` to domain-level app errors.
+  Future<MaybeEncodedAccount> fetchCounter(Address counterAddress) {
+    return fetchEncodedAccount(rpc, counterAddress);
+  }
 
-Reason: protocol errors should remain actionable at product boundaries.
+  Instruction buildIncrement({
+    required Address counterAddress,
+    required Address authority,
+    required BigInt amount,
+  }) {
+    return buildIncrementInstruction(
+      programAddress: programAddress,
+      counterAddress: counterAddress,
+      authority: authority,
+      amount: amount,
+    );
+  }
+}
+```
 
-## Step 6: Package and Reuse
+At this point, the rest of your app can depend on `CounterProgramClient` instead of knowing the raw layout and account-role details.
 
-- publish as an internal package or module.
-- expose a narrow public API.
+## Step 5: add higher-level workflows
 
-Reason: program upgrades then require changes in one location.
+Once the client owns the instruction and decode rules, you can add methods like:
+
+- `fetchAndDecodeCounter(...)`
+- `buildIncrementMessage(...)`
+- `submitIncrement(...)`
+
+Those methods are usually more stable and more meaningful to application code than the raw Solana details underneath.
+
+## Related docs
+
+- [Codecs](../core/codecs)
+- [Accounts](../core/accounts)
+- [Create Instructions](../getting-started/create-instructions)

--- a/docs/site/content/guides/build-realtime-observer.md
+++ b/docs/site/content/guides/build-realtime-observer.md
@@ -1,48 +1,88 @@
 ---
 title: Build a Realtime Observer
-description: Step-by-step guide for account/log subscriptions and stream fanout.
+description: Turn Solana websocket notifications into a reusable observer layer for your app or service.
 ---
 
-Realtime dApps depend on reliable subscription pipelines.
+Realtime apps often need a thin layer between raw websocket subscriptions and the rest of the application.
 
-## Why a Dedicated Observer Layer
+That observer layer should own:
 
-- websocket lifecycle handling is non-trivial.
-- reconnection/fanout behavior should be centralized.
-- UI components should consume clean streams, not sockets.
+- websocket connection setup
+- subscription registration
+- cancellation
+- stream fanout
+- reconnect/replay policy
 
-## Step 1: Initialize Subscription Client
+## Step 1: create a subscription client
 
-- create client with `solana_kit_rpc_subscriptions`.
-- configure channel transport from websocket package.
+```dart
+import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';
 
-Reason: keep transport details out of feature modules.
+final subscriptions = createSolanaRpcSubscriptions(
+  'wss://api.devnet.solana.com',
+);
+```
 
-## Step 2: Register Typed Subscriptions
+## Step 2: register a typed subscription request
 
-- account notifications
-- slot notifications
-- logs notifications
+```dart
+import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart';
 
-Reason: typed methods prevent payload mismatch bugs.
+final controller = AbortController();
+final pending = subscriptions.request('slotNotifications');
 
-## Step 3: Convert to Stream Abstractions
+final stream = await pending.subscribe(
+  RpcSubscribeOptions(abortSignal: controller.signal),
+);
+```
 
-- use `solana_kit_subscribable` adapters.
-- expose stream interfaces to application consumers.
+## Step 3: adapt that stream to your own observer interface
 
-Reason: stream contracts decouple UI from transport protocol.
+```dart
+class SlotObserver {
+  SlotObserver(this._subscriptions);
 
-## Step 4: Add Backpressure Strategy
+  final RpcSubscriptions _subscriptions;
 
-- debounce noisy update types.
-- batch updates where downstream permits.
+  Stream<Object?> watchSlots() async* {
+    final controller = AbortController();
+    final pending = _subscriptions.request('slotNotifications');
+    final stream = await pending.subscribe(
+      RpcSubscribeOptions(abortSignal: controller.signal),
+    );
 
-Reason: high-frequency Solana events can overwhelm app state layers.
+    yield* stream;
+  }
+}
+```
 
-## Step 5: Reconnect and Replay
+In a production app, you would usually hold onto the abort controller so your service can cancel the subscription on shutdown or when the last listener disconnects.
 
-- reconnect with jittered backoff.
-- re-register subscriptions after reconnect.
+## Step 4: subscribe to account or logs updates
 
-Reason: websocket sessions can drop under network/provider churn.
+The same pattern works for account or logs subscriptions; only the notification name and params differ.
+
+```dart
+final pending = subscriptions.request('accountNotifications', [
+  '11111111111111111111111111111111',
+  {'encoding': 'base64', 'commitment': 'confirmed'},
+]);
+```
+
+## Step 5: make reconnect policy explicit
+
+Transport disruptions are normal. Decide up front how your observer should behave when the socket drops:
+
+- reconnect immediately or with backoff?
+- replay active subscriptions automatically?
+- publish a disconnected state to downstream consumers?
+- buffer, debounce, or drop noisy updates?
+
+Keeping this logic in one observer layer prevents UI code from learning socket lifecycle rules.
+
+## Related docs
+
+- [RPC and Subscriptions](../core/rpc-and-subscriptions)
+- [Build an RPC Service](build-rpc-service)
+- [Package Catalog](../reference/package-catalog)

--- a/docs/site/content/guides/build-rpc-service.md
+++ b/docs/site/content/guides/build-rpc-service.md
@@ -1,17 +1,22 @@
 ---
 title: Build an RPC Service
-description: Step-by-step guide for creating a production-ready Solana RPC service layer.
+description: Create a reusable application service that owns Solana RPC access, policy, and error mapping.
 ---
 
-This guide builds a reusable service that isolates RPC concerns from UI/business logic.
+This guide shows a practical pattern for keeping raw RPC details out of your UI, controllers, or domain services.
 
-## Why This Pattern Matters
+## Why this pattern works
 
-- It keeps transport/retry policy in one place.
-- It makes testing easier by mocking one service boundary.
-- It prevents ad-hoc method calls spread across the app.
+A dedicated RPC service gives you one place to own:
 
-## Step 1: Create a Service Class
+- endpoint configuration
+- commitment defaults
+- transport policy
+- retries/timeouts
+- error mapping
+- request-specific helper methods
+
+## Step 1: wrap the RPC client
 
 ```dart
 import 'package:solana_kit/solana_kit.dart';
@@ -21,51 +26,91 @@ class SolanaRpcService {
 
   final Rpc _rpc;
 
-  Future<BigInt> getBalance(Address address) async {
+  Future<Slot> getSlot() {
+    return _rpc.getSlot().send();
+  }
+
+  Future<Lamports> getBalance(Address address) async {
     final result = await _rpc.getBalance(address).send();
     return result.value;
   }
 
-  Future<int> getSlot() => _rpc.getSlot().send();
+  Future<MaybeEncodedAccount> getAccount(Address address) {
+    return fetchEncodedAccount(_rpc, address);
+  }
 }
 ```
 
-Reason: this turns request construction into a single testable dependency.
+This already pays off because callers no longer need to know which RPC method to call or how the result is shaped.
 
-## Step 2: Add Error Mapping
+## Step 2: centralize error classification
 
 ```dart
-Future<T> withSolanaErrorHandling<T>(Future<T> Function() operation) async {
+Future<T> mapSolanaErrors<T>(Future<T> Function() operation) async {
   try {
     return await operation();
   } on SolanaError catch (error) {
-    // Map to your app-level error model here.
+    if (error.isInDomain(SolanaErrorDomain.rpc)) {
+      // Map to a transport/service-level error in your app.
+      rethrow;
+    }
     rethrow;
   }
 }
 ```
 
-Reason: typed error handling avoids brittle string matching.
+Then use that wrapper inside service methods if your application has its own domain error model.
 
-## Step 3: Centralize Configuration
+## Step 3: expose task-oriented methods
 
-- Keep endpoint URLs in one config object.
-- Optionally inject a custom transport from `solana_kit_rpc_transport_http`.
-- Define commitment defaults at service initialization.
+Your application usually cares about workflows, not raw JSON-RPC calls.
 
-Reason: consistency and easier environment switching.
+```dart
+class WalletOverviewService {
+  WalletOverviewService(this._rpcService);
 
-## Step 4: Add Health and Latency Probes
+  final SolanaRpcService _rpcService;
 
-- call `getSlot()` as a health probe.
-- measure timing around critical methods.
-- emit metrics with method labels.
+  Future<(Lamports, Slot)> loadOverview(Address address) async {
+    final balance = await _rpcService.getBalance(address);
+    final slot = await _rpcService.getSlot();
+    return (balance, slot);
+  }
+}
+```
 
-Reason: Solana RPC reliability is workload-dependent and should be observable.
+This keeps your app code focused on product behavior rather than transport mechanics.
 
-## Step 5: Integrate in App Layer
+## Step 4: move transport configuration to the edge
 
-- provide `SolanaRpcService` via dependency injection.
-- keep widgets/controllers free of raw RPC method construction.
+If you need a custom HTTP client or transport policy, configure it at service creation time.
 
-Reason: cleaner architecture and easier migration/testing.
+```dart
+import 'package:http/http.dart' as http;
+import 'package:solana_kit_rpc_transport_http/solana_kit_rpc_transport_http.dart';
+
+final transport = createHttpTransportForSolanaRpc(
+  url: 'https://api.devnet.solana.com',
+  client: http.Client(),
+  headers: {'x-service-name': 'wallet-api'},
+);
+```
+
+That makes it much easier to switch providers, add observability, or test against a custom transport.
+
+## Step 5: test at the service boundary
+
+A service wrapper is a much more useful unit to test than many ad hoc RPC calls spread throughout the app.
+
+Typical test cases:
+
+- returns a typed balance result
+- maps missing accounts to the expected app behavior
+- classifies RPC-domain failures correctly
+- applies the right commitment or endpoint policy
+
+## Related docs
+
+- [RPC and Subscriptions](../core/rpc-and-subscriptions)
+- [Errors and Diagnostics](../core/errors-and-diagnostics)
+- [Fetch an Account](../getting-started/fetch-an-account)

--- a/docs/site/content/guides/build-token-transfer-flow.md
+++ b/docs/site/content/guides/build-token-transfer-flow.md
@@ -1,58 +1,102 @@
 ---
 title: Build a Token Transfer Flow
-description: Step-by-step guide for assembling and sending a transfer transaction.
+description: Assemble a production-friendly transfer pipeline from inputs to confirmation.
 ---
 
-This guide shows a robust transfer flow from message creation to confirmation.
+A transfer flow is more than a single helper call. In practice, you need to:
 
-## Why This Flow Exists
+1. collect inputs
+2. fetch chain state
+3. build the message
+4. sign
+5. send
+6. confirm
+7. classify failures
 
-A transfer is not a single API call. It is a sequence: fetch state, build message, sign, send, confirm.
+This guide focuses on the shape of that pipeline so you can adapt it to SOL transfers, SPL token transfers, or your own typed program client.
 
-## Step 1: Gather Inputs
+## Step 1: gather the inputs
 
-- sender keypair/signer
-- recipient address
-- amount
-- latest blockhash
+Typical transfer inputs:
 
-Reason: transaction assembly requires all of these before signing.
+- the sender signer or wallet
+- the recipient address
+- the amount
+- an instruction builder or program client
+- an RPC client
 
-## Step 2: Build the Message
+Keeping these explicit at the function boundary makes the transfer flow easier to test.
+
+## Step 2: fetch the latest blockhash
+
+```dart
+final latestBlockhash = await rpc.getLatestBlockhash().send();
+```
+
+A blockhash-based transaction must include a valid lifetime constraint before it can be signed.
+
+## Step 3: build the transfer instruction
+
+Whether you use a system-program helper, a token-program client, or a custom instruction builder, the output should be an `Instruction`.
+
+```dart
+final transferInstruction = buildTransferInstruction(
+  sender: sender.address,
+  recipient: recipient,
+  amount: amount,
+);
+```
+
+## Step 4: build the transaction message
 
 ```dart
 final message = createTransactionMessage()
-    .pipe(setTransactionMessageFeePayer(sender.address))
-    .pipe(setTransactionMessageLifetimeUsingBlockhash(blockhash));
+    .pipe(setTransactionMessageFeePayerSigner(sender))
+    .pipe(
+      setTransactionMessageLifetimeUsingBlockhash(
+        BlockhashLifetimeConstraint(
+          blockhash: latestBlockhash.value.blockhash,
+          lastValidBlockHeight: latestBlockhash.value.lastValidBlockHeight,
+        ),
+      ),
+    )
+    .pipe(appendTransactionMessageInstruction(transferInstruction));
 ```
 
-Reason: fee payer and lifetime are mandatory correctness constraints.
+## Step 5: sign and submit
 
-## Step 3: Append Transfer Instructions
+```dart
+final signedTransaction = await signTransactionMessageWithSigners(message);
 
-- build instruction(s) for SOL or SPL transfer.
-- append with `appendTransactionMessageInstruction(...)`.
+final signature = await sendAndConfirmTransaction(
+  rpc: rpc,
+  transaction: signedTransaction,
+);
+```
 
-Reason: message mutations remain explicit and auditable.
+## Step 6: map failures by domain
 
-## Step 4: Compile and Sign
+Useful high-level buckets:
 
-- compile to transaction bytes.
-- sign with required signers (`solana_kit_signers`).
+- **RPC failures** — provider downtime, transport errors, malformed responses
+- **transaction failures** — missing signers, expired blockhash, signature issues
+- **program/instruction failures** — insufficient funds, invalid accounts, program-specific rules
 
-Reason: compile/sign boundaries make partial and multi-signer flows manageable.
+`SolanaError` domains make it easier to route these to the right product behavior.
 
-## Step 5: Send and Confirm Strategically
+## Why this structure scales
 
-- send via RPC.
-- confirm using `solana_kit_transaction_confirmation` strategy.
+This shape works equally well for:
 
-Reason: confirmation behavior should match UX and risk tolerance.
+- one-off wallet sends
+- backend automation
+- mobile wallet adapter integrations
+- typed program clients
+- instruction-plan-based multi-step workflows
 
-## Step 6: Handle Failures by Domain
+## Related docs
 
-- RPC domain: transport/server issues.
-- instruction/program domain: semantic failures.
-- transaction domain: signature/lifetime issues.
-
-Reason: domain-specific recovery paths improve reliability.
+- [First Transaction](../getting-started/first-transaction)
+- [Transactions](../core/transactions)
+- [Signers](../core/signers)
+- [Errors and Diagnostics](../core/errors-and-diagnostics)

--- a/docs/site/content/index.md
+++ b/docs/site/content/index.md
@@ -1,9 +1,9 @@
 ---
 title: Solana Kit for Dart
-description: Comprehensive documentation for the Solana Kit Dart workspace.
+description: Comprehensive, example-driven documentation for the Solana Kit Dart workspace.
 ---
 
-A Dart-first Solana SDK workspace modeled after `@solana/kit`, with strongly typed APIs for addresses, instructions, transactions, RPC, subscriptions, and Mobile Wallet Adapter integrations.
+A Dart-first Solana SDK workspace modeled after `@solana/kit`, with strongly typed APIs for addresses, instructions, transactions, RPC, subscriptions, account decoding, and Mobile Wallet Adapter integrations.
 
 <!-- {=docsUpstreamCompatibilitySection} -->
 
@@ -14,24 +14,66 @@ A Dart-first Solana SDK workspace modeled after `@solana/kit`, with strongly typ
 
 <!-- {/docsUpstreamCompatibilitySection} -->
 
-## What You Can Build
+## What makes Solana Kit different?
 
-- Wallet-enabled dApps using typed transaction builders.
-- Program clients that decode account data with explicit codecs.
-- RPC and websocket workflows with strongly typed request/response models.
-- Flutter Android integrations through the Mobile Wallet Adapter package.
+- **Typed end to end** — addresses, RPC requests, subscriptions, transactions, and account models are all expressed with explicit Dart types.
+- **Modular by default** — import the umbrella package for convenience, or pull in only the packages you need.
+- **Composable primitives** — build transaction messages, codecs, program clients, and confirmation strategies from smaller reusable pieces.
+- **Dart-native ergonomics** — modern Dart 3 features like records, patterns, extension types, and sealed classes are used throughout the workspace.
+- **Upstream-aware** — the repo tracks `@solana/kit` compatibility and documents sync status explicitly.
+
+## Start here
+
+If you're new to the workspace, follow this path:
+
+1. [Installation](getting-started/installation)
+2. [Quick Start](getting-started/quick-start)
+3. [Generate a Signer](getting-started/generate-a-signer)
+4. [Fetch an Account](getting-started/fetch-an-account)
+5. [First Transaction](getting-started/first-transaction)
+6. [Transactions](core/transactions)
+7. [RPC and Subscriptions](core/rpc-and-subscriptions)
+
+## Common workflows
+
+### Read chain state
+
+- [Fetch an Account](getting-started/fetch-an-account)
+- [Accounts](core/accounts)
+- [RPC and Subscriptions](core/rpc-and-subscriptions)
+
+### Build and submit transactions
+
+- [Create Instructions](getting-started/create-instructions)
+- [Build a Transaction](getting-started/build-a-transaction)
+- [First Transaction](getting-started/first-transaction)
+- [Transactions](core/transactions)
+- [Signers](core/signers)
+
+### Work with binary layouts and account schemas
+
+- [Codecs](core/codecs)
+- [Build a Program Client](guides/build-program-client)
+
+### Build production integrations
+
+- [Build an RPC Service](guides/build-rpc-service)
+- [Build a Realtime Observer](guides/build-realtime-observer)
+- [Mobile Wallet Adapter](guides/mobile-wallet-adapter)
+- [Helius package](https://pub.dev/packages/solana_kit_helius)
 
 <Info>
-Use the header toggle button to switch between light and dark themes while reading the docs.
+Use the package catalog when you want to know which package to import. Use the core concept pages when you want to understand how the pieces fit together.
 </Info>
 
-## Read Next
+## Package map
 
-- [Installation](getting-started/installation)
-- [Quick Start](getting-started/quick-start)
-- [Build an RPC Service](guides/build-rpc-service)
-- [Build a Token Transfer Flow](guides/build-token-transfer-flow)
-- [Build a Program Client](guides/build-program-client)
-- [Build a Realtime Observer](guides/build-realtime-observer)
+- [Package Index](reference/package-index)
 - [Complete Package Catalog](reference/package-catalog)
+- [Upstream Compatibility](reference/upstream-compatibility)
+
+## Contributor resources
+
 - [Contributing](contributing)
+- [Release Process](guides/release-process)
+- [Benchmarking](guides/benchmarking)

--- a/docs/site/content/reference/package-index.md
+++ b/docs/site/content/reference/package-index.md
@@ -1,45 +1,68 @@
 ---
 title: Package Index
-description: Category-level map of the Solana Kit workspace packages.
+description: Category-level map of the Solana Kit workspace packages with guidance on where to start.
 ---
 
-This page gives a category-level map. For full per-package rationale and usage guidance, use [Complete Package Catalog](package-catalog).
+Use this page when you need to answer: **which package should I import?**
+
+For full per-package rationale and package-by-package usage guidance, continue to [Complete Package Catalog](package-catalog).
+
+## Start with the umbrella package unless you have a reason not to
+
+If you're building an application and want the smoothest experience, start with:
+
+- [`solana_kit`](https://pub.dev/packages/solana_kit)
+
+Then move to smaller packages only when you want a narrower dependency surface or a stricter architectural boundary.
 
 ## Umbrella
 
 - [`solana_kit`](https://pub.dev/packages/solana_kit)
 - [`solana_kit_codecs`](https://pub.dev/packages/solana_kit_codecs)
 
-## Core Primitives
+## Core primitives
 
 - [`solana_kit_addresses`](https://pub.dev/packages/solana_kit_addresses)
 - [`solana_kit_keys`](https://pub.dev/packages/solana_kit_keys)
 - [`solana_kit_signers`](https://pub.dev/packages/solana_kit_signers)
 - [`solana_kit_errors`](https://pub.dev/packages/solana_kit_errors)
 
-## Transaction Stack
+## Transaction stack
 
 - [`solana_kit_instructions`](https://pub.dev/packages/solana_kit_instructions)
 - [`solana_kit_transaction_messages`](https://pub.dev/packages/solana_kit_transaction_messages)
 - [`solana_kit_transactions`](https://pub.dev/packages/solana_kit_transactions)
 - [`solana_kit_transaction_confirmation`](https://pub.dev/packages/solana_kit_transaction_confirmation)
+- [`solana_kit_instruction_plans`](https://pub.dev/packages/solana_kit_instruction_plans)
 
-## RPC + Subscriptions
+## RPC + subscriptions
 
 - [`solana_kit_rpc`](https://pub.dev/packages/solana_kit_rpc)
 - [`solana_kit_rpc_api`](https://pub.dev/packages/solana_kit_rpc_api)
 - [`solana_kit_rpc_types`](https://pub.dev/packages/solana_kit_rpc_types)
 - [`solana_kit_rpc_transport_http`](https://pub.dev/packages/solana_kit_rpc_transport_http)
 - [`solana_kit_rpc_subscriptions`](https://pub.dev/packages/solana_kit_rpc_subscriptions)
+- [`solana_kit_rpc_subscriptions_api`](https://pub.dev/packages/solana_kit_rpc_subscriptions_api)
+- [`solana_kit_rpc_subscriptions_channel_websocket`](https://pub.dev/packages/solana_kit_rpc_subscriptions_channel_websocket)
+- [`solana_kit_subscribable`](https://pub.dev/packages/solana_kit_subscribable)
 
-## Accounts + Programs
+## Accounts + programs
 
 - [`solana_kit_accounts`](https://pub.dev/packages/solana_kit_accounts)
 - [`solana_kit_programs`](https://pub.dev/packages/solana_kit_programs)
 - [`solana_kit_program_client_core`](https://pub.dev/packages/solana_kit_program_client_core)
 - [`solana_kit_sysvars`](https://pub.dev/packages/solana_kit_sysvars)
+- [`solana_kit_rpc_parsed_types`](https://pub.dev/packages/solana_kit_rpc_parsed_types)
 
-## Specialized Integrations
+## Codecs + options
+
+- [`solana_kit_codecs_core`](https://pub.dev/packages/solana_kit_codecs_core)
+- [`solana_kit_codecs_numbers`](https://pub.dev/packages/solana_kit_codecs_numbers)
+- [`solana_kit_codecs_strings`](https://pub.dev/packages/solana_kit_codecs_strings)
+- [`solana_kit_codecs_data_structures`](https://pub.dev/packages/solana_kit_codecs_data_structures)
+- [`solana_kit_options`](https://pub.dev/packages/solana_kit_options)
+
+## Specialized integrations
 
 - [`solana_kit_mobile_wallet_adapter`](https://pub.dev/packages/solana_kit_mobile_wallet_adapter)
 - [`solana_kit_mobile_wallet_adapter_protocol`](https://pub.dev/packages/solana_kit_mobile_wallet_adapter_protocol)
@@ -49,8 +72,11 @@ This page gives a category-level map. For full per-package rationale and usage g
 
 - [`solana_kit_functional`](https://pub.dev/packages/solana_kit_functional)
 - [`solana_kit_fast_stable_stringify`](https://pub.dev/packages/solana_kit_fast_stable_stringify)
-- [`solana_kit_options`](https://pub.dev/packages/solana_kit_options)
 
-## Full Detail
+## Helpful follow-ups
 
-Continue to [Complete Package Catalog](package-catalog) for every workspace package and guidance on why each exists.
+- [Quick Start](../getting-started/quick-start)
+- [Accounts](../core/accounts)
+- [Codecs](../core/codecs)
+- [Transactions](../core/transactions)
+- [Complete Package Catalog](package-catalog)

--- a/packages/solana_kit/README.md
+++ b/packages/solana_kit/README.md
@@ -19,58 +19,39 @@ This is the umbrella package that re-exports all 35 public packages in the SDK, 
 
 <!-- {/upstreamSupportSection} -->
 
+<!-- {=packageInstallSection:"solana_kit"} -->
+
 ## Installation
 
-Add `solana_kit` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
 
-Then import everything with a single line:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```dart
-import 'package:solana_kit/solana_kit.dart';
+```bash
+dart pub add solana_kit
 ```
 
-## Quick start
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
 
-```dart
-import 'package:solana_kit/solana_kit.dart';
+<!-- {/packageInstallSection} -->
 
-Future<void> main() async {
-  // 1. Create an RPC client.
-  final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
-
-  // 2. Generate a new Ed25519 key pair.
-  final keyPair = await generateKeyPair();
-  final signer = await createKeyPairSignerFromKeyPair(keyPair);
-  print('Address: ${signer.address}');
-
-  // 3. Check the balance.
-  final balanceResponse = await rpc.getBalance(
-    signer.address,
-    const GetBalanceConfig(commitment: Commitment.confirmed),
-  ).send();
-  print('Balance: $balanceResponse');
-
-  // 4. Fetch an account.
-  final account = await fetchEncodedAccount(
-    rpc,
-    const Address('11111111111111111111111111111111'),
-  );
-  if (account.exists) {
-    print('System program account exists');
-  }
-}
-```
+<!-- {=packageDocumentationSection:"solana_kit"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit
 - API reference: https://pub.dev/documentation/solana_kit/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_accounts/README.md
+++ b/packages/solana_kit_accounts/README.md
@@ -10,27 +10,39 @@ Account fetching, decoding, and assertion utilities for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/accounts`](https://github.com/anza-xyz/kit/tree/main/packages/accounts) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_accounts"} -->
+
 ## Installation
 
-Add `solana_kit_accounts` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_accounts:
+```bash
+dart pub add solana_kit_accounts
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_accounts"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_accounts
 - API reference: https://pub.dev/documentation/solana_kit_accounts/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_accounts
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_accounts
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_accounts/lib/solana_kit_accounts.dart
+++ b/packages/solana_kit_accounts/lib/solana_kit_accounts.dart
@@ -1,3 +1,9 @@
+/// Account fetching, decoding, and maybe-account abstractions for the Solana Kit Dart SDK.
+///
+/// Use this library to fetch raw or jsonParsed accounts, decode byte-backed
+/// account data, and model account existence explicitly with `MaybeAccount`.
+library;
+
 export 'src/account.dart';
 export 'src/decode_account.dart';
 export 'src/fetch_account.dart';

--- a/packages/solana_kit_addresses/README.md
+++ b/packages/solana_kit_addresses/README.md
@@ -8,27 +8,39 @@
 
 Base58-encoded Solana address utilities for the Solana Kit Dart SDK -- a Dart port of [`@solana/addresses`](https://github.com/anza-xyz/kit/tree/main/packages/addresses).
 
+<!-- {=packageInstallSection:"solana_kit_addresses"} -->
+
 ## Installation
 
-Add `solana_kit_addresses` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_addresses:
+```bash
+dart pub add solana_kit_addresses
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_addresses"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_addresses
 - API reference: https://pub.dev/documentation/solana_kit_addresses/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_addresses
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_addresses
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_addresses/lib/solana_kit_addresses.dart
+++ b/packages/solana_kit_addresses/lib/solana_kit_addresses.dart
@@ -1,3 +1,9 @@
+/// Solana address primitives for the Solana Kit Dart SDK.
+///
+/// Provides strongly typed addresses, validation helpers, base58 codecs, and
+/// program-derived address utilities.
+library;
+
 export 'src/address.dart';
 export 'src/address_codec.dart';
 export 'src/address_comparator.dart';

--- a/packages/solana_kit_codecs/README.md
+++ b/packages/solana_kit_codecs/README.md
@@ -10,20 +10,39 @@ Umbrella package that re-exports all Solana Kit codec sub-packages through a sin
 
 This is a Dart port of [`@solana/codecs`](https://github.com/anza-xyz/kit/tree/main/packages/codecs) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_codecs"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_codecs:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_codecs
 ```
 
-Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_codecs"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_codecs
 - API reference: https://pub.dev/documentation/solana_kit_codecs/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_codecs
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_codecs_core/README.md
+++ b/packages/solana_kit_codecs_core/README.md
@@ -10,20 +10,39 @@ Core codec interfaces and composition utilities for encoding and decoding Solana
 
 This is a Dart port of [`@solana/codecs-core`](https://github.com/anza-xyz/kit/tree/main/packages/codecs-core) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_codecs_core"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_codecs_core:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_codecs_core
 ```
 
-Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_codecs_core"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_codecs_core
 - API reference: https://pub.dev/documentation/solana_kit_codecs_core/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs_core
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_codecs_core
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_codecs_core/lib/solana_kit_codecs_core.dart
+++ b/packages/solana_kit_codecs_core/lib/solana_kit_codecs_core.dart
@@ -1,3 +1,9 @@
+/// Core codec interfaces and composition helpers for the Solana Kit Dart SDK.
+///
+/// Use this library when you need foundational `Encoder`, `Decoder`, and
+/// `Codec` abstractions plus size, padding, transform, and sentinel helpers.
+library;
+
 export 'src/add_codec_sentinel.dart';
 export 'src/add_codec_size_prefix.dart';
 export 'src/assertions.dart';

--- a/packages/solana_kit_codecs_data_structures/README.md
+++ b/packages/solana_kit_codecs_data_structures/README.md
@@ -10,20 +10,39 @@ Codecs for encoding and decoding composite data structures -- structs, arrays, t
 
 This is a Dart port of [`@solana/codecs-data-structures`](https://github.com/anza-xyz/kit/tree/main/packages/codecs-data-structures) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_codecs_data_structures"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_codecs_data_structures:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_codecs_data_structures
 ```
 
-Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_codecs_data_structures"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_codecs_data_structures
 - API reference: https://pub.dev/documentation/solana_kit_codecs_data_structures/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs_data_structures
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_codecs_data_structures
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_codecs_data_structures/lib/solana_kit_codecs_data_structures.dart
+++ b/packages/solana_kit_codecs_data_structures/lib/solana_kit_codecs_data_structures.dart
@@ -1,3 +1,9 @@
+/// Composite data-structure codecs for the Solana Kit Dart SDK.
+///
+/// Provides codecs for arrays, structs, tuples, unions, maps, sets, nullable
+/// values, booleans, and other higher-level binary layouts.
+library;
+
 export 'src/array.dart';
 export 'src/assertions.dart';
 export 'src/bit_array.dart';

--- a/packages/solana_kit_codecs_numbers/README.md
+++ b/packages/solana_kit_codecs_numbers/README.md
@@ -10,20 +10,39 @@ Numeric codecs for encoding and decoding integers and floats in Solana data stru
 
 This is a Dart port of [`@solana/codecs-numbers`](https://github.com/anza-xyz/kit/tree/main/packages/codecs-numbers) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_codecs_numbers"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_codecs_numbers:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_codecs_numbers
 ```
 
-Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_codecs_numbers"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_codecs_numbers
 - API reference: https://pub.dev/documentation/solana_kit_codecs_numbers/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs_numbers
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_codecs_numbers
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_codecs_numbers/lib/solana_kit_codecs_numbers.dart
+++ b/packages/solana_kit_codecs_numbers/lib/solana_kit_codecs_numbers.dart
@@ -1,3 +1,9 @@
+/// Numeric codecs for the Solana Kit Dart SDK.
+///
+/// Includes little-endian integer and floating-point codecs commonly used in
+/// Solana instruction data and account layouts.
+library;
+
 export 'src/assertions.dart';
 export 'src/common.dart';
 export 'src/f32.dart';

--- a/packages/solana_kit_codecs_strings/README.md
+++ b/packages/solana_kit_codecs_strings/README.md
@@ -10,20 +10,39 @@ String codecs for encoding and decoding string data in various bases (base-10, b
 
 This is a Dart port of [`@solana/codecs-strings`](https://github.com/anza-xyz/kit/tree/main/packages/codecs-strings) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_codecs_strings"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_codecs_strings:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_codecs_strings
 ```
 
-Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_codecs_strings"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_codecs_strings
 - API reference: https://pub.dev/documentation/solana_kit_codecs_strings/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs_strings
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_codecs_strings
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_codecs_strings/lib/solana_kit_codecs_strings.dart
+++ b/packages/solana_kit_codecs_strings/lib/solana_kit_codecs_strings.dart
@@ -1,3 +1,9 @@
+/// String and base-encoding codecs for the Solana Kit Dart SDK.
+///
+/// Provides utf8, base16, base58, base64, base10, and generic baseX codecs
+/// for Solana-facing textual and binary conversions.
+library;
+
 export 'src/assertions.dart';
 export 'src/base10.dart';
 export 'src/base16.dart';

--- a/packages/solana_kit_errors/README.md
+++ b/packages/solana_kit_errors/README.md
@@ -10,21 +10,39 @@ Error codes, structured error class, and error conversion utilities for the Sola
 
 This is the Dart port of [`@solana/errors`](https://github.com/anza-xyz/kit/tree/main/packages/errors) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_errors"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_errors
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_errors"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_errors
 - API reference: https://pub.dev/documentation/solana_kit_errors/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_errors
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_errors
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_errors/lib/solana_kit_errors.dart
+++ b/packages/solana_kit_errors/lib/solana_kit_errors.dart
@@ -1,3 +1,9 @@
+/// Structured error types and error-code utilities for the Solana Kit Dart SDK.
+///
+/// Exports `SolanaError`, numeric error codes, error domains, message
+/// formatting helpers, and Solana runtime/RPC error conversion utilities.
+library;
+
 export 'src/codes.dart';
 export 'src/context.dart';
 export 'src/error.dart';

--- a/packages/solana_kit_fast_stable_stringify/README.md
+++ b/packages/solana_kit_fast_stable_stringify/README.md
@@ -10,21 +10,39 @@ Deterministic JSON serialization with sorted keys for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/fast-stable-stringify`](https://github.com/anza-xyz/kit/tree/main/packages/fast-stable-stringify) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_fast_stable_stringify"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_fast_stable_stringify
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_fast_stable_stringify"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_fast_stable_stringify
 - API reference: https://pub.dev/documentation/solana_kit_fast_stable_stringify/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_fast_stable_stringify
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_fast_stable_stringify
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_functional/README.md
+++ b/packages/solana_kit_functional/README.md
@@ -10,21 +10,39 @@ Pipe and compose utilities for the Solana Kit Dart SDK, enabling functional pipe
 
 This is the Dart port of [`@solana/functional`](https://github.com/anza-xyz/kit/tree/main/packages/functional) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_functional"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_functional
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_functional"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_functional
 - API reference: https://pub.dev/documentation/solana_kit_functional/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_functional
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_functional
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_helius/README.md
+++ b/packages/solana_kit_helius/README.md
@@ -22,19 +22,39 @@ Helius SDK for the Solana Kit Dart SDK. A Dart port of the [Helius TypeScript SD
 - **Priority Fees** - Estimate priority fees for transactions
 - **RPC V2** - Enhanced RPC methods with pagination
 
+<!-- {=packageInstallSection:"solana_kit_helius"} -->
+
 ## Installation
+
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_helius
 ```
 
-If you're working inside the `solana_kit` monorepo, workspace resolution uses local packages automatically.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_helius"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_helius
 - API reference: https://pub.dev/documentation/solana_kit_helius/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_helius
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_helius
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_instruction_plans/README.md
+++ b/packages/solana_kit_instruction_plans/README.md
@@ -10,40 +10,39 @@ Plan, organize, and execute complex multi-instruction and multi-transaction oper
 
 This is the Dart port of [`@solana/instruction-plans`](https://github.com/anza-xyz/kit/tree/main/packages/instruction-plans) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_instruction_plans"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_instruction_plans:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_instruction_plans
 ```
 
-Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
 
-## Overview
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
 
-Instruction plans describe operations that may go beyond a single instruction and can span multiple transactions. They define a tree of instructions with constraints on execution order:
+<!-- {/packageInstallSection} -->
 
-- **Sequential** -- Instructions that must run in order.
-- **Parallel** -- Instructions that can run concurrently.
-- **Single** -- A leaf node wrapping one instruction.
-- **MessagePacker** -- A dynamic node that packs instructions into transaction messages to fill available space.
-
-The workflow has three stages:
-
-1. **Instruction Plan** -- Describe what needs to happen.
-2. **Transaction Planner** -- Convert instruction plans into transaction plans (decides how instructions are grouped into transactions).
-3. **Transaction Plan Executor** -- Compile, sign, send, and report results.
+<!-- {=packageDocumentationSection:"solana_kit_instruction_plans"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_instruction_plans
 - API reference: https://pub.dev/documentation/solana_kit_instruction_plans/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_instruction_plans
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_instruction_plans
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_instructions/README.md
+++ b/packages/solana_kit_instructions/README.md
@@ -10,25 +10,39 @@ Types and helpers for creating Solana transaction instructions.
 
 This is the Dart port of [`@solana/instructions`](https://github.com/anza-xyz/kit/tree/main/packages/instructions) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_instructions"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_instructions:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_instructions
 ```
 
-Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_instructions"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_instructions
 - API reference: https://pub.dev/documentation/solana_kit_instructions/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_instructions
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_instructions
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_instructions/lib/solana_kit_instructions.dart
+++ b/packages/solana_kit_instructions/lib/solana_kit_instructions.dart
@@ -1,3 +1,9 @@
+/// Instruction primitives for the Solana Kit Dart SDK.
+///
+/// Use this library to model program invocations with explicit account
+/// metadata roles and binary instruction payloads.
+library;
+
 export 'src/accounts.dart';
 export 'src/instruction.dart';
 export 'src/roles.dart';

--- a/packages/solana_kit_keys/README.md
+++ b/packages/solana_kit_keys/README.md
@@ -8,27 +8,39 @@
 
 Ed25519 key pair generation, signing, and signature verification for the Solana Kit Dart SDK -- a Dart port of [`@solana/keys`](https://github.com/anza-xyz/kit/tree/main/packages/keys).
 
+<!-- {=packageInstallSection:"solana_kit_keys"} -->
+
 ## Installation
 
-Add `solana_kit_keys` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_keys:
+```bash
+dart pub add solana_kit_keys
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_keys"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_keys
 - API reference: https://pub.dev/documentation/solana_kit_keys/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_keys
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_keys
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_keys/lib/solana_kit_keys.dart
+++ b/packages/solana_kit_keys/lib/solana_kit_keys.dart
@@ -1,3 +1,9 @@
+/// Ed25519 key and signature primitives for the Solana Kit Dart SDK.
+///
+/// Exports key-pair generation, public/private key types, and Solana
+/// compatible signature byte wrappers.
+library;
+
 export 'src/key_pair.dart';
 export 'src/private_key.dart';
 export 'src/public_key.dart';

--- a/packages/solana_kit_mobile_wallet_adapter_protocol/README.md
+++ b/packages/solana_kit_mobile_wallet_adapter_protocol/README.md
@@ -23,19 +23,39 @@ This package has **zero Flutter dependency** and can be used in server-side Dart
 - **JWS ES256** compact serialization for attestation
 - **Central error codes** integrated with `solana_kit_errors`
 
+<!-- {=packageInstallSection:"solana_kit_mobile_wallet_adapter_protocol"} -->
+
 ## Installation
+
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_mobile_wallet_adapter_protocol
 ```
 
-If you're working inside the `solana_kit` monorepo, workspace resolution uses local packages automatically.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_mobile_wallet_adapter_protocol"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_mobile_wallet_adapter_protocol
 - API reference: https://pub.dev/documentation/solana_kit_mobile_wallet_adapter_protocol/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_mobile_wallet_adapter_protocol
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_mobile_wallet_adapter_protocol
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_offchain_messages/README.md
+++ b/packages/solana_kit_offchain_messages/README.md
@@ -10,25 +10,39 @@ Create, compile, sign, and verify Solana offchain messages.
 
 Offchain messages allow wallets and applications to sign structured messages that are never submitted to the Solana network. This is the Dart implementation of the [Solana offchain message signing specification](https://github.com/solana-labs/solana/blob/master/docs/src/proposals/off-chain-message-signing.md), related to the signing capabilities in [`@solana/keys`](https://github.com/anza-xyz/kit/tree/main/packages/keys) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_offchain_messages"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_offchain_messages:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_offchain_messages
 ```
 
-Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_offchain_messages"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_offchain_messages
 - API reference: https://pub.dev/documentation/solana_kit_offchain_messages/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_offchain_messages
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_offchain_messages
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_options/README.md
+++ b/packages/solana_kit_options/README.md
@@ -10,20 +10,39 @@ A Rust-like `Option<T>` type and corresponding codec for encoding and decoding o
 
 This is a Dart port of [`@solana/options`](https://github.com/anza-xyz/kit/tree/main/packages/options) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_options"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_options:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_options
 ```
 
-Since this package is part of the `solana_kit` Dart workspace, it is resolved automatically. For standalone use, point to the repository or use a path dependency.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_options"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_options
 - API reference: https://pub.dev/documentation/solana_kit_options/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_options
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_options
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_options/lib/solana_kit_options.dart
+++ b/packages/solana_kit_options/lib/solana_kit_options.dart
@@ -1,3 +1,9 @@
+/// Rust-style optional value modeling for the Solana Kit Dart SDK.
+///
+/// Provides `Option<T>`, `Some`, `None`, and codec helpers for Solana layouts
+/// that encode optional values explicitly.
+library;
+
 export 'src/option.dart';
 export 'src/option_codec.dart';
 export 'src/unwrap_option.dart';

--- a/packages/solana_kit_program_client_core/README.md
+++ b/packages/solana_kit_program_client_core/README.md
@@ -10,27 +10,39 @@ Core building blocks for generated Solana program clients in the Solana Kit Dart
 
 This package provides the foundational types and utilities used by generated program clients, including instruction types that track storage changes, self-fetch functions for decoder-based account retrieval, and instruction input resolution helpers.
 
+<!-- {=packageInstallSection:"solana_kit_program_client_core"} -->
+
 ## Installation
 
-Add `solana_kit_program_client_core` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_program_client_core:
+```bash
+dart pub add solana_kit_program_client_core
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_program_client_core"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_program_client_core
 - API reference: https://pub.dev/documentation/solana_kit_program_client_core/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_program_client_core
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_program_client_core
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_programs/README.md
+++ b/packages/solana_kit_programs/README.md
@@ -10,27 +10,39 @@ Program error identification utilities for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/programs`](https://github.com/anza-xyz/kit/tree/main/packages/programs) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_programs"} -->
+
 ## Installation
 
-Add `solana_kit_programs` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_programs:
+```bash
+dart pub add solana_kit_programs
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_programs"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_programs
 - API reference: https://pub.dev/documentation/solana_kit_programs/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_programs
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_programs
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc/README.md
+++ b/packages/solana_kit_rpc/README.md
@@ -10,21 +10,39 @@ Primary RPC client for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/rpc`](https://github.com/anza-xyz/kit/tree/main/packages/rpc) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_rpc
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc
 - API reference: https://pub.dev/documentation/solana_kit_rpc/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_api/README.md
+++ b/packages/solana_kit_rpc_api/README.md
@@ -10,21 +10,39 @@ RPC method type definitions and API composition for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/rpc-api`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-api) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_api"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_rpc_api
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_api"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_api
 - API reference: https://pub.dev/documentation/solana_kit_rpc_api/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_api
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_api
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_parsed_types/README.md
+++ b/packages/solana_kit_rpc_parsed_types/README.md
@@ -10,21 +10,39 @@ Parsed account data types for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/rpc-parsed-types`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-parsed-types) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_parsed_types"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_rpc_parsed_types
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_parsed_types"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_parsed_types
 - API reference: https://pub.dev/documentation/solana_kit_rpc_parsed_types/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_parsed_types
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_parsed_types
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_spec/README.md
+++ b/packages/solana_kit_rpc_spec/README.md
@@ -10,21 +10,39 @@ RPC specification implementation for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/rpc-spec`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-spec) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_spec"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_rpc_spec
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_spec"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_spec
 - API reference: https://pub.dev/documentation/solana_kit_rpc_spec/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_spec
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_spec
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_spec/lib/solana_kit_rpc_spec.dart
+++ b/packages/solana_kit_rpc_spec/lib/solana_kit_rpc_spec.dart
@@ -1,3 +1,9 @@
+/// Transport-agnostic JSON-RPC contracts for the Solana Kit Dart SDK.
+///
+/// Use this library when building custom RPC APIs, transports, or middleware
+/// around Solana JSON-RPC request planning and execution.
+library;
+
 export 'src/rpc.dart';
 export 'src/rpc_api.dart';
 export 'src/rpc_transport.dart';

--- a/packages/solana_kit_rpc_spec_types/README.md
+++ b/packages/solana_kit_rpc_spec_types/README.md
@@ -10,21 +10,39 @@ RPC spec type definitions for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/rpc-spec-types`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-spec-types) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_spec_types"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_rpc_spec_types
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_spec_types"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_spec_types
 - API reference: https://pub.dev/documentation/solana_kit_rpc_spec_types/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_spec_types
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_spec_types
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_subscriptions/README.md
+++ b/packages/solana_kit_rpc_subscriptions/README.md
@@ -10,27 +10,39 @@ Subscription client for the Solana Kit Dart SDK -- the composition layer that ti
 
 This is the Dart port of [`@solana/rpc-subscriptions`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-subscriptions) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_subscriptions"} -->
+
 ## Installation
 
-Add `solana_kit_rpc_subscriptions` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_rpc_subscriptions:
+```bash
+dart pub add solana_kit_rpc_subscriptions
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_subscriptions"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_subscriptions
 - API reference: https://pub.dev/documentation/solana_kit_rpc_subscriptions/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_subscriptions
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_subscriptions
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_subscriptions_api/README.md
+++ b/packages/solana_kit_rpc_subscriptions_api/README.md
@@ -10,27 +10,39 @@ Subscription method type definitions and parameter builders for all Solana RPC s
 
 This is the Dart port of [`@solana/rpc-subscriptions-api`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-subscriptions-api) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_subscriptions_api"} -->
+
 ## Installation
 
-Add `solana_kit_rpc_subscriptions_api` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_rpc_subscriptions_api:
+```bash
+dart pub add solana_kit_rpc_subscriptions_api
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_subscriptions_api"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_subscriptions_api
 - API reference: https://pub.dev/documentation/solana_kit_rpc_subscriptions_api/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_subscriptions_api
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_subscriptions_api
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/README.md
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/README.md
@@ -10,27 +10,39 @@ WebSocket channel transport for Solana RPC subscriptions in the Solana Kit Dart 
 
 This is the Dart port of [`@solana/rpc-subscriptions-channel-websocket`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-subscriptions-channel-websocket) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_subscriptions_channel_websocket"} -->
+
 ## Installation
 
-Add `solana_kit_rpc_subscriptions_channel_websocket` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_rpc_subscriptions_channel_websocket:
+```bash
+dart pub add solana_kit_rpc_subscriptions_channel_websocket
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_subscriptions_channel_websocket"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_subscriptions_channel_websocket
 - API reference: https://pub.dev/documentation/solana_kit_rpc_subscriptions_channel_websocket/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_subscriptions_channel_websocket
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_subscriptions_channel_websocket
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_transformers/README.md
+++ b/packages/solana_kit_rpc_transformers/README.md
@@ -10,21 +10,39 @@ Request and response transformers for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/rpc-transformers`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-transformers) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_transformers"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_rpc_transformers
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_transformers"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_transformers
 - API reference: https://pub.dev/documentation/solana_kit_rpc_transformers/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_transformers
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_transformers
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_transport_http/README.md
+++ b/packages/solana_kit_rpc_transport_http/README.md
@@ -10,21 +10,39 @@ HTTP transport for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/rpc-transport-http`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-transport-http) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_transport_http"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_rpc_transport_http
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_transport_http"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_transport_http
 - API reference: https://pub.dev/documentation/solana_kit_rpc_transport_http/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_transport_http
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_transport_http
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_types/README.md
+++ b/packages/solana_kit_rpc_types/README.md
@@ -10,21 +10,39 @@ Shared RPC types for the Solana Kit Dart SDK.
 
 This is the Dart port of [`@solana/rpc-types`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-types) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_rpc_types"} -->
+
 ## Installation
 
-Install with:
+Install the package directly:
 
 ```bash
 dart pub add solana_kit_rpc_types
 ```
 
-If you are working within the `solana_kit` monorepo, the package resolves through the Dart workspace. Otherwise, specify a version or path as needed.
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_rpc_types"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_rpc_types
 - API reference: https://pub.dev/documentation/solana_kit_rpc_types/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_types
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_rpc_types
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_rpc_types/lib/solana_kit_rpc_types.dart
+++ b/packages/solana_kit_rpc_types/lib/solana_kit_rpc_types.dart
@@ -1,3 +1,9 @@
+/// Shared Solana RPC type models for the Solana Kit Dart SDK.
+///
+/// Exports common response, parameter, and value types used across account,
+/// block, balance, transaction, and commitment-oriented RPC flows.
+library;
+
 export 'src/account_filter.dart';
 export 'src/account_info.dart';
 export 'src/blockhash.dart';

--- a/packages/solana_kit_signers/README.md
+++ b/packages/solana_kit_signers/README.md
@@ -8,27 +8,39 @@
 
 Signer interfaces and utilities for signing Solana messages and transactions -- a Dart port of [`@solana/signers`](https://github.com/anza-xyz/kit/tree/main/packages/signers).
 
+<!-- {=packageInstallSection:"solana_kit_signers"} -->
+
 ## Installation
 
-Add `solana_kit_signers` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_signers:
+```bash
+dart pub add solana_kit_signers
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_signers"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_signers
 - API reference: https://pub.dev/documentation/solana_kit_signers/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_signers
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_signers
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_signers/lib/solana_kit_signers.dart
+++ b/packages/solana_kit_signers/lib/solana_kit_signers.dart
@@ -1,3 +1,9 @@
+/// Signer interfaces and signing helpers for the Solana Kit Dart SDK.
+///
+/// Models key-pair, fee-payer, partial, modifying, and sending signers for
+/// message and transaction authorization flows.
+library;
+
 export 'src/account_signer_meta.dart';
 export 'src/add_signers.dart';
 export 'src/deduplicate_signers.dart';

--- a/packages/solana_kit_subscribable/README.md
+++ b/packages/solana_kit_subscribable/README.md
@@ -10,27 +10,39 @@ Subscribable and observable patterns for the Solana Kit Dart SDK -- a publish/su
 
 This is the Dart port of [`@solana/subscribable`](https://github.com/anza-xyz/kit/tree/main/packages/subscribable) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_subscribable"} -->
+
 ## Installation
 
-Add `solana_kit_subscribable` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_subscribable:
+```bash
+dart pub add solana_kit_subscribable
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_subscribable"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_subscribable
 - API reference: https://pub.dev/documentation/solana_kit_subscribable/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_subscribable
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_subscribable
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_sysvars/README.md
+++ b/packages/solana_kit_sysvars/README.md
@@ -10,27 +10,39 @@ System variable (sysvar) account access for the Solana Kit Dart SDK -- provides 
 
 This is the Dart port of [`@solana/sysvars`](https://github.com/anza-xyz/kit/tree/main/packages/sysvars) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_sysvars"} -->
+
 ## Installation
 
-Add `solana_kit_sysvars` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_sysvars:
+```bash
+dart pub add solana_kit_sysvars
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_sysvars"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_sysvars
 - API reference: https://pub.dev/documentation/solana_kit_sysvars/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_sysvars
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_sysvars
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_transaction_confirmation/README.md
+++ b/packages/solana_kit_transaction_confirmation/README.md
@@ -10,27 +10,39 @@ Transaction confirmation tracking for the Solana Kit Dart SDK -- provides multip
 
 This is the Dart port of [`@solana/transaction-confirmation`](https://github.com/anza-xyz/kit/tree/main/packages/transaction-confirmation) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_transaction_confirmation"} -->
+
 ## Installation
 
-Add `solana_kit_transaction_confirmation` to your `pubspec.yaml`:
+Install the package directly:
 
-```yaml
-dependencies:
-  solana_kit_transaction_confirmation:
+```bash
+dart pub add solana_kit_transaction_confirmation
 ```
 
-Or, if you are using the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_transaction_confirmation"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_transaction_confirmation
 - API reference: https://pub.dev/documentation/solana_kit_transaction_confirmation/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_transaction_confirmation
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_transaction_confirmation
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_transaction_messages/README.md
+++ b/packages/solana_kit_transaction_messages/README.md
@@ -10,25 +10,39 @@ Build, compile, and decompile Solana transaction messages.
 
 This is the Dart port of [`@solana/transaction-messages`](https://github.com/anza-xyz/kit/tree/main/packages/transaction-messages) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_transaction_messages"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_transaction_messages:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_transaction_messages
 ```
 
-Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_transaction_messages"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_transaction_messages
 - API reference: https://pub.dev/documentation/solana_kit_transaction_messages/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_transaction_messages
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_transaction_messages
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_transaction_messages/lib/solana_kit_transaction_messages.dart
+++ b/packages/solana_kit_transaction_messages/lib/solana_kit_transaction_messages.dart
@@ -1,3 +1,9 @@
+/// Transaction message builders and transforms for the Solana Kit Dart SDK.
+///
+/// Use this library to assemble immutable transaction messages, configure
+/// lifetimes, append instructions, and compile or decompile message state.
+library;
+
 export 'src/addresses_by_lookup_table_address.dart';
 export 'src/blockhash.dart';
 export 'src/codecs/address_table_lookup_codec.dart';

--- a/packages/solana_kit_transactions/README.md
+++ b/packages/solana_kit_transactions/README.md
@@ -10,25 +10,39 @@ Compile, sign, encode, and decode Solana transactions.
 
 This is the Dart port of [`@solana/transactions`](https://github.com/anza-xyz/kit/tree/main/packages/transactions) from the Solana TypeScript SDK.
 
+<!-- {=packageInstallSection:"solana_kit_transactions"} -->
+
 ## Installation
 
-```yaml
-dependencies:
-  solana_kit_transactions:
+Install the package directly:
+
+```bash
+dart pub add solana_kit_transactions
 ```
 
-Since this package is part of the `solana_kit` workspace, you can also use the umbrella package:
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
 
-```yaml
-dependencies:
-  solana_kit:
+```bash
+dart pub add solana_kit
 ```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
+<!-- {=packageDocumentationSection:"solana_kit_transactions"} -->
 
 ## Documentation
 
 - Package page: https://pub.dev/packages/solana_kit_transactions
 - API reference: https://pub.dev/documentation/solana_kit_transactions/latest/
-- Guides website: https://openbudgetfun.github.io/solana_kit/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_transactions
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/solana_kit_transactions
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
 
 ## Usage
 

--- a/packages/solana_kit_transactions/lib/solana_kit_transactions.dart
+++ b/packages/solana_kit_transactions/lib/solana_kit_transactions.dart
@@ -1,3 +1,9 @@
+/// Signed transaction primitives and wire-format helpers for the Solana Kit Dart SDK.
+///
+/// Exports transaction models, signature collections, compile helpers, and
+/// serialization utilities for sending Solana transactions.
+library;
+
 export 'src/codecs/signatures_encoder.dart';
 export 'src/codecs/transaction_codec.dart';
 export 'src/compile_transaction.dart';

--- a/readme.md
+++ b/readme.md
@@ -25,21 +25,97 @@ Documentation website: https://openbudgetfun.github.io/solana_kit/
 
 ## Quick Start
 
+<!-- {=docsCreateRpcClientSection} -->
+
+## Create an RPC client
+
+Start with a typed RPC client. It gives you method-specific helpers instead of
+building raw JSON-RPC requests by hand.
+
 ```dart
 import 'package:solana_kit/solana_kit.dart';
 
-// Create an RPC client
-final rpc = createSolanaRpc(url: 'https://api.mainnet-beta.solana.com');
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
 
-// Generate a key pair
-final keyPair = await generateKeyPair();
+final slot = await rpc.getSlot().send();
+final latestBlockhash = await rpc.getLatestBlockhash().send();
 
-// Create and send a transaction
-final message = createTransactionMessage()
-  .pipe(setTransactionMessageFeePayer(keyPair.address))
-  .pipe(setTransactionMessageLifetimeUsingBlockhash(blockhash))
-  .pipe(appendTransactionMessageInstruction(instruction));
+print('Current slot: $slot');
+print('Latest blockhash: ${latestBlockhash.value.blockhash}');
 ```
+
+Use `solana_kit_rpc_subscriptions` alongside `solana_kit_rpc` when you also
+need websocket notifications for accounts, signatures, logs, or slots.
+
+<!-- {/docsCreateRpcClientSection} -->
+
+<!-- {=docsGenerateSignerSection} -->
+
+## Generate a signer
+
+Most app flows need a signer for fee payment, message signing, or transaction
+submission. `generateKeyPair()` creates a new Ed25519 key pair and returns a
+`KeyPairSigner`.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+final signer = await generateKeyPair();
+
+print('Address: ${signer.address}');
+```
+
+Use key-pair signers for local development, testing, and server-side flows.
+For wallet-driven applications, you can also model fee-payer, partial, and
+sending signers explicitly with `solana_kit_signers`.
+
+<!-- {/docsGenerateSignerSection} -->
+
+<!-- {=docsBuildTransactionSection} -->
+
+## Build a transaction message
+
+Transaction messages are assembled incrementally. The most common pattern is:
+
+1. Create an empty message.
+2. Set the fee payer.
+3. Set a lifetime constraint using a recent blockhash.
+4. Append one or more instructions.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+final feePayer = await generateKeyPair();
+final latestBlockhash = await rpc.getLatestBlockhash().send();
+
+final instruction = Instruction(
+  programAddress: const Address('11111111111111111111111111111111'),
+  accounts: [
+    AccountMeta(address: feePayer.address, role: AccountRole.writableSigner),
+  ],
+  data: Uint8List(0),
+);
+
+final message = createTransactionMessage()
+    .pipe(setTransactionMessageFeePayer(feePayer.address))
+    .pipe(
+      setTransactionMessageLifetimeUsingBlockhash(
+        BlockhashLifetimeConstraint(
+          blockhash: latestBlockhash.value.blockhash,
+          lastValidBlockHeight: latestBlockhash.value.lastValidBlockHeight,
+        ),
+      ),
+    )
+    .pipe(appendTransactionMessageInstruction(instruction));
+```
+
+This separation keeps transaction construction explicit and makes it easier to
+reason about fee payment, expiry, and instruction ordering.
+
+<!-- {/docsBuildTransactionSection} -->
 
 <!-- {=typedRpcMethodsSection|replace:"__RPC_IMPORT_PATH__":"package:solana_kit/solana_kit.dart"|replace:"__RPC_URL__":"https://api.mainnet-beta.solana.com"} -->
 
@@ -68,50 +144,52 @@ These helpers forward to canonical params builders in `solana_kit_rpc_api` and r
 
 ### Setup
 
+<!-- {=docsWorkspaceSetupSection} -->
+
 ```bash
 # Clone the repository
 git clone https://github.com/openbudgetfun/solana_kit.git
 cd solana_kit
 
-# Allow direnv (loads devenv automatically)
+# Load devenv
 direnv allow
 
-# Install binary dependencies
+# Install binary tools and Dart dependencies
 install:all
-
-# Resolve Dart dependencies
 dart pub get
 
-# Clone reference repositories
+# Pull reference repositories used for compatibility checks
 clone:repos
 ```
 
+<!-- {/docsWorkspaceSetupSection} -->
+
 ### Development
 
+<!-- {=docsWorkspaceDevCommandsSection} -->
+
 ```bash
-# Run all lint checks
+# Lint, docs drift, formatting, and analysis checks
 lint:all
 
-# Run all tests
+# Run all package tests
 test:all
 
 # Generate merged test coverage across all packages
 test:coverage
 
-# Validate documentation templates and generated workspace docs
+# Validate markdown templates and generated docs
+# (also runs mdt doctor and workspace docs drift checks)
 docs:check
 
 # Regenerate documentation template consumers and workspace docs
 docs:update
 
-# Serve the Jaspr docs site locally
-docs:site:serve
+# Inspect mdt provider/consumer state and cache reuse
+mdt:info
 
-# Build static docs output (for GitHub Pages)
-docs:site:build
-
-# Run docs build + HTTP smoke checks
-docs:site:smoke
+# Run actionable mdt health checks
+mdt:doctor
 
 # Check tracked upstream compatibility metadata
 upstream:check
@@ -119,9 +197,11 @@ upstream:check
 # Run local benchmark scripts across benchmark-enabled packages
 bench:all
 
-# Fix formatting and lint issues
+# Fix formatting and lint issues where possible
 fix:all
 ```
+
+<!-- {/docsWorkspaceDevCommandsSection} -->
 
 The merged LCOV report is written to `coverage/lcov.info`.
 

--- a/template.t.md
+++ b/template.t.md
@@ -1,3 +1,37 @@
+<!-- {@packageDocumentationSection:"package_name"} -->
+
+## Documentation
+
+- Package page: https://pub.dev/packages/{{ package_name }}
+- API reference: https://pub.dev/documentation/{{ package_name }}/latest/
+- Workspace docs: https://openbudgetfun.github.io/solana_kit/
+- Package catalog entry: https://openbudgetfun.github.io/solana_kit/reference/package-catalog#{{ package_name }}
+- Source code: https://github.com/openbudgetfun/solana_kit/tree/main/packages/{{ package_name }}
+
+For architecture notes, getting-started guides, and cross-package examples, start with the workspace docs site and then drill down into the package README and API reference.
+
+<!-- {/packageDocumentationSection} -->
+
+<!-- {@packageInstallSection:"package_name"} -->
+
+## Installation
+
+Install the package directly:
+
+```bash
+dart pub add {{ package_name }}
+```
+
+If your app uses several Solana Kit packages together, you can also depend on the umbrella package instead:
+
+```bash
+dart pub add solana_kit
+```
+
+Inside this monorepo, Dart workspace resolution uses the local package automatically.
+
+<!-- {/packageInstallSection} -->
+
 <!-- {@packageExampleSection} -->
 
 ## Example
@@ -137,11 +171,30 @@ lint:all
 # Run all package tests
 test:all
 
+# Generate merged test coverage across all packages
+test:coverage
+
 # Validate markdown templates and generated docs
+# (also runs mdt doctor and workspace docs drift checks)
 docs:check
 
 # Regenerate documentation template consumers and workspace docs
 docs:update
+
+# Inspect mdt provider/consumer state and cache reuse
+mdt:info
+
+# Run actionable mdt health checks
+mdt:doctor
+
+# Check tracked upstream compatibility metadata
+upstream:check
+
+# Run local benchmark scripts across benchmark-enabled packages
+bench:all
+
+# Fix formatting and lint issues where possible
+fix:all
 ```
 
 <!-- {/docsWorkspaceDevCommandsSection} -->
@@ -209,3 +262,150 @@ For direct parsing, use `parseJsonWithBigIntsAsync(...)` with
 `runInIsolate: true`.
 
 <!-- {/docsIsolateJsonDecodeHttpSection} -->
+
+<!-- {@docsCreateRpcClientSection} -->
+
+## Create an RPC client
+
+Start with a typed RPC client. It gives you method-specific helpers instead of
+building raw JSON-RPC requests by hand.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+
+final slot = await rpc.getSlot().send();
+final latestBlockhash = await rpc.getLatestBlockhash().send();
+
+print('Current slot: $slot');
+print('Latest blockhash: ${latestBlockhash.value.blockhash}');
+```
+
+Use `solana_kit_rpc_subscriptions` alongside `solana_kit_rpc` when you also
+need websocket notifications for accounts, signatures, logs, or slots.
+
+<!-- {/docsCreateRpcClientSection} -->
+
+<!-- {@docsGenerateSignerSection} -->
+
+## Generate a signer
+
+Most app flows need a signer for fee payment, message signing, or transaction
+submission. `generateKeyPair()` creates a new Ed25519 key pair and returns a
+`KeyPairSigner`.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+final signer = await generateKeyPair();
+
+print('Address: ${signer.address}');
+```
+
+Use key-pair signers for local development, testing, and server-side flows.
+For wallet-driven applications, you can also model fee-payer, partial, and
+sending signers explicitly with `solana_kit_signers`.
+
+<!-- {/docsGenerateSignerSection} -->
+
+<!-- {@docsBuildTransactionSection} -->
+
+## Build a transaction message
+
+Transaction messages are assembled incrementally. The most common pattern is:
+
+1. Create an empty message.
+2. Set the fee payer.
+3. Set a lifetime constraint using a recent blockhash.
+4. Append one or more instructions.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+final feePayer = await generateKeyPair();
+final latestBlockhash = await rpc.getLatestBlockhash().send();
+
+final instruction = Instruction(
+  programAddress: const Address('11111111111111111111111111111111'),
+  accounts: [
+    AccountMeta(address: feePayer.address, role: AccountRole.writableSigner),
+  ],
+  data: Uint8List(0),
+);
+
+final message = createTransactionMessage()
+    .pipe(setTransactionMessageFeePayer(feePayer.address))
+    .pipe(
+      setTransactionMessageLifetimeUsingBlockhash(
+        BlockhashLifetimeConstraint(
+          blockhash: latestBlockhash.value.blockhash,
+          lastValidBlockHeight: latestBlockhash.value.lastValidBlockHeight,
+        ),
+      ),
+    )
+    .pipe(appendTransactionMessageInstruction(instruction));
+```
+
+This separation keeps transaction construction explicit and makes it easier to
+reason about fee payment, expiry, and instruction ordering.
+
+<!-- {/docsBuildTransactionSection} -->
+
+<!-- {@docsFetchAccountSection} -->
+
+## Fetch an account
+
+Use `fetchEncodedAccount` when you want the raw account bytes plus its Solana
+metadata. Decode it later with the codec or parser that matches your program.
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit/solana_kit.dart';
+
+final rpc = createSolanaRpc(url: 'https://api.devnet.solana.com');
+const address = Address('11111111111111111111111111111111');
+
+final maybeAccount = await fetchEncodedAccount(rpc, address);
+
+switch (maybeAccount) {
+  case ExistingAccount<Uint8List>(:final account):
+    print('Owner: ${account.programAddress}');
+    print('Bytes: ${account.data.length}');
+  case NonExistingAccount():
+    print('No account exists at $address');
+}
+```
+
+Use `fetchJsonParsedAccount` when the RPC can return a structured
+`jsonParsed` representation for a well-known program.
+
+<!-- {/docsFetchAccountSection} -->
+
+<!-- {@docsSendAndConfirmSection} -->
+
+## Send and confirm a signed transaction
+
+Once you have a signed `Transaction`, use the additive confirmation helper for
+an end-to-end “send then wait for confirmation” flow.
+
+```dart
+import 'package:solana_kit/solana_kit.dart';
+
+final signature = await sendAndConfirmTransaction(
+  rpc: rpc,
+  transaction: signedTransaction,
+);
+
+print('Confirmed signature: ${signature.value}');
+```
+
+For lower-level control, `solana_kit_transaction_confirmation` also exposes
+strategy factories for block-height expiry, durable nonce invalidation,
+signature notifications, and timeout racing.
+
+<!-- {/docsSendAndConfirmSection} -->


### PR DESCRIPTION
## Summary
- upgrade the workspace mdt integration in `devenv` and add richer docs maintenance commands
- reuse shared documentation blocks across the root README, package READMEs, and docs-site pages
- expand the docs site with stronger getting-started and core concept guides, plus package library doc comments for key entrypoints

## Validation
- `devenv shell -- bash -lc 'docs:check'`
- `devenv shell -- bash -lc 'docs:site:build'`
- `devenv shell -- bash -lc 'dprint check'`

## Notes
- broader workspace `dart analyze` remains blocked by existing unrelated generated/example resolution issues; this PR uses the docs-specific validation path already defined in `devenv.nix`