### PR TITLE
refactor: move reference repo pins into JSON config

### DIFF
--- a/.changeset/reference-repo-config-json.md
+++ b/.changeset/reference-repo-config-json.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+Move reference repo pins out of `devenv.nix` into `config/reference-repos.json`, and teach `clone:repos` to read that config and report repo status.

--- a/config/reference-repos.json
+++ b/config/reference-repos.json
@@ -1,0 +1,112 @@
+{
+  "repos": [
+    {
+      "name": "kit",
+      "path": ".repos/kit",
+      "url": "https://github.com/anza-xyz/kit",
+      "ref": { "type": "branch", "value": "main" },
+      "notes": "upstream TypeScript source from anza-xyz/kit"
+    },
+    {
+      "name": "espresso-cash-public",
+      "path": ".repos/espresso-cash-public",
+      "url": "https://github.com/brij-digital/espresso-cash-public",
+      "ref": { "type": "branch", "value": "main" },
+      "notes": "Dart Solana reference from brij-digital/espresso-cash-public"
+    },
+    {
+      "name": "mobile-wallet-adapter",
+      "path": ".repos/mobile-wallet-adapter",
+      "url": "https://github.com/solana-mobile/mobile-wallet-adapter",
+      "ref": { "type": "branch", "value": "main" },
+      "notes": "Solana Mobile Wallet Adapter reference from solana-mobile/mobile-wallet-adapter"
+    },
+    {
+      "name": "system",
+      "path": ".repos/solana-program/system",
+      "url": "https://github.com/solana-program/system",
+      "ref": { "type": "tag", "value": "js@v0.12.0" },
+      "package": "solana_kit_system",
+      "issue": 131
+    },
+    {
+      "name": "token",
+      "path": ".repos/solana-program/token",
+      "url": "https://github.com/solana-program/token",
+      "ref": { "type": "tag", "value": "js@v0.13.0" },
+      "package": "solana_kit_token"
+    },
+    {
+      "name": "token-2022",
+      "path": ".repos/solana-program/token-2022",
+      "url": "https://github.com/solana-program/token-2022",
+      "ref": { "type": "tag", "value": "js@v0.9.0" },
+      "package": "solana_kit_token_2022"
+    },
+    {
+      "name": "associated-token-account",
+      "path": ".repos/solana-program/associated-token-account",
+      "url": "https://github.com/solana-program/associated-token-account",
+      "ref": { "type": "tag", "value": "program@v8.0.0" },
+      "package": "solana_kit_associated_token_account",
+      "issue": 132
+    },
+    {
+      "name": "address-lookup-table",
+      "path": ".repos/solana-program/address-lookup-table",
+      "url": "https://github.com/solana-program/address-lookup-table",
+      "ref": { "type": "tag", "value": "js@v0.11.0" },
+      "package": "solana_kit_address_lookup_table",
+      "issue": 134
+    },
+    {
+      "name": "memo",
+      "path": ".repos/solana-program/memo",
+      "url": "https://github.com/solana-program/memo",
+      "ref": { "type": "tag", "value": "js@v0.11.0" },
+      "package": "solana_kit_memo",
+      "issue": 135
+    },
+    {
+      "name": "compute-budget",
+      "path": ".repos/solana-program/compute-budget",
+      "url": "https://github.com/solana-program/compute-budget",
+      "ref": { "type": "tag", "value": "js@v0.15.0" },
+      "package": "solana_kit_compute_budget",
+      "issue": 133
+    },
+    {
+      "name": "stake",
+      "path": ".repos/solana-program/stake",
+      "url": "https://github.com/solana-program/stake",
+      "ref": { "type": "tag", "value": "js@v0.6.0" },
+      "package": "solana_kit_stake",
+      "issue": 136
+    },
+    {
+      "name": "config",
+      "path": ".repos/solana-program/config",
+      "url": "https://github.com/solana-program/config",
+      "ref": { "type": "tag", "value": "solana-config-program-client@v1.1.0" },
+      "package": "solana_kit_config",
+      "issue": 137
+    },
+    {
+      "name": "loader-v3",
+      "path": ".repos/solana-program/loader-v3",
+      "url": "https://github.com/solana-program/loader-v3",
+      "ref": { "type": "tag", "value": "js@v0.3.0" },
+      "package": "solana_kit_loader",
+      "issue": 138
+    },
+    {
+      "name": "loader-v4",
+      "path": ".repos/solana-program/loader-v4",
+      "url": "https://github.com/solana-program/loader-v4",
+      "ref": { "type": "commit", "value": "5df834d" },
+      "package": "solana_kit_loader",
+      "issue": 138,
+      "notes": "Pinned to commit 5df834d (2026-03-08) because no versioned release exists yet"
+    }
+  ]
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -16,6 +16,7 @@ in
       dprint
       fvm
       gitleaks
+      jq
       ktlint
       libiconv
       nixfmt
@@ -38,7 +39,6 @@ in
 
   # Rely on the global sdk for now as the nix apple sdk is not working for me.
   apple.sdk = null;
-
 
   git-hooks = {
     package = pkgs.prek;
@@ -472,70 +472,134 @@ in
     };
     "clone:repos" = {
       exec = ''
-        set -e
+        set -euo pipefail
+        config_file="$DEVENV_ROOT/config/reference-repos.json"
+        jq_bin="${pkgs.jq}/bin/jq"
+
         mkdir -p "$DEVENV_ROOT/.repos"
 
-        if [ -d "$DEVENV_ROOT/.repos/kit" ]; then
-          echo "Updating .repos/kit..."
-          cd "$DEVENV_ROOT/.repos/kit" && git pull --ff-only
-        else
-          echo "Cloning anza-xyz/kit..."
-          git clone https://github.com/anza-xyz/kit "$DEVENV_ROOT/.repos/kit"
-        fi
+        sync_reference_repo() {
+          local name="$1" path="$2" url="$3" ref_type="$4" ref_value="$5"
+          local dest="$DEVENV_ROOT/$path"
 
-        if [ -d "$DEVENV_ROOT/.repos/espresso-cash-public" ]; then
-          echo "Updating .repos/espresso-cash-public..."
-          cd "$DEVENV_ROOT/.repos/espresso-cash-public" && git pull --ff-only
-        else
-          echo "Cloning brij-digital/espresso-cash-public..."
-          git clone https://github.com/brij-digital/espresso-cash-public "$DEVENV_ROOT/.repos/espresso-cash-public"
-        fi
+          mkdir -p "$(dirname "$dest")"
 
-        # solana-program/* repos — pinned to specific tags/commits for stability.
-        # Update the tag and re-run clone:repos when a new program version ships.
-        mkdir -p "$DEVENV_ROOT/.repos/solana-program"
-
-        clone_or_update_at_tag() {
-          local repo="$1" tag="$2" dest="$3"
-          if [ -d "$dest" ]; then
-            echo "Checking $repo at $tag..."
-            cd "$dest"
-            git fetch --tags --quiet
-            git checkout --quiet "$tag"
-          else
-            echo "Cloning $repo at $tag..."
-            git clone --branch "$tag" --depth 1 \
-              "https://github.com/solana-program/$repo" "$dest"
-          fi
+          case "$ref_type" in
+            branch)
+              if [ -d "$dest/.git" ]; then
+                echo "Updating $path on branch $ref_value..."
+                git -C "$dest" fetch origin --quiet
+                git -C "$dest" checkout --quiet "$ref_value"
+                git -C "$dest" pull --ff-only origin "$ref_value"
+              else
+                echo "Cloning $name on branch $ref_value..."
+                git clone --branch "$ref_value" "$url" "$dest"
+              fi
+              ;;
+            tag)
+              if [ -d "$dest/.git" ]; then
+                echo "Checking $path at tag $ref_value..."
+                git -C "$dest" fetch origin --tags --quiet
+                git -C "$dest" checkout --quiet "$ref_value"
+              else
+                echo "Cloning $name at tag $ref_value..."
+                git clone --branch "$ref_value" --depth 1 "$url" "$dest"
+              fi
+              ;;
+            commit)
+              if [ -d "$dest/.git" ]; then
+                echo "Checking $path at commit $ref_value..."
+                git -C "$dest" fetch origin --quiet
+              else
+                echo "Cloning $name at commit $ref_value..."
+                git clone "$url" "$dest"
+              fi
+              git -C "$dest" checkout --quiet "$ref_value"
+              ;;
+            *)
+              echo "Unknown ref type '$ref_type' for $name" >&2
+              return 1
+              ;;
+          esac
         }
 
-        clone_or_update_at_tag system           js@v0.12.0                          "$DEVENV_ROOT/.repos/solana-program/system"
-        clone_or_update_at_tag token            js@v0.13.0                          "$DEVENV_ROOT/.repos/solana-program/token"
-        clone_or_update_at_tag token-2022       js@v0.9.0                           "$DEVENV_ROOT/.repos/solana-program/token-2022"
-        clone_or_update_at_tag associated-token-account program@v8.0.0             "$DEVENV_ROOT/.repos/solana-program/associated-token-account"
-        clone_or_update_at_tag address-lookup-table js@v0.11.0                     "$DEVENV_ROOT/.repos/solana-program/address-lookup-table"
-        clone_or_update_at_tag memo             js@v0.11.0                          "$DEVENV_ROOT/.repos/solana-program/memo"
-        clone_or_update_at_tag compute-budget   js@v0.15.0                          "$DEVENV_ROOT/.repos/solana-program/compute-budget"
-        clone_or_update_at_tag stake            js@v0.6.0                           "$DEVENV_ROOT/.repos/solana-program/stake"
-        clone_or_update_at_tag config           solana-config-program-client@v1.1.0 "$DEVENV_ROOT/.repos/solana-program/config"
-        clone_or_update_at_tag loader-v3        js@v0.3.0                           "$DEVENV_ROOT/.repos/solana-program/loader-v3"
-
-        # loader-v4 has no versioned release yet; pin to a specific commit.
-        # Pinned: 5df834d (2026-03-08)
-        if [ -d "$DEVENV_ROOT/.repos/solana-program/loader-v4" ]; then
-          echo "Checking loader-v4 at 5df834d..."
-          cd "$DEVENV_ROOT/.repos/solana-program/loader-v4"
-          git fetch --quiet
-          git checkout --quiet 5df834d
-        else
-          echo "Cloning loader-v4 at 5df834d..."
-          git clone https://github.com/solana-program/loader-v4 \
-            "$DEVENV_ROOT/.repos/solana-program/loader-v4"
-          cd "$DEVENV_ROOT/.repos/solana-program/loader-v4"
-          git checkout --quiet 5df834d
-        fi
+        while IFS= read -r repo_json; do
+          name="$($jq_bin -r '.name' <<<"$repo_json")"
+          path="$($jq_bin -r '.path' <<<"$repo_json")"
+          url="$($jq_bin -r '.url' <<<"$repo_json")"
+          ref_type="$($jq_bin -r '.ref.type' <<<"$repo_json")"
+          ref_value="$($jq_bin -r '.ref.value' <<<"$repo_json")"
+          sync_reference_repo "$name" "$path" "$url" "$ref_type" "$ref_value"
+        done < <($jq_bin -c '.repos[]' "$config_file")
       '';
-      description = "Clone or update reference repos into .repos/.";
+      description = "Clone or update reference repos listed in config/reference-repos.json into .repos/.";
+      binary = "bash";
+    };
+    "clone:repos:status" = {
+      exec = ''
+                set -euo pipefail
+                config_file="$DEVENV_ROOT/config/reference-repos.json"
+                jq_bin="${pkgs.jq}/bin/jq"
+                status=0
+
+                while IFS= read -r repo_json; do
+                  name="$($jq_bin -r '.name' <<<"$repo_json")"
+                  path="$($jq_bin -r '.path' <<<"$repo_json")"
+                  ref_type="$($jq_bin -r '.ref.type' <<<"$repo_json")"
+                  ref_value="$($jq_bin -r '.ref.value' <<<"$repo_json")"
+                  dest="$DEVENV_ROOT/$path"
+
+                  if [ ! -d "$dest/.git" ]; then
+                    echo "MISSING  $path ($ref_type:$ref_value)"
+                    status=1
+                    continue
+                  fi
+
+                  git -C "$dest" fetch origin --tags --quiet >/dev/null 2>&1 || true
+                  head_short="$(git -C "$dest" rev-parse --short HEAD)"
+
+                  case "$ref_type" in
+                    branch)
+                      if git -C "$dest" show-ref --verify --quiet "refs/remotes/origin/$ref_value"; then
+                        read -r ahead behind <<EOF
+        $(git -C "$dest" rev-list --left-right --count "HEAD...origin/$ref_value")
+        EOF
+                        if [ "$ahead" -eq 0 ] && [ "$behind" -eq 0 ]; then
+                          echo "OK       $path @ $head_short (branch $ref_value in sync)"
+                        else
+                          echo "DRIFT    $path @ $head_short (branch $ref_value ahead=$ahead behind=$behind)"
+                          status=1
+                        fi
+                      else
+                        echo "UNKNOWN  $path @ $head_short (missing origin/$ref_value)"
+                        status=1
+                      fi
+                      ;;
+                    tag)
+                      expected_commit="$(git -C "$dest" rev-list -n 1 "$ref_value")"
+                      current_commit="$(git -C "$dest" rev-parse HEAD)"
+                      if [ "$current_commit" = "$expected_commit" ]; then
+                        echo "OK       $path @ $head_short (tag $ref_value)"
+                      else
+                        echo "DRIFT    $path @ $head_short (expected tag $ref_value -> ''${expected_commit:0:7})"
+                        status=1
+                      fi
+                      ;;
+                    commit)
+                      current_commit="$(git -C "$dest" rev-parse HEAD)"
+                      if [ "$current_commit" = "$(git -C "$dest" rev-parse "$ref_value^{commit}")" ]; then
+                        echo "OK       $path @ $head_short (commit $ref_value)"
+                      else
+                        echo "DRIFT    $path @ $head_short (expected commit $ref_value)"
+                        status=1
+                      fi
+                      ;;
+                  esac
+                done < <($jq_bin -c '.repos[]' "$config_file")
+
+                exit "$status"
+      '';
+      description = "Report whether cloned reference repos match config/reference-repos.json.";
       binary = "bash";
     };
     "update:deps" = {

--- a/docs/agents/reference-repos.md
+++ b/docs/agents/reference-repos.md
@@ -6,7 +6,25 @@ Clone or update reference repos with:
 clone:repos
 ```
 
-They are stored under `.repos/`.
+Check whether your local clones still match the configured refs with:
+
+```bash
+clone:repos:status
+```
+
+Reference repo definitions live in [`config/reference-repos.json`](../../config/reference-repos.json).
+They are cloned under `.repos/`.
+
+## Config-driven workflow
+
+`clone:repos` reads the JSON file and applies each configured ref:
+
+- `branch` — clones or fast-forwards a named branch
+- `tag` — clones or checks out a pinned tag
+- `commit` — clones or checks out a pinned commit hash
+
+When you need to update an upstream pin, change the JSON config first instead of
+editing `devenv.nix` directly.
 
 ## Core SDK references
 
@@ -16,10 +34,10 @@ They are stored under `.repos/`.
 
 ## solana-program/* references
 
-Each program repo is pinned to a specific tag or commit. When a new version
-ships upstream, update the pin in `devenv.nix` under `clone:repos`, run
-`clone:repos`, regenerate the affected package with `codama-renderers-dart`,
-bump the package version, and add a changeset.
+Each program repo is pinned to a specific tag or commit in
+`config/reference-repos.json`. When a new version ships upstream, update the
+config, run `clone:repos`, regenerate the affected package with
+`codama-renderers-dart`, bump the package version, and add a changeset.
 
 | Path                                             | Repo                                                                                                  | Pinned version                            | Used by                                                                                |
 | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------- |
@@ -37,8 +55,9 @@ bump the package version, and add a changeset.
 
 ## Updating a pinned version
 
-1. Find the new tag on the upstream repo (e.g. `js@v0.14.0`).
-2. Update the tag string in `devenv.nix` under `clone:repos`.
-3. Run `clone:repos` to fetch the new version.
-4. Re-run the Codama generator for the affected Dart package.
-5. Review the generated diff, update the package, bump version, add a changeset.
+1. Find the new upstream tag or commit.
+2. Update `config/reference-repos.json`.
+3. Run `clone:repos` to fetch the new revision.
+4. Run `clone:repos:status` to confirm your local clones match the config.
+5. Re-run the Codama generator or handwritten implementation work for the affected package.
+6. Review the diff, bump the package version, and add a changeset.


### PR DESCRIPTION
## Summary

Follow-up to #144.

Moves reference repo definitions out of `devenv.nix` and into a dedicated JSON config file so the set of cloned repos and their pinned refs is data-driven rather than shell-script-driven.

## What changed

- adds `config/reference-repos.json` as the source of truth for reference repos
  - includes core refs (`kit`, `espresso-cash-public`, `mobile-wallet-adapter`)
  - includes all pinned `solana-program/*` refs
  - records branch/tag/commit ref types explicitly
- updates `clone:repos` to read the JSON config via `jq`
- adds `clone:repos:status`
  - reports `OK`, `DRIFT`, `UNKNOWN`, or `MISSING`
  - compares local clones against the configured branch/tag/commit pin
- updates `docs/agents/reference-repos.md`
  - documents the config file
  - documents the status/check workflow
  - points version updates at the JSON file instead of `devenv.nix`
- adds `jq` to the `devenv` toolchain for local inspection and scripting

## Why

This makes the repo pin set easier to review, update, diff, and eventually automate. Future reference repo changes can now be made by editing a simple data file instead of modifying shell logic.

## Validation

- `devenv shell -- bash -lc 'nixfmt devenv.nix && dprint fmt config/reference-repos.json docs/agents/reference-repos.md'`
- `devenv shell -- bash -lc 'clone:repos:status || true'`
- `devenv shell -- bash -lc 'docs:check'`

