### PR TITLE
🔧 build: cache pnpm-managed Node.js and bump actions to Node 24

### DIFF
--- a/.github/actions/devenv/action.yml
+++ b/.github/actions/devenv/action.yml
@@ -13,12 +13,20 @@ runs:
   using: composite
   steps:
     - name: cache eget
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ./.eget/bin
         key: ${{ runner.os }}-eget-${{ inputs.cache-version }}-${{ github.job }}-${{ hashFiles('.eget/.eget.toml') }}
         restore-keys: |
           ${{ runner.os }}-eget-${{ inputs.cache-version }}-${{ github.job }}-
+
+    - name: cache pnpm node
+      uses: actions/cache@v5
+      with:
+        path: ~/.local/share/pnpm
+        key: ${{ runner.os }}-pnpm-node-${{ inputs.cache-version }}-${{ hashFiles('pnpm-workspace.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-node-${{ inputs.cache-version }}-
 
     - name: install nix
       uses: cachix/install-nix-action@v31

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   changeset-frontmatter:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Validate changeset frontmatter
         run: scripts/check-changeset-frontmatter.sh
 
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Require changes to be documented
@@ -30,7 +30,7 @@ jobs:
   docs-drift:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
   docs-site:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +52,7 @@ jobs:
   upstream-compatibility:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
   lint:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +74,7 @@ jobs:
   test:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
   coverage-risk-tiers:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -96,8 +96,8 @@ jobs:
   android-plugin-compile:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -105,7 +105,7 @@ jobs:
         with:
           channel: stable
           cache: true
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@v4
       - name: Accept Android SDK licenses
         run: yes | sdkmanager --licenses >/dev/null || true
       - name: Install Android SDK components
@@ -119,9 +119,9 @@ jobs:
       run:
         working-directory: packages/codama-renderers-dart
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -140,7 +140,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -27,12 +27,12 @@ jobs:
   build:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Resolve docs base path
         id: base
         run: |
@@ -60,7 +60,7 @@ jobs:
         run: docs:site:build --dart-define=DOCS_BASE_PATH=${{ steps.base.outputs.base_path }}
         shell: devenv shell -- bash -e {0}
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/site/build/jaspr
 
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,14 +30,14 @@ jobs:
   publish:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   release:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: ./.github/actions/devenv


### PR DESCRIPTION
## Summary

Cache the pnpm-managed Node.js installation in CI and bump all GitHub Actions to latest versions that use Node 24 (removing Node 20 deprecation warnings).

## Changes

### Cache pnpm Node.js
- Add `actions/cache@v5` step in `.github/actions/devenv/action.yml` for `~/.local/share/pnpm`
- Cache key is based on `hashFiles('pnpm-workspace.yaml')` so it busts when `useNodeVersion` changes
- Avoids re-downloading Node.js via `pnpm env add --global` on every CI run

### Bump actions to Node 24
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/setup-node` | v4 | v6 |
| `actions/setup-java` | v4 | v5 |
| `actions/upload-pages-artifact` | v3 | v4 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/configure-pages` | v5 | v6 |
| `android-actions/setup-android` | v3 | v4 |
| `pnpm/action-setup` | v4 | v5 |

All updated actions run on Node 24, eliminating the deprecation warning:
> *Node.js 20 actions are deprecated... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.*