### PR TITLE
🐛 fix(ci): pass sdk-version and ndk-version to setup-android v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,11 @@ jobs:
         with:
           channel: stable
           cache: true
-      - uses: android-actions/setup-android@v4
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4
+        with:
+          sdk-version: 34
+          ndk-version: "26.0.10792818"
       - name: Accept Android SDK licenses
         run: yes | sdkmanager --licenses >/dev/null || true
       - name: Install Android SDK components


### PR DESCRIPTION
Fixes the `android-plugin-compile` CI failure caused by the `android-actions/setup-android` v3→v4 bump in #104.

v4 changed the action interface and no longer auto-detects the SDK version — it now requires explicit `sdk-version` and `ndk-version` inputs.