### PR TITLE
💚 ci: deploy docs pages from main pushes

### DIFF
--- a/.changeset/fix_docs_pages_main_push_trigger.md
+++ b/.changeset/fix_docs_pages_main_push_trigger.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Deploy the docs site from `main` pushes instead of release-tag events so GitHub Pages deployments comply with the repository's `github-pages` environment branch policy.

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -8,8 +8,11 @@ on:
         required: false
         default: ""
         type: string
-  release:
-    types: [published]
+  # GitHub Pages environment deployment is restricted to the `main` branch,
+  # so release-tag runs cannot complete the deploy job.
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- switch the Docs Pages workflow from release-tag triggers to main push triggers
- keep manual workflow_dispatch support
- add a changeset for the CI fix

## Why
The latest Docs Pages run failed because the workflow was triggered from the `v0.3.1` release tag, while the `github-pages` environment only allows deployments from the `main` branch. The build job succeeded, but the deploy job never ran any steps because the environment branch policy rejected the tag ref.

## Validation
- `devenv shell -- bash -lc 'docs:site:build'