### PR TITLE
feat: add `solana-program/*` reference repos to clone:repos

### DIFF
--- a/.changeset/improve-handwritten-coverage.md
+++ b/.changeset/improve-handwritten-coverage.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Improve handwritten test coverage across RPC, token, websocket, and sysvar packages.

--- a/.changeset/issue-139-solana-program-reference-repos.md
+++ b/.changeset/issue-139-solana-program-reference-repos.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Add solana-program/* reference repos to clone:repos with pinned version tracking for all 11 program repos.

--- a/devenv.nix
+++ b/devenv.nix
@@ -490,6 +490,50 @@ in
           echo "Cloning brij-digital/espresso-cash-public..."
           git clone https://github.com/brij-digital/espresso-cash-public "$DEVENV_ROOT/.repos/espresso-cash-public"
         fi
+
+        # solana-program/* repos — pinned to specific tags/commits for stability.
+        # Update the tag and re-run clone:repos when a new program version ships.
+        mkdir -p "$DEVENV_ROOT/.repos/solana-program"
+
+        clone_or_update_at_tag() {
+          local repo="$1" tag="$2" dest="$3"
+          if [ -d "$dest" ]; then
+            echo "Checking $repo at $tag..."
+            cd "$dest"
+            git fetch --tags --quiet
+            git checkout --quiet "$tag"
+          else
+            echo "Cloning $repo at $tag..."
+            git clone --branch "$tag" --depth 1 \
+              "https://github.com/solana-program/$repo" "$dest"
+          fi
+        }
+
+        clone_or_update_at_tag system           js@v0.12.0                          "$DEVENV_ROOT/.repos/solana-program/system"
+        clone_or_update_at_tag token            js@v0.13.0                          "$DEVENV_ROOT/.repos/solana-program/token"
+        clone_or_update_at_tag token-2022       js@v0.9.0                           "$DEVENV_ROOT/.repos/solana-program/token-2022"
+        clone_or_update_at_tag associated-token-account program@v8.0.0             "$DEVENV_ROOT/.repos/solana-program/associated-token-account"
+        clone_or_update_at_tag address-lookup-table js@v0.11.0                     "$DEVENV_ROOT/.repos/solana-program/address-lookup-table"
+        clone_or_update_at_tag memo             js@v0.11.0                          "$DEVENV_ROOT/.repos/solana-program/memo"
+        clone_or_update_at_tag compute-budget   js@v0.15.0                          "$DEVENV_ROOT/.repos/solana-program/compute-budget"
+        clone_or_update_at_tag stake            js@v0.6.0                           "$DEVENV_ROOT/.repos/solana-program/stake"
+        clone_or_update_at_tag config           solana-config-program-client@v1.1.0 "$DEVENV_ROOT/.repos/solana-program/config"
+        clone_or_update_at_tag loader-v3        js@v0.3.0                           "$DEVENV_ROOT/.repos/solana-program/loader-v3"
+
+        # loader-v4 has no versioned release yet; pin to a specific commit.
+        # Pinned: 5df834d (2026-03-08)
+        if [ -d "$DEVENV_ROOT/.repos/solana-program/loader-v4" ]; then
+          echo "Checking loader-v4 at 5df834d..."
+          cd "$DEVENV_ROOT/.repos/solana-program/loader-v4"
+          git fetch --quiet
+          git checkout --quiet 5df834d
+        else
+          echo "Cloning loader-v4 at 5df834d..."
+          git clone https://github.com/solana-program/loader-v4 \
+            "$DEVENV_ROOT/.repos/solana-program/loader-v4"
+          cd "$DEVENV_ROOT/.repos/solana-program/loader-v4"
+          git checkout --quiet 5df834d
+        fi
       '';
       description = "Clone or update reference repos into .repos/.";
       binary = "bash";

--- a/docs/agents/reference-repos.md
+++ b/docs/agents/reference-repos.md
@@ -21,19 +21,19 @@ ships upstream, update the pin in `devenv.nix` under `clone:repos`, run
 `clone:repos`, regenerate the affected package with `codama-renderers-dart`,
 bump the package version, and add a changeset.
 
-| Path | Repo | Pinned version | Used by |
-|------|------|---------------|---------|
-| `.repos/solana-program/system` | [solana-program/system](https://github.com/solana-program/system) | `js@v0.12.0` | `solana_kit_system` (#131) |
-| `.repos/solana-program/token` | [solana-program/token](https://github.com/solana-program/token) | `js@v0.13.0` | `solana_kit_token` |
-| `.repos/solana-program/token-2022` | [solana-program/token-2022](https://github.com/solana-program/token-2022) | `js@v0.9.0` | `solana_kit_token_2022` |
-| `.repos/solana-program/associated-token-account` | [solana-program/associated-token-account](https://github.com/solana-program/associated-token-account) | `program@v8.0.0` | `solana_kit_associated_token_account` (#132) — handwritten, use as interface reference |
-| `.repos/solana-program/address-lookup-table` | [solana-program/address-lookup-table](https://github.com/solana-program/address-lookup-table) | `js@v0.11.0` | `solana_kit_address_lookup_table` (#134) |
-| `.repos/solana-program/memo` | [solana-program/memo](https://github.com/solana-program/memo) | `js@v0.11.0` | `solana_kit_memo` (#135) |
-| `.repos/solana-program/compute-budget` | [solana-program/compute-budget](https://github.com/solana-program/compute-budget) | `js@v0.15.0` | `solana_kit_compute_budget` (#133) |
-| `.repos/solana-program/stake` | [solana-program/stake](https://github.com/solana-program/stake) | `js@v0.6.0` | `solana_kit_stake` (#136) |
-| `.repos/solana-program/config` | [solana-program/config](https://github.com/solana-program/config) | `solana-config-program-client@v1.1.0` | `solana_kit_config` (#137) |
-| `.repos/solana-program/loader-v3` | [solana-program/loader-v3](https://github.com/solana-program/loader-v3) | `js@v0.3.0` | `solana_kit_loader` (#138) |
-| `.repos/solana-program/loader-v4` | [solana-program/loader-v4](https://github.com/solana-program/loader-v4) | commit `5df834d` (2026-03-08, no tag yet) | `solana_kit_loader` (#138) |
+| Path                                             | Repo                                                                                                  | Pinned version                            | Used by                                                                                |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------- |
+| `.repos/solana-program/system`                   | [solana-program/system](https://github.com/solana-program/system)                                     | `js@v0.12.0`                              | `solana_kit_system` (#131)                                                             |
+| `.repos/solana-program/token`                    | [solana-program/token](https://github.com/solana-program/token)                                       | `js@v0.13.0`                              | `solana_kit_token`                                                                     |
+| `.repos/solana-program/token-2022`               | [solana-program/token-2022](https://github.com/solana-program/token-2022)                             | `js@v0.9.0`                               | `solana_kit_token_2022`                                                                |
+| `.repos/solana-program/associated-token-account` | [solana-program/associated-token-account](https://github.com/solana-program/associated-token-account) | `program@v8.0.0`                          | `solana_kit_associated_token_account` (#132) — handwritten, use as interface reference |
+| `.repos/solana-program/address-lookup-table`     | [solana-program/address-lookup-table](https://github.com/solana-program/address-lookup-table)         | `js@v0.11.0`                              | `solana_kit_address_lookup_table` (#134)                                               |
+| `.repos/solana-program/memo`                     | [solana-program/memo](https://github.com/solana-program/memo)                                         | `js@v0.11.0`                              | `solana_kit_memo` (#135)                                                               |
+| `.repos/solana-program/compute-budget`           | [solana-program/compute-budget](https://github.com/solana-program/compute-budget)                     | `js@v0.15.0`                              | `solana_kit_compute_budget` (#133)                                                     |
+| `.repos/solana-program/stake`                    | [solana-program/stake](https://github.com/solana-program/stake)                                       | `js@v0.6.0`                               | `solana_kit_stake` (#136)                                                              |
+| `.repos/solana-program/config`                   | [solana-program/config](https://github.com/solana-program/config)                                     | `solana-config-program-client@v1.1.0`     | `solana_kit_config` (#137)                                                             |
+| `.repos/solana-program/loader-v3`                | [solana-program/loader-v3](https://github.com/solana-program/loader-v3)                               | `js@v0.3.0`                               | `solana_kit_loader` (#138)                                                             |
+| `.repos/solana-program/loader-v4`                | [solana-program/loader-v4](https://github.com/solana-program/loader-v4)                               | commit `5df834d` (2026-03-08, no tag yet) | `solana_kit_loader` (#138)                                                             |
 
 ## Updating a pinned version
 

--- a/docs/agents/reference-repos.md
+++ b/docs/agents/reference-repos.md
@@ -8,6 +8,37 @@ clone:repos
 
 They are stored under `.repos/`.
 
+## Core SDK references
+
 - `.repos/kit` — upstream TypeScript source from `anza-xyz/kit`
 - `.repos/espresso-cash-public` — Dart Solana reference from `brij-digital/espresso-cash-public`
 - `.repos/mobile-wallet-adapter` — Solana Mobile Wallet Adapter reference from `solana-mobile/mobile-wallet-adapter`
+
+## solana-program/* references
+
+Each program repo is pinned to a specific tag or commit. When a new version
+ships upstream, update the pin in `devenv.nix` under `clone:repos`, run
+`clone:repos`, regenerate the affected package with `codama-renderers-dart`,
+bump the package version, and add a changeset.
+
+| Path | Repo | Pinned version | Used by |
+|------|------|---------------|---------|
+| `.repos/solana-program/system` | [solana-program/system](https://github.com/solana-program/system) | `js@v0.12.0` | `solana_kit_system` (#131) |
+| `.repos/solana-program/token` | [solana-program/token](https://github.com/solana-program/token) | `js@v0.13.0` | `solana_kit_token` |
+| `.repos/solana-program/token-2022` | [solana-program/token-2022](https://github.com/solana-program/token-2022) | `js@v0.9.0` | `solana_kit_token_2022` |
+| `.repos/solana-program/associated-token-account` | [solana-program/associated-token-account](https://github.com/solana-program/associated-token-account) | `program@v8.0.0` | `solana_kit_associated_token_account` (#132) — handwritten, use as interface reference |
+| `.repos/solana-program/address-lookup-table` | [solana-program/address-lookup-table](https://github.com/solana-program/address-lookup-table) | `js@v0.11.0` | `solana_kit_address_lookup_table` (#134) |
+| `.repos/solana-program/memo` | [solana-program/memo](https://github.com/solana-program/memo) | `js@v0.11.0` | `solana_kit_memo` (#135) |
+| `.repos/solana-program/compute-budget` | [solana-program/compute-budget](https://github.com/solana-program/compute-budget) | `js@v0.15.0` | `solana_kit_compute_budget` (#133) |
+| `.repos/solana-program/stake` | [solana-program/stake](https://github.com/solana-program/stake) | `js@v0.6.0` | `solana_kit_stake` (#136) |
+| `.repos/solana-program/config` | [solana-program/config](https://github.com/solana-program/config) | `solana-config-program-client@v1.1.0` | `solana_kit_config` (#137) |
+| `.repos/solana-program/loader-v3` | [solana-program/loader-v3](https://github.com/solana-program/loader-v3) | `js@v0.3.0` | `solana_kit_loader` (#138) |
+| `.repos/solana-program/loader-v4` | [solana-program/loader-v4](https://github.com/solana-program/loader-v4) | commit `5df834d` (2026-03-08, no tag yet) | `solana_kit_loader` (#138) |
+
+## Updating a pinned version
+
+1. Find the new tag on the upstream repo (e.g. `js@v0.14.0`).
+2. Update the tag string in `devenv.nix` under `clone:repos`.
+3. Run `clone:repos` to fetch the new version.
+4. Re-run the Codama generator for the affected Dart package.
+5. Review the generated diff, update the package, bump version, add a changeset.

--- a/packages/solana_kit_rpc_api/test/get_block_production_test.dart
+++ b/packages/solana_kit_rpc_api/test/get_block_production_test.dart
@@ -15,8 +15,10 @@ void main() {
     });
 
     test('toJson includes both slots when lastSlot provided', () {
-      final range =
-          SlotRange(firstSlot: BigInt.from(10), lastSlot: BigInt.from(20));
+      final range = SlotRange(
+        firstSlot: BigInt.from(10),
+        lastSlot: BigInt.from(20),
+      );
       final json = range.toJson();
       expect(json, hasLength(2));
       expect(json['firstSlot'], BigInt.from(10));
@@ -31,8 +33,7 @@ void main() {
     });
 
     test('toJson includes commitment when set', () {
-      const config =
-          GetBlockProductionConfig(commitment: Commitment.finalized);
+      const config = GetBlockProductionConfig(commitment: Commitment.finalized);
       final json = config.toJson();
       expect(json['commitment'], 'finalized');
     });
@@ -48,7 +49,10 @@ void main() {
         range: SlotRange(firstSlot: BigInt.from(5), lastSlot: BigInt.from(10)),
       );
       final json = config.toJson();
-      expect(json['range'], {'firstSlot': BigInt.from(5), 'lastSlot': BigInt.from(10)});
+      expect(json['range'], {
+        'firstSlot': BigInt.from(5),
+        'lastSlot': BigInt.from(10),
+      });
     });
 
     test('toJson includes all fields when all set', () {
@@ -62,6 +66,44 @@ void main() {
       expect(json['commitment'], 'confirmed');
       expect(json['identity'], '11111111111111111111111111111111');
       expect(json['range'], {'firstSlot': BigInt.from(1)});
+    });
+  });
+
+  group('equality and toString', () {
+    test('SlotRange supports equality, hashCode, and toString', () {
+      final a = SlotRange(
+        firstSlot: BigInt.from(10),
+        lastSlot: BigInt.from(20),
+      );
+      final b = SlotRange(
+        firstSlot: BigInt.from(10),
+        lastSlot: BigInt.from(20),
+      );
+      final c = SlotRange(firstSlot: BigInt.from(10));
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+      expect(a.toString(), contains('lastSlot: 20'));
+    });
+
+    test('GetBlockProductionConfig supports equality and toString', () {
+      final a = GetBlockProductionConfig(
+        commitment: Commitment.confirmed,
+        identity: testAddress,
+        range: SlotRange(firstSlot: BigInt.from(1)),
+      );
+      final b = GetBlockProductionConfig(
+        commitment: Commitment.confirmed,
+        identity: testAddress,
+        range: SlotRange(firstSlot: BigInt.from(1)),
+      );
+      const c = GetBlockProductionConfig(identity: testAddress);
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+      expect(a.toString(), contains('identity: $testAddress'));
     });
   });
 

--- a/packages/solana_kit_rpc_api/test/get_epoch_info_test.dart
+++ b/packages/solana_kit_rpc_api/test/get_epoch_info_test.dart
@@ -35,6 +35,58 @@ void main() {
     });
   });
 
+  group('GetEpochInfoConfig equality', () {
+    test('supports equality, hashCode, and toString', () {
+      final a = GetEpochInfoConfig(
+        commitment: Commitment.finalized,
+        minContextSlot: BigInt.from(12),
+      );
+      final b = GetEpochInfoConfig(
+        commitment: Commitment.finalized,
+        minContextSlot: BigInt.from(12),
+      );
+      final c = GetEpochInfoConfig(minContextSlot: BigInt.from(13));
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+      expect(a.toString(), contains('minContextSlot: 12'));
+    });
+  });
+
+  group('EpochInfo', () {
+    test('supports equality, hashCode, and toString', () {
+      final a = EpochInfo(
+        absoluteSlot: BigInt.one,
+        blockHeight: BigInt.from(2),
+        epoch: BigInt.from(3),
+        slotIndex: BigInt.from(4),
+        slotsInEpoch: BigInt.from(5),
+        transactionCount: BigInt.from(6),
+      );
+      final b = EpochInfo(
+        absoluteSlot: BigInt.one,
+        blockHeight: BigInt.from(2),
+        epoch: BigInt.from(3),
+        slotIndex: BigInt.from(4),
+        slotsInEpoch: BigInt.from(5),
+        transactionCount: BigInt.from(6),
+      );
+      final c = EpochInfo(
+        absoluteSlot: BigInt.one,
+        blockHeight: BigInt.from(2),
+        epoch: BigInt.from(3),
+        slotIndex: BigInt.from(4),
+        slotsInEpoch: BigInt.from(5),
+      );
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+      expect(a.toString(), contains('transactionCount: 6'));
+    });
+  });
+
   group('getEpochInfoParams', () {
     test('returns empty list when no config', () {
       final params = getEpochInfoParams();

--- a/packages/solana_kit_rpc_api/test/get_token_accounts_by_delegate_test.dart
+++ b/packages/solana_kit_rpc_api/test/get_token_accounts_by_delegate_test.dart
@@ -33,6 +33,24 @@ void main() {
     expect(filter.toJson(), {'programId': mint.value});
   });
 
+  test('config includes minContextSlot when set', () {
+    final config = GetTokenAccountsByDelegateConfig(
+      minContextSlot: BigInt.from(99),
+    );
+    expect(config.toJson(), {'minContextSlot': BigInt.from(99)});
+  });
+
+  test('filters support equality, hashCode, and toString', () {
+    const mintFilterA = TokenAccountMintFilter(mint: mint);
+    const mintFilterB = TokenAccountMintFilter(mint: mint);
+    const programFilter = TokenAccountProgramIdFilter(programId: mint);
+
+    expect(mintFilterA, mintFilterB);
+    expect(mintFilterA.hashCode, mintFilterB.hashCode);
+    expect(mintFilterA.toString(), contains('mint: $mint'));
+    expect(programFilter.toString(), contains('programId: $mint'));
+  });
+
   test('params serialize delegate, filter, and config', () {
     final params = getTokenAccountsByDelegateParams(
       delegate,

--- a/packages/solana_kit_rpc_api/test/get_vote_accounts_test.dart
+++ b/packages/solana_kit_rpc_api/test/get_vote_accounts_test.dart
@@ -19,8 +19,9 @@ void main() {
     });
 
     test('toJson includes delinquentSlotDistance when set', () {
-      final config =
-          GetVoteAccountsConfig(delinquentSlotDistance: BigInt.from(3));
+      final config = GetVoteAccountsConfig(
+        delinquentSlotDistance: BigInt.from(3),
+      );
       final json = config.toJson();
       expect(json['delinquentSlotDistance'], BigInt.from(3));
     });
@@ -50,6 +51,29 @@ void main() {
       expect(json['delinquentSlotDistance'], BigInt.from(5));
       expect(json['keepUnstakedDelinquents'], false);
       expect(json['votePubkey'], '11111111111111111111111111111111');
+    });
+  });
+
+  group('GetVoteAccountsConfig equality', () {
+    test('supports equality, hashCode, and toString', () {
+      final a = GetVoteAccountsConfig(
+        commitment: Commitment.finalized,
+        delinquentSlotDistance: BigInt.from(5),
+        keepUnstakedDelinquents: true,
+        votePubkey: testAddress,
+      );
+      final b = GetVoteAccountsConfig(
+        commitment: Commitment.finalized,
+        delinquentSlotDistance: BigInt.from(5),
+        keepUnstakedDelinquents: true,
+        votePubkey: testAddress,
+      );
+      const c = GetVoteAccountsConfig(votePubkey: testAddress);
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+      expect(a.toString(), contains('votePubkey: $testAddress'));
     });
   });
 

--- a/packages/solana_kit_rpc_api/test/simulate_transaction_test.dart
+++ b/packages/solana_kit_rpc_api/test/simulate_transaction_test.dart
@@ -1,0 +1,105 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_api/solana_kit_rpc_api.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const owner = Address('11111111111111111111111111111111');
+  const mint = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+  group('SimulateTransactionAccountsConfig', () {
+    test('serializes addresses and optional encoding', () {
+      const config = SimulateTransactionAccountsConfig(
+        addresses: [owner, mint],
+        encoding: AccountEncoding.base64,
+      );
+
+      expect(config.toJson(), {
+        'addresses': [owner.value, mint.value],
+        'encoding': 'base64',
+      });
+    });
+
+    test('supports equality, hashCode, and toString', () {
+      const a = SimulateTransactionAccountsConfig(addresses: [owner, mint]);
+      const b = SimulateTransactionAccountsConfig(addresses: [owner, mint]);
+      const c = SimulateTransactionAccountsConfig(addresses: [owner]);
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+      expect(a.toString(), contains(owner.value));
+    });
+  });
+
+  group('SimulateTransactionConfig', () {
+    test('serializes all populated fields', () {
+      final config = SimulateTransactionConfig(
+        accounts: const SimulateTransactionAccountsConfig(
+          addresses: [owner],
+          encoding: AccountEncoding.base64,
+        ),
+        commitment: Commitment.processed,
+        encoding: WireTransactionEncoding.base64,
+        innerInstructions: true,
+        minContextSlot: BigInt.from(12),
+        replaceRecentBlockhash: false,
+        sigVerify: true,
+      );
+
+      expect(config.toJson(), {
+        'accounts': {
+          'addresses': [owner.value],
+          'encoding': 'base64',
+        },
+        'commitment': 'processed',
+        'encoding': 'base64',
+        'innerInstructions': true,
+        'minContextSlot': BigInt.from(12),
+        'replaceRecentBlockhash': false,
+        'sigVerify': true,
+      });
+    });
+
+    test('supports equality, hashCode, and toString', () {
+      const accounts = SimulateTransactionAccountsConfig(addresses: [owner]);
+      const a = SimulateTransactionConfig(
+        accounts: accounts,
+        commitment: Commitment.confirmed,
+        innerInstructions: true,
+      );
+      const b = SimulateTransactionConfig(
+        accounts: accounts,
+        commitment: Commitment.confirmed,
+        innerInstructions: true,
+      );
+      const c = SimulateTransactionConfig(accounts: accounts);
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+      expect(a.toString(), contains('innerInstructions: true'));
+    });
+  });
+
+  group('simulateTransactionParams', () {
+    test('serializes encoded transaction only when config omitted', () {
+      expect(simulateTransactionParams('abc123'), ['abc123']);
+    });
+
+    test('serializes encoded transaction and config', () {
+      final params = simulateTransactionParams(
+        'abc123',
+        const SimulateTransactionConfig(
+          commitment: Commitment.finalized,
+          replaceRecentBlockhash: true,
+        ),
+      );
+
+      expect(params, [
+        'abc123',
+        {'commitment': 'finalized', 'replaceRecentBlockhash': true},
+      ]);
+    });
+  });
+}

--- a/packages/solana_kit_rpc_parsed_types/test/equality_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/equality_test.dart
@@ -2,7 +2,12 @@ import 'package:meta/meta.dart';
 import 'package:solana_kit_addresses/solana_kit_addresses.dart';
 import 'package:solana_kit_rpc_parsed_types/solana_kit_rpc_parsed_types.dart';
 import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart'
-    show Blockhash, StringifiedBigInt, UnixTimestamp;
+    show
+        Blockhash,
+        StringifiedBigInt,
+        StringifiedNumber,
+        TokenAmount,
+        UnixTimestamp;
 import 'package:test/test.dart';
 
 // ---------------------------------------------------------------------------
@@ -275,10 +280,16 @@ void main() {
 
     test('deep equality flows up through JsonParsedStakeConfig', () {
       const a = JsonParsedStakeConfig(
-        info: JsonParsedStakeConfigInfo(slashPenalty: 12, warmupCooldownRate: 0.25),
+        info: JsonParsedStakeConfigInfo(
+          slashPenalty: 12,
+          warmupCooldownRate: 0.25,
+        ),
       );
       const b = JsonParsedStakeConfig(
-        info: JsonParsedStakeConfigInfo(slashPenalty: 12, warmupCooldownRate: 0.25),
+        info: JsonParsedStakeConfigInfo(
+          slashPenalty: 12,
+          warmupCooldownRate: 0.25,
+        ),
       );
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
@@ -480,14 +491,8 @@ void main() {
 
   group('JsonParsedVote equality', () {
     test('equal when all fields match', () {
-      final a = JsonParsedVote(
-        confirmationCount: 32,
-        slot: BigInt.zero,
-      );
-      final b = JsonParsedVote(
-        confirmationCount: 32,
-        slot: BigInt.zero,
-      );
+      final a = JsonParsedVote(confirmationCount: 32, slot: BigInt.zero);
+      final b = JsonParsedVote(confirmationCount: 32, slot: BigInt.zero);
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
     });
@@ -829,6 +834,128 @@ void main() {
       );
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('low-coverage parsed account branches', () {
+    test(
+      'stake account wrappers include nested values in equality and toString',
+      () {
+        const authorized = JsonParsedStakeAuthorized(
+          staker: _addr1,
+          withdrawer: _addr2,
+        );
+        final lockup = JsonParsedStakeLockup(
+          custodian: _addr1,
+          epoch: BigInt.one,
+          unixTimestamp: UnixTimestamp(BigInt.from(2)),
+        );
+        const delegation = JsonParsedStakeDelegation(
+          activationEpoch: StringifiedBigInt('1'),
+          deactivationEpoch: StringifiedBigInt('2'),
+          stake: StringifiedBigInt('3'),
+          voter: _addr1,
+          warmupCooldownRate: 0.5,
+        );
+        final account = JsonParsedStakeAccountInfo(
+          meta: JsonParsedStakeMeta(
+            authorized: authorized,
+            lockup: lockup,
+            rentExemptReserve: const StringifiedBigInt('4'),
+          ),
+          stake: JsonParsedStakeData(
+            creditsObserved: BigInt.from(5),
+            delegation: delegation,
+          ),
+        );
+
+        expect(
+          JsonParsedDelegatedStake(info: account),
+          JsonParsedDelegatedStake(info: account),
+        );
+        expect(account.toString(), contains('rentExemptReserve: 4'));
+        expect(authorized.toString(), contains('withdrawer'));
+        expect(lockup.toString(), contains('custodian'));
+      },
+    );
+
+    test(
+      'token account list equality handles nulls and differing elements',
+      () {
+        const tokenAmount = TokenAmount(
+          amount: StringifiedBigInt('1'),
+          decimals: 6,
+          uiAmountString: StringifiedNumber('0.000001'),
+        );
+        const a = JsonParsedTokenAccount(
+          isNative: false,
+          mint: _addr1,
+          owner: _addr2,
+          state: TokenAccountState.initialized,
+          tokenAmount: tokenAmount,
+          extensions: ['memo'],
+        );
+        const b = JsonParsedTokenAccount(
+          isNative: false,
+          mint: _addr1,
+          owner: _addr2,
+          state: TokenAccountState.initialized,
+          tokenAmount: tokenAmount,
+          extensions: ['memo'],
+        );
+        const c = JsonParsedTokenAccount(
+          isNative: false,
+          mint: _addr1,
+          owner: _addr2,
+          state: TokenAccountState.initialized,
+          tokenAmount: tokenAmount,
+        );
+        const d = JsonParsedMintInfo(
+          decimals: 6,
+          isInitialized: true,
+          supply: StringifiedBigInt('9'),
+          extensions: ['memo'],
+        );
+
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+        expect(a, isNot(c));
+        expect(a.toString(), contains('extensions: [memo]'));
+        expect(d.toString(), contains('extensions: [memo]'));
+        expect(
+          const JsonParsedTokenAccountVariant(info: a),
+          const JsonParsedTokenAccountVariant(info: a),
+        );
+      },
+    );
+
+    test('sysvar parsed models preserve list-like value semantics', () {
+      const recentBlockhash = JsonParsedRecentBlockhashEntry(
+        blockhash: Blockhash('hash'),
+        feeCalculator: JsonParsedFeeCalculator(
+          lamportsPerSignature: StringifiedBigInt('5000'),
+        ),
+      );
+      final stakeHistory = JsonParsedStakeHistoryEntry(
+        epoch: BigInt.zero,
+        stakeHistory: JsonParsedStakeHistoryData(
+          activating: BigInt.one,
+          deactivating: BigInt.from(2),
+          effective: BigInt.from(3),
+        ),
+      );
+      final a = JsonParsedSlotHistoryInfo(bits: '1010', nextSlot: BigInt.one);
+      final b = JsonParsedSlotHistoryInfo(bits: '1010', nextSlot: BigInt.one);
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a.toString(), contains('nextSlot: 1'));
+      expect(recentBlockhash.toString(), contains('hash'));
+      expect(stakeHistory.toString(), contains('effective: 3'));
+      expect(
+        const JsonParsedRecentBlockhashesSysvar(info: [recentBlockhash]),
+        const JsonParsedRecentBlockhashesSysvar(info: [recentBlockhash]),
+      );
     });
   });
 }

--- a/packages/solana_kit_rpc_parsed_types/test/stake_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/stake_accounts_test.dart
@@ -95,5 +95,18 @@ void main() {
           fail('Expected initialized, got delegated');
       }
     });
+
+    test('stake account models expose readable toString output', () {
+      final stakeInfo = createStakeInfo();
+      expect(stakeInfo.toString(), contains('rentExemptReserve'));
+      expect(stakeInfo.meta.toString(), contains('authorized'));
+      expect(stakeInfo.meta.authorized.toString(), contains('staker'));
+      expect(stakeInfo.meta.lockup.toString(), contains('custodian'));
+      expect(stakeInfo.stake.toString(), contains('creditsObserved'));
+      expect(
+        stakeInfo.stake!.delegation.toString(),
+        contains('warmupCooldownRate: 0.25'),
+      );
+    });
   });
 }

--- a/packages/solana_kit_rpc_parsed_types/test/sysvar_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/sysvar_accounts_test.dart
@@ -224,5 +224,37 @@ void main() {
           fail('Expected clock sysvar');
       }
     });
+
+    test('sysvar models expose readable toString output', () {
+      final clock = JsonParsedClockInfo(
+        epoch: BigInt.zero,
+        epochStartTimestamp: UnixTimestamp(BigInt.from(1704907181)),
+        leaderScheduleEpoch: BigInt.one,
+        slot: BigInt.from(90829),
+        unixTimestamp: UnixTimestamp(BigInt.from(1704998009)),
+      );
+      const fees = JsonParsedFeesInfo(
+        feeCalculator: JsonParsedFeeCalculator(
+          lamportsPerSignature: StringifiedBigInt('5000'),
+        ),
+      );
+      final slotHistory = JsonParsedSlotHistoryInfo(
+        bits: '1111100000',
+        nextSlot: BigInt.from(150104),
+      );
+      final stakeHistory = JsonParsedStakeHistoryEntry(
+        epoch: BigInt.from(683),
+        stakeHistory: JsonParsedStakeHistoryData(
+          activating: BigInt.zero,
+          deactivating: BigInt.zero,
+          effective: BigInt.from(6561315032320),
+        ),
+      );
+
+      expect(clock.toString(), contains('leaderScheduleEpoch'));
+      expect(fees.toString(), contains('lamportsPerSignature: 5000'));
+      expect(slotHistory.toString(), contains('nextSlot: 150104'));
+      expect(stakeHistory.toString(), contains('effective: 6561315032320'));
+    });
   });
 }

--- a/packages/solana_kit_rpc_parsed_types/test/token_accounts_test.dart
+++ b/packages/solana_kit_rpc_parsed_types/test/token_accounts_test.dart
@@ -99,5 +99,39 @@ void main() {
           fail('Expected mint, got multisig');
       }
     });
+
+    test('token account models expose readable toString output', () {
+      const tokenAccount = JsonParsedTokenAccount(
+        isNative: false,
+        mint: Address('Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr'),
+        owner: Address('6UsGbaMgchgj4wiwKKuE1v5URHdcDfEiMSM25QpesKir'),
+        state: TokenAccountState.initialized,
+        tokenAmount: TokenAmount(
+          amount: StringifiedBigInt('9999999779500000'),
+          decimals: 6,
+          uiAmountString: StringifiedNumber('9999999779.5'),
+        ),
+        extensions: ['memo-transfer'],
+      );
+      const mintInfo = JsonParsedMintInfo(
+        decimals: 6,
+        isInitialized: true,
+        supply: StringifiedBigInt('1792635195340523528'),
+        extensions: ['transfer-fee'],
+      );
+      const multisigInfo = JsonParsedMultisigInfo(
+        isInitialized: true,
+        numRequiredSigners: 2,
+        numValidSigners: 2,
+        signers: [
+          Address('Fkc4FN7PPhyGsAcHPW3dBBJ4BvtYkDr2rBFBgFpvy3nB'),
+          Address('5scSndUhfZJ8j8wZz5UNHhvuPBhvN1RboTdkKSvFHLtW'),
+        ],
+      );
+
+      expect(tokenAccount.toString(), contains('extensions: [memo-transfer]'));
+      expect(mintInfo.toString(), contains('extensions: [transfer-fee]'));
+      expect(multisigInfo.toString(), contains('numRequiredSigners: 2'));
+    });
   });
 }

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/test/websocket_channel_test.dart
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/test/websocket_channel_test.dart
@@ -59,9 +59,7 @@ void main() {
 
   group('WebSocketChannelConfig', () {
     test('disallows insecure ws:// URLs by default', () {
-      final config = WebSocketChannelConfig(
-        url: Uri.parse('ws://example.com'),
-      );
+      final config = WebSocketChannelConfig(url: Uri.parse('ws://example.com'));
       expect(config.allowInsecureWs, isFalse);
     });
 
@@ -133,10 +131,57 @@ void main() {
       );
     });
 
+    test(
+      'uses a SolanaError when already aborted with a non-error reason',
+      () async {
+        final controller = AbortController()..abort('cancelled');
+        await expectLater(
+          createWebSocketChannel(
+            WebSocketChannelConfig(
+              url: Uri.parse('ws://localhost:0'),
+              allowInsecureWs: true,
+              signal: controller.signal,
+            ),
+          ),
+          throwsA(
+            isA<SolanaError>().having(
+              (e) => e.code,
+              'code',
+              SolanaErrorCode.rpcSubscriptionsChannelConnectionClosed,
+            ),
+          ),
+        );
+      },
+    );
+
     test('rejects insecure ws:// URLs by default', () async {
       await expectLater(
         createWebSocketChannel(
           WebSocketChannelConfig(url: Uri.parse('ws://localhost:1')),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects non-websocket schemes', () async {
+      await expectLater(
+        createWebSocketChannel(
+          WebSocketChannelConfig(
+            url: Uri.parse('https://example.com/socket'),
+            allowInsecureWs: true,
+          ),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects relative websocket URLs', () async {
+      await expectLater(
+        createWebSocketChannel(
+          WebSocketChannelConfig(
+            url: Uri.parse('/socket'),
+            allowInsecureWs: true,
+          ),
         ),
         throwsArgumentError,
       );

--- a/packages/solana_kit_rpc_types/test/equality_test.dart
+++ b/packages/solana_kit_rpc_types/test/equality_test.dart
@@ -253,6 +253,40 @@ void main() {
       );
       expect(base64, isNot(equals(parsed)));
     });
+
+    test('wrappers and deprecated aliases preserve equality and toString', () {
+      const base58BytesA = AccountInfoWithBase58Bytes(
+        data: Base58EncodedBytes('1111111111'),
+      );
+      const base58BytesB = AccountInfoWithBase58Bytes(
+        data: Base58EncodedBytes('1111111111'),
+      );
+      const base58Encoded = AccountInfoWithBase58EncodedData(
+        data: (Base58EncodedBytes('1111111111'), 'base58'),
+      );
+      const base64Encoded = AccountInfoWithBase64EncodedData(data: data);
+      const zstd = AccountInfoWithBase64EncodedZStdCompressedData(
+        data: (
+          Base64EncodedZStdCompressedBytes('AQIDBA=='),
+          'base64+zstd',
+        ),
+      );
+      const wrappedA = AccountInfoWithJsonData(
+        data: AccountInfoJsonDataBase64(data: data),
+      );
+      const wrappedB = AccountInfoWithJsonData(
+        data: AccountInfoJsonDataBase64(data: data),
+      );
+
+      expect(base58BytesA, base58BytesB);
+      expect(base58BytesA.hashCode, base58BytesB.hashCode);
+      expect(wrappedA, wrappedB);
+      expect(wrappedA.hashCode, wrappedB.hashCode);
+      expect(base58Encoded.toString(), contains('base58'));
+      expect(base64Encoded.toString(), contains('base64'));
+      expect(zstd.toString(), contains('base64+zstd'));
+      expect(wrappedA.toString(), contains('AccountInfoWithJsonData'));
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/solana_kit_rpc_types/test/model_types_test.dart
+++ b/packages/solana_kit_rpc_types/test/model_types_test.dart
@@ -85,18 +85,12 @@ void main() {
         data: (Base64EncodedBytes('AQID'), 'base64'),
       );
       const zstd = AccountInfoWithBase64EncodedZStdCompressedData(
-        data: (
-          Base64EncodedZStdCompressedBytes('AQIDBA=='),
-          'base64+zstd',
-        ),
+        data: (Base64EncodedZStdCompressedBytes('AQIDBA=='), 'base64+zstd'),
       );
 
       expect(base64.data.$1, const Base64EncodedBytes('AQID'));
       expect(base64.data.$2, 'base64');
-      expect(
-        zstd.data.$1,
-        const Base64EncodedZStdCompressedBytes('AQIDBA=='),
-      );
+      expect(zstd.data.$1, const Base64EncodedZStdCompressedBytes('AQIDBA=='));
       expect(zstd.data.$2, 'base64+zstd');
     });
 
@@ -136,6 +130,88 @@ void main() {
 
       expect(wrapper.account, base);
       expect(wrapper.pubkey, _addressB);
+    });
+  });
+
+  group('Value object coverage', () {
+    test('LatestBlockhashValue supports equality, hashCode, and toString', () {
+      final a = LatestBlockhashValue(
+        blockhash: const Blockhash('abc'),
+        lastValidBlockHeight: BigInt.from(42),
+      );
+      final b = LatestBlockhashValue(
+        blockhash: const Blockhash('abc'),
+        lastValidBlockHeight: BigInt.from(42),
+      );
+      final c = LatestBlockhashValue(
+        blockhash: const Blockhash('def'),
+        lastValidBlockHeight: BigInt.from(42),
+      );
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+      expect(a.toString(), contains('lastValidBlockHeight: 42'));
+    });
+
+    test(
+      'ParsedAccountData equality handles null and differing map values',
+      () {
+        final a = ParsedAccountData(
+          type: 'mint',
+          program: 'spl-token',
+          space: BigInt.from(82),
+          info: {'decimals': 9},
+        );
+        final b = ParsedAccountData(
+          type: 'mint',
+          program: 'spl-token',
+          space: BigInt.from(82),
+          info: {'decimals': 9},
+        );
+        final c = ParsedAccountData(
+          type: 'mint',
+          program: 'spl-token',
+          space: BigInt.from(82),
+        );
+        final d = ParsedAccountData(
+          type: 'mint',
+          program: 'spl-token',
+          space: BigInt.from(82),
+          info: {'decimals': 8},
+        );
+
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+        expect(a, isNot(c));
+        expect(a, isNot(d));
+        expect(a.toString(), contains('spl-token'));
+      },
+    );
+
+    test('account info wrappers support equality and toString', () {
+      const base58BytesA = AccountInfoWithBase58Bytes(
+        data: Base58EncodedBytes('1111111111'),
+      );
+      const base58BytesB = AccountInfoWithBase58Bytes(
+        data: Base58EncodedBytes('1111111111'),
+      );
+      const base58Encoded = AccountInfoWithBase58EncodedData(
+        data: (Base58EncodedBytes('1111111111'), 'base58'),
+      );
+      const base64Encoded = AccountInfoWithBase64EncodedData(
+        data: (Base64EncodedBytes('AQID'), 'base64'),
+      );
+      const base64Zstd = AccountInfoWithBase64EncodedZStdCompressedData(
+        data: (Base64EncodedZStdCompressedBytes('AQIDBA=='), 'base64+zstd'),
+      );
+
+      expect(base58BytesA, base58BytesB);
+      expect(base58BytesA.hashCode, base58BytesB.hashCode);
+      expect(base58BytesA.toString(), contains('Base58'));
+      expect(base58Encoded.toString(), contains('base58'));
+      expect(base64Encoded.toString(), contains('base64'));
+      expect(base64Zstd.toString(), contains('base64+zstd'));
     });
   });
 

--- a/packages/solana_kit_sysvars/test/slot_history_test.dart
+++ b/packages/solana_kit_sysvars/test/slot_history_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
 import 'package:solana_kit_sysvars/solana_kit_sysvars.dart';
 import 'package:test/test.dart';
 
@@ -78,6 +79,55 @@ void main() {
       final b = SysvarSlotHistory(bits: bits2, nextSlot: BigInt.from(100));
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
+      expect(a.toString(), contains('nextSlot: 100'));
+    });
+
+    test('decoder rejects invalid byte length', () {
+      final bytes = Uint8List(sysvarSlotHistorySize - 1);
+      expect(
+        () => getSysvarSlotHistoryDecoder().decode(bytes),
+        throwsA(
+          isA<SolanaError>().having(
+            (error) => error.code,
+            'code',
+            SolanaErrorCode.codecsInvalidByteLength,
+          ),
+        ),
+      );
+    });
+
+    test('decoder rejects invalid discriminator', () {
+      final bytes = Uint8List(sysvarSlotHistorySize)
+        ..[0] = 9
+        ..setAll(1, [0, 64, 0, 0, 0, 0, 0, 0])
+        ..setAll(1 + 8 + bitvecLength * 8, [0, 0, 16, 0, 0, 0, 0, 0]);
+      expect(
+        () => getSysvarSlotHistoryDecoder().decode(bytes),
+        throwsA(
+          isA<SolanaError>().having(
+            (error) => error.code,
+            'code',
+            SolanaErrorCode.codecsEnumDiscriminatorOutOfRange,
+          ),
+        ),
+      );
+    });
+
+    test('decoder rejects unexpected bit-vector metadata', () {
+      final bytes = Uint8List(sysvarSlotHistorySize)
+        ..[0] = bitvecDiscriminator
+        ..setAll(1, List<int>.filled(8, 0))
+        ..setAll(1 + 8 + bitvecLength * 8, [0, 0, 16, 0, 0, 0, 0, 0]);
+      expect(
+        () => getSysvarSlotHistoryDecoder().decode(bytes),
+        throwsA(
+          isA<SolanaError>().having(
+            (error) => error.code,
+            'code',
+            SolanaErrorCode.codecsInvalidNumberOfItems,
+          ),
+        ),
+      );
     });
   });
 }

--- a/packages/solana_kit_token/test/instruction_builder_test.dart
+++ b/packages/solana_kit_token/test/instruction_builder_test.dart
@@ -4,6 +4,7 @@
 import 'package:solana_kit_addresses/solana_kit_addresses.dart';
 import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
 import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_system/solana_kit_system.dart';
 import 'package:solana_kit_token/solana_kit_token.dart';
 import 'package:test/test.dart';
 
@@ -97,8 +98,7 @@ void main() {
       final seq = plan as SequentialInstructionPlan;
       expect(seq.plans, hasLength(2));
 
-      final createIx =
-          (seq.plans[0] as SingleInstructionPlan).instruction;
+      final createIx = (seq.plans[0] as SingleInstructionPlan).instruction;
       expect(
         createIx.programAddress,
         Address('11111111111111111111111111111111'),
@@ -107,6 +107,43 @@ void main() {
       final initIx = (seq.plans[1] as SingleInstructionPlan).instruction;
       expect(initIx.programAddress, tokenProgramAddress);
     });
+
+    test(
+      'supports freeze authority, custom lamports, and program overrides',
+      () {
+        const customSystemProgram = Address('11111111111111111111111111111114');
+        const customTokenProgram = Address('11111111111111111111111111111115');
+
+        final plan =
+            getCreateMintInstructionPlan(
+                  CreateMintInput(
+                    payer: owner,
+                    newMint: mint,
+                    decimals: 9,
+                    mintAuthority: authority,
+                    freezeAuthority: destination,
+                    mintAccountLamports: BigInt.from(99),
+                  ),
+                  const CreateMintConfig(
+                    tokenProgram: customTokenProgram,
+                    systemProgram: customSystemProgram,
+                  ),
+                )
+                as SequentialInstructionPlan;
+
+        final createIx = (plan.plans[0] as SingleInstructionPlan).instruction;
+        final parsedCreate = parseCreateAccountInstruction(createIx);
+        expect(createIx.programAddress, customSystemProgram);
+        expect(parsedCreate.lamports, BigInt.from(99));
+        expect(parsedCreate.programOwner, customTokenProgram);
+
+        final initIx = (plan.plans[1] as SingleInstructionPlan).instruction;
+        final parsedInit = parseInitializeMint2Instruction(initIx);
+        expect(initIx.programAddress, customTokenProgram);
+        expect(parsedInit.freezeAuthority, destination);
+        expect(parsedInit.decimals, 9);
+      },
+    );
   });
 
   group('getMintToAtaInstructionPlan', () {
@@ -127,14 +164,48 @@ void main() {
       final seq = plan as SequentialInstructionPlan;
       expect(seq.plans, hasLength(2));
 
-      final createAtaIx =
-          (seq.plans[0] as SingleInstructionPlan).instruction;
+      final createAtaIx = (seq.plans[0] as SingleInstructionPlan).instruction;
       expect(createAtaIx.programAddress, associatedTokenProgramAddress);
 
-      final mintToIx =
-          (seq.plans[1] as SingleInstructionPlan).instruction;
+      final mintToIx = (seq.plans[1] as SingleInstructionPlan).instruction;
       expect(mintToIx.programAddress, tokenProgramAddress);
     });
+
+    test(
+      'async helper derives the ATA and respects config overrides',
+      () async {
+        const customTokenProgram = Address('11111111111111111111111111111114');
+        const customAtaProgram = Address('11111111111111111111111111111115');
+        const customSystemProgram = Address('11111111111111111111111111111116');
+
+        final plan =
+            await getMintToAtaInstructionPlanAsync(
+                  payer: owner,
+                  owner: authority,
+                  mint: mint,
+                  mintAuthority: authority,
+                  amount: BigInt.from(500),
+                  decimals: 6,
+                  config: const MintToAtaConfig(
+                    tokenProgram: customTokenProgram,
+                    associatedTokenProgram: customAtaProgram,
+                    systemProgram: customSystemProgram,
+                  ),
+                )
+                as SequentialInstructionPlan;
+
+        final createAtaIx =
+            (plan.plans[0] as SingleInstructionPlan).instruction;
+        expect(createAtaIx.programAddress, customAtaProgram);
+        expect(createAtaIx.accounts![2].address, authority);
+        expect(createAtaIx.accounts![4].address, customSystemProgram);
+        expect(createAtaIx.accounts![5].address, customTokenProgram);
+
+        final mintToIx = (plan.plans[1] as SingleInstructionPlan).instruction;
+        expect(mintToIx.programAddress, customTokenProgram);
+        expect(mintToIx.accounts![1].address, createAtaIx.accounts![1].address);
+      },
+    );
   });
 
   group('getTransferToAtaInstructionPlan', () {
@@ -156,13 +227,47 @@ void main() {
       final seq = plan as SequentialInstructionPlan;
       expect(seq.plans, hasLength(2));
 
-      final createAtaIx =
-          (seq.plans[0] as SingleInstructionPlan).instruction;
+      final createAtaIx = (seq.plans[0] as SingleInstructionPlan).instruction;
       expect(createAtaIx.programAddress, associatedTokenProgramAddress);
 
-      final transferIx =
-          (seq.plans[1] as SingleInstructionPlan).instruction;
+      final transferIx = (seq.plans[1] as SingleInstructionPlan).instruction;
       expect(transferIx.programAddress, tokenProgramAddress);
+    });
+
+    test('async helper derives source and destination ATAs', () async {
+      const customTokenProgram = Address('11111111111111111111111111111114');
+      const customAtaProgram = Address('11111111111111111111111111111115');
+
+      final plan =
+          await getTransferToAtaInstructionPlanAsync(
+                payer: owner,
+                mint: mint,
+                authority: authority,
+                recipient: destination,
+                amount: BigInt.from(100),
+                decimals: 6,
+                config: const TransferToAtaConfig(
+                  tokenProgram: customTokenProgram,
+                  associatedTokenProgram: customAtaProgram,
+                ),
+              )
+              as SequentialInstructionPlan;
+
+      final createAtaIx = (plan.plans[0] as SingleInstructionPlan).instruction;
+      expect(createAtaIx.programAddress, customAtaProgram);
+      expect(createAtaIx.accounts![2].address, destination);
+      expect(createAtaIx.accounts![5].address, customTokenProgram);
+
+      final transferIx = (plan.plans[1] as SingleInstructionPlan).instruction;
+      final parsedTransfer = parseTransferCheckedInstruction(transferIx);
+      expect(transferIx.programAddress, customTokenProgram);
+      expect(transferIx.accounts![2].address, createAtaIx.accounts![1].address);
+      expect(
+        transferIx.accounts![0].address,
+        isNot(transferIx.accounts![2].address),
+      );
+      expect(transferIx.accounts![3].address, authority);
+      expect(parsedTransfer.amount, BigInt.from(100));
     });
   });
 


### PR DESCRIPTION
## Summary

Implements #139.

Extends the `clone:repos` devenv command to clone and pin all `solana-program/*` repos used as upstream IDL/interface references when developing Dart program packages. Each repo is pinned to a specific tag or commit so the working copy stays stable across machines and CI.

## Changes

### `devenv.nix`
Added a `clone_or_update_at_tag` helper function and 11 repo clone/update blocks under `.repos/solana-program/`:

| Repo | Pinned version |
|------|---------------|
| `system` | `js@v0.12.0` |
| `token` | `js@v0.13.0` |
| `token-2022` | `js@v0.9.0` |
| `associated-token-account` | `program@v8.0.0` |
| `address-lookup-table` | `js@v0.11.0` |
| `memo` | `js@v0.11.0` |
| `compute-budget` | `js@v0.15.0` |
| `stake` | `js@v0.6.0` |
| `config` | `solana-config-program-client@v1.1.0` |
| `loader-v3` | `js@v0.3.0` |
| `loader-v4` | commit `5df834d` (2026-03-08 — no versioned tag yet) |

### `docs/agents/reference-repos.md`
Updated with a full table of all repos, their pinned versions, the Dart package they feed, and step-by-step instructions for updating a pin when a new upstream version ships.

Closes #139