### PR TITLE
feat: add solana_kit_address_lookup_table package

### DIFF
--- a/.changeset/issue-134-address-lookup-table-package.md
+++ b/.changeset/issue-134-address-lookup-table-package.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+Add `solana_kit_address_lookup_table` package with the full generated+helpers Address Lookup Table program client. Includes all five instructions (CreateLookupTable, FreezeLookupTable, ExtendLookupTable, DeactivateLookupTable, CloseLookupTable), AddressLookupTable account decoder, codec round-trip tests, instruction identification, and parsed instruction types.

--- a/.changeset/issue-134-address-lookup-table-package.md
+++ b/.changeset/issue-134-address-lookup-table-package.md
@@ -1,5 +1,7 @@
 ---
-default: minor
+"solana_kit_address_lookup_table": minor
 ---
 
-Add `solana_kit_address_lookup_table` package with the full generated+helpers Address Lookup Table program client. Includes all five instructions (CreateLookupTable, FreezeLookupTable, ExtendLookupTable, DeactivateLookupTable, CloseLookupTable), AddressLookupTable account decoder, codec round-trip tests, instruction identification, and parsed instruction types.
+# Add Address Lookup Table program package
+
+Add `solana_kit_address_lookup_table` package with the full generated+helpers Address Lookup Table program client. Includes all five instructions (`CreateLookupTable`, `FreezeLookupTable`, `ExtendLookupTable`, `DeactivateLookupTable`, `CloseLookupTable`), the `AddressLookupTable` account decoder, codec round-trip tests, instruction identification, and parsed instruction types.

--- a/.changeset/issue-134-address-lookup-table-package.md
+++ b/.changeset/issue-134-address-lookup-table-package.md
@@ -4,4 +4,4 @@
 
 # Add Address Lookup Table program package
 
-Add `solana_kit_address_lookup_table` package with the full generated+helpers Address Lookup Table program client. Includes all five instructions (`CreateLookupTable`, `FreezeLookupTable`, `ExtendLookupTable`, `DeactivateLookupTable`, `CloseLookupTable`), the `AddressLookupTable` account decoder, codec round-trip tests, instruction identification, and parsed instruction types.
+Add `solana_kit_address_lookup_table` package with the full generated+helpers Address Lookup Table program client. Includes all five instructions (`CreateLookupTable`, `FreezeLookupTable`, `ExtendLookupTable`, `DeactivateLookupTable`, `CloseLookupTable`), the `AddressLookupTable` account decoder/fetch helpers, PDA derivation, create-with-PDA convenience builder, lookup table size constants, byte-delta metadata, codec round-trip tests, instruction identification, and parsed instruction types.

--- a/devenv.nix
+++ b/devenv.nix
@@ -269,6 +269,10 @@ in
         mkdir -p .mdt/cache
         mdt check --verbose
         python3 "$DEVENV_ROOT/scripts/sync-dart-doc-comments.py" --check
+        # Prime the cache history so mdt doctor can evaluate cache efficiency
+        # in fresh CI checkouts without returning a cache-history-only skip.
+        mdt info >/dev/null
+        mdt info >/dev/null
         mdt doctor --format text
         scripts/workspace-doc-drift.sh --check
       '';

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -6,7 +6,7 @@ This guide covers how to version, release, and publish the `solana_kit` Dart SDK
 
 <!-- workspace-summary:start -->
 
-This monorepo contains **45 packages** under `packages/`: **43 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
+This monorepo contains **46 packages** under `packages/`: **44 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
 
 <!-- workspace-summary:end -->
 
@@ -45,6 +45,7 @@ Versioning is managed by [knope](https://knope.tech/) using changesets stored in
 | 5     | `solana_kit_subscribable`                        | errors                                                                                                                                                                                |
 | 5     | `solana_kit_system`                              | addresses, codecs_core, codecs_data_structures, codecs_numbers, instructions                                                                                                          |
 | 5     | `solana_kit_associated_token_account`            | addresses, codecs_core, codecs_data_structures, codecs_numbers, errors, instructions                                                                                                  |
+| 5     | `solana_kit_address_lookup_table`                | addresses, codecs_core, codecs_data_structures, codecs_numbers, instructions                                                                                                          |
 | 5     | `solana_kit_compute_budget`                      | addresses, codecs_core, codecs_data_structures, codecs_numbers, instructions                                                                                                          |
 | 6     | `solana_kit_transactions`                        | errors, addresses, codecs, instructions, keys, transaction_messages                                                                                                                   |
 | 6     | `solana_kit_rpc`                                 | rpc_api, rpc_spec, rpc_transport_http, rpc_transformers                                                                                                                               |
@@ -85,6 +86,7 @@ solana_kit_codecs_core -> solana_kit_errors
 solana_kit_codecs_data_structures -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
 solana_kit_codecs_numbers -> solana_kit_codecs_core, solana_kit_errors
 solana_kit_codecs_strings -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
+solana_kit_address_lookup_table -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_compute_budget -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_errors -> (none)
 solana_kit_fast_stable_stringify -> (none)

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -79,6 +79,7 @@ Generated from package `pubspec.yaml` files with `scripts/workspace-doc-drift.sh
 ```text
 solana_kit -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs, solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_instruction_plans, solana_kit_instructions, solana_kit_keys, solana_kit_offchain_messages, solana_kit_options, solana_kit_program_client_core, solana_kit_programs, solana_kit_rpc, solana_kit_rpc_parsed_types, solana_kit_rpc_spec_types, solana_kit_rpc_subscriptions, solana_kit_rpc_transport_http, solana_kit_rpc_types, solana_kit_signers, solana_kit_subscribable, solana_kit_sysvars, solana_kit_transaction_confirmation, solana_kit_transaction_messages, solana_kit_transactions
 solana_kit_accounts -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors, solana_kit_rpc, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_types
+solana_kit_address_lookup_table -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_addresses -> solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
 solana_kit_associated_token_account -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_errors, solana_kit_instructions
 solana_kit_codecs -> solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_options
@@ -86,7 +87,6 @@ solana_kit_codecs_core -> solana_kit_errors
 solana_kit_codecs_data_structures -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
 solana_kit_codecs_numbers -> solana_kit_codecs_core, solana_kit_errors
 solana_kit_codecs_strings -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
-solana_kit_address_lookup_table -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_compute_budget -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_errors -> (none)
 solana_kit_fast_stable_stringify -> (none)

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -86,6 +86,7 @@ Generated from package `pubspec.yaml` files with `scripts/workspace-doc-drift.sh
 ```text
 solana_kit -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs, solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_functional, solana_kit_instruction_plans, solana_kit_instructions, solana_kit_keys, solana_kit_offchain_messages, solana_kit_options, solana_kit_program_client_core, solana_kit_programs, solana_kit_rpc, solana_kit_rpc_parsed_types, solana_kit_rpc_spec_types, solana_kit_rpc_subscriptions, solana_kit_rpc_transport_http, solana_kit_rpc_types, solana_kit_signers, solana_kit_subscribable, solana_kit_sysvars, solana_kit_transaction_confirmation, solana_kit_transaction_messages, solana_kit_transactions
 solana_kit_accounts -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors, solana_kit_rpc, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_types
+solana_kit_address_lookup_table -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_addresses -> solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
 solana_kit_associated_token_account -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_errors, solana_kit_instructions
 solana_kit_codecs -> solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_fixed_points, solana_kit_options
@@ -93,7 +94,6 @@ solana_kit_codecs_core -> solana_kit_errors
 solana_kit_codecs_data_structures -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
 solana_kit_codecs_numbers -> solana_kit_codecs_core, solana_kit_errors
 solana_kit_codecs_strings -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
-solana_kit_address_lookup_table -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_compute_budget -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_config -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_errors -> (none)

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -86,7 +86,7 @@ Generated from package `pubspec.yaml` files with `scripts/workspace-doc-drift.sh
 ```text
 solana_kit -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs, solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_functional, solana_kit_instruction_plans, solana_kit_instructions, solana_kit_keys, solana_kit_offchain_messages, solana_kit_options, solana_kit_program_client_core, solana_kit_programs, solana_kit_rpc, solana_kit_rpc_parsed_types, solana_kit_rpc_spec_types, solana_kit_rpc_subscriptions, solana_kit_rpc_transport_http, solana_kit_rpc_types, solana_kit_signers, solana_kit_subscribable, solana_kit_sysvars, solana_kit_transaction_confirmation, solana_kit_transaction_messages, solana_kit_transactions
 solana_kit_accounts -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors, solana_kit_rpc, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_types
-solana_kit_address_lookup_table -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
+solana_kit_address_lookup_table -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions, solana_kit_rpc_spec
 solana_kit_addresses -> solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
 solana_kit_associated_token_account -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_errors, solana_kit_instructions
 solana_kit_codecs -> solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_fixed_points, solana_kit_options

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -6,7 +6,7 @@ This guide covers how to version, release, and publish the `solana_kit` Dart SDK
 
 <!-- workspace-summary:start -->
 
-This monorepo contains **52 packages** under `packages/`: **50 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
+This monorepo contains **53 packages** under `packages/`: **51 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
 
 <!-- workspace-summary:end -->
 
@@ -46,6 +46,7 @@ Versioning is managed by [monochange](https://github.com/monochange/monochange) 
 | 5     | `solana_kit_subscribable`                        | errors                                                                                                                                                                                |
 | 5     | `solana_kit_system`                              | addresses, codecs_core, codecs_data_structures, codecs_numbers, instructions                                                                                                          |
 | 5     | `solana_kit_associated_token_account`            | addresses, codecs_core, codecs_data_structures, codecs_numbers, errors, instructions                                                                                                  |
+| 5     | `solana_kit_address_lookup_table`                | addresses, codecs_core, codecs_data_structures, codecs_numbers, instructions                                                                                                          |
 | 5     | `solana_kit_compute_budget`                      | addresses, codecs_core, codecs_data_structures, codecs_numbers, instructions                                                                                                          |
 | 5     | `solana_kit_memo`                                | addresses, codecs_core, codecs_data_structures, codecs_strings, instructions                                                                                                          |
 | 6     | `solana_kit_transactions`                        | errors, addresses, codecs, instructions, keys, transaction_messages                                                                                                                   |
@@ -92,6 +93,7 @@ solana_kit_codecs_core -> solana_kit_errors
 solana_kit_codecs_data_structures -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
 solana_kit_codecs_numbers -> solana_kit_codecs_core, solana_kit_errors
 solana_kit_codecs_strings -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
+solana_kit_address_lookup_table -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_compute_budget -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_config -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_errors -> (none)

--- a/docs/site/content/reference/package-catalog.md
+++ b/docs/site/content/reference/package-catalog.md
@@ -252,6 +252,13 @@ Each subsection below maps one package to its role in the Solana ecosystem and t
 - What it does: provides the canonical ATA program address, PDA derivation helpers, and handwritten ATA instruction builders.
 - Use it when: deriving ATA addresses or building create/idempotent/recover ATA instructions directly.
 
+### solana_kit_address_lookup_table
+
+- Pub.dev: [solana_kit_address_lookup_table](https://pub.dev/packages/solana_kit_address_lookup_table)
+- Why it exists: address lookup tables are required for versioned (v0) transactions that reference more than 32 accounts.
+- What it does: provides instruction builders, codecs, account decoders, and parsers for all five Address Lookup Table instructions.
+- Use it when: creating, extending, deactivating, or closing address lookup tables.
+
 ### solana_kit_compute_budget
 
 - Pub.dev: [solana_kit_compute_budget](https://pub.dev/packages/solana_kit_compute_budget)

--- a/docs/site/content/reference/package-index.md
+++ b/docs/site/content/reference/package-index.md
@@ -68,6 +68,7 @@ Then move to smaller packages only when you want a narrower dependency surface o
 - [`solana_kit_token`](https://pub.dev/packages/solana_kit_token)
 - [`solana_kit_token_2022`](https://pub.dev/packages/solana_kit_token_2022)
 - [`solana_kit_associated_token_account`](https://pub.dev/packages/solana_kit_associated_token_account)
+- [`solana_kit_address_lookup_table`](https://pub.dev/packages/solana_kit_address_lookup_table)
 - [`solana_kit_compute_budget`](https://pub.dev/packages/solana_kit_compute_budget)
 
 ## Specialized integrations

--- a/docs/site/content/reference/package-index.md
+++ b/docs/site/content/reference/package-index.md
@@ -68,6 +68,7 @@ Then move to smaller packages only when you want a narrower dependency surface o
 - [`solana_kit_token`](https://pub.dev/packages/solana_kit_token)
 - [`solana_kit_token_2022`](https://pub.dev/packages/solana_kit_token_2022)
 - [`solana_kit_associated_token_account`](https://pub.dev/packages/solana_kit_associated_token_account)
+- [`solana_kit_address_lookup_table`](https://pub.dev/packages/solana_kit_address_lookup_table)
 - [`solana_kit_compute_budget`](https://pub.dev/packages/solana_kit_compute_budget)
 - [`solana_kit_stake`](https://pub.dev/packages/solana_kit_stake)
 

--- a/monochange.toml
+++ b/monochange.toml
@@ -23,6 +23,9 @@ path = "packages/solana_kit"
 [package.solana_kit_accounts]
 path = "packages/solana_kit_accounts"
 
+[package.solana_kit_address_lookup_table]
+path = "packages/solana_kit_address_lookup_table"
+
 [package.solana_kit_addresses]
 path = "packages/solana_kit_addresses"
 
@@ -218,6 +221,7 @@ versioned_files = [
 packages = [
   "solana_kit",
   "solana_kit_accounts",
+  "solana_kit_address_lookup_table",
   "solana_kit_addresses",
   "solana_kit_codecs",
   "solana_kit_codecs_core",

--- a/packages/solana_kit_address_lookup_table/CHANGELOG.md
+++ b/packages/solana_kit_address_lookup_table/CHANGELOG.md
@@ -1,0 +1,2817 @@
+# Changelog
+
+Consolidated changelog for all workspace packages and renderers.
+
+## solana_kit
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for codec and umbrella packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement umbrella package re-exporting all Solana Kit Dart SDK packages.
+
+**solana_kit** (10 tests):
+
+- Re-exports all 28 public packages from the SDK (accounts, addresses, codecs, errors, instructions, keys, rpc, signers, transactions, etc.)
+- `getMinimumBalanceForRentExemption` helper computing rent exemption without RPC call
+- Handles ambiguous exports with explicit `hide` directives for conflicting names
+
+#### Fixes
+
+- Validate quickstart.md code examples against actual implemented APIs and mark all 136 spec tasks as complete.
+
+---
+
+## solana_kit_accounts
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for address and signer packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement accounts package ported from `@solana/accounts`.
+
+**solana_kit_accounts** (45 tests):
+
+- `Account<TData>` and `BaseAccount` with owner, lamports, executable, rentEpoch fields
+- `EncodedAccount` typedef for base64-encoded account data
+- `MaybeAccount<TData>` sealed class: `ExistingAccount` and `NonExistingAccount` variants
+- `assertAccountExists()` and `assertAccountsExist()` for null-safe account unwrapping
+- `parseBase64RpcAccount()`, `parseBase58RpcAccount()`, `parseJsonRpcAccount()` parsers
+- `decodeAccount()`, `decodeMaybeAccount()` with codec-based data decoding
+- `assertAccountDecoded()`, `assertAccountsDecoded()` for decoded type assertions
+- `fetchEncodedAccount()`, `fetchEncodedAccounts()` via RPC `getAccountInfo`/`getMultipleAccounts`
+- `fetchJsonParsedAccount()`, `fetchJsonParsedAccounts()` for JSON-parsed account data
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+---
+
+## solana_kit_addresses
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for address and signer packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement addresses and keys packages ported from `@solana/addresses` and `@solana/keys`.
+
+**solana_kit_addresses** (65 tests):
+
+- `Address` extension type wrapping validated base58-encoded 32-byte strings
+- Address codec (`getAddressEncoder`/`getAddressDecoder`/`getAddressCodec`) for 32-byte fixed-size encoding
+- Address comparator with base58 collation rules matching Solana runtime ordering
+- Ed25519 curve checking (`compressedPointBytesAreOnCurve`, `isOnCurveAddress`, `isOffCurveAddress`)
+- PDA derivation (`getProgramDerivedAddress`) with SHA-256, bump seed search, and seed validation
+- `createAddressWithSeed` for deterministic address derivation
+- Public key to/from address conversion utilities
+
+**solana_kit_keys** (36 tests):
+
+- `Signature` and `SignatureBytes` extension types for Ed25519 signatures
+- Key pair generation, creation from bytes, and creation from private key bytes
+- Ed25519 sign/verify operations using `ed25519_edwards` package
+- Signature validation (string length, byte length, base58 decoding)
+- Private key validation and public key derivation
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+---
+
+## solana_kit_codecs
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for codec and umbrella packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement options package and codecs umbrella re-export.
+
+**solana_kit_options** (90 tests):
+
+- Rust-like `Option<T>` sealed class with `Some<T>` and `None<T>` subclasses
+- Option codec with 6 encoding modes: prefix-based, zeroes, custom none value,
+  combined prefix+zeroes, combined prefix+custom, and absence-based detection
+- `unwrapOption()` and `unwrapOptionOr()` for extracting values with fallback
+- `wrapNullable()` for converting `T?` to `Option<T>`
+- `unwrapOptionRecursively()` for deep unwrapping of nested Options in Maps/Lists
+
+**solana_kit_codecs** (umbrella):
+
+- Re-exports all codec sub-packages: core, numbers, strings, data structures
+- Re-exports options package (matching TypeScript `@solana/codecs` behavior)
+
+---
+
+## solana_kit_codecs_core
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for foundational utility packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement `solana_kit_codecs_core` and `solana_kit_codecs_numbers` packages, ported
+
+from `@solana/codecs-core` and `@solana/codecs-numbers` in the TypeScript SDK.
+
+**solana_kit_codecs_core** provides the foundational codec interfaces and utilities:
+
+- Sealed class hierarchy: `Encoder<T>`, `Decoder<T>`, `Codec<TFrom, TTo>` with
+  fixed-size and variable-size variants
+- Composition utilities: `combineCodec`, `transformCodec`, `fixCodecSize`,
+  `reverseCodec`, `addCodecSentinel`, `addCodecSizePrefix`, `offsetCodec`,
+  `padCodec`, `resizeCodec`
+- Byte utilities: `mergeBytes`, `padBytes`, `fixBytes`, `containsBytes`
+- Assertion helpers for byte array validation
+- 135 tests covering all codec operations
+
+**solana_kit_codecs_numbers** provides number encoding/decoding:
+
+- Integer codecs: u8, i8, u16, i16, u32, i32, u64, i64, u128, i128
+- Float codecs: f32, f64
+- Variable-size shortU16 codec (Solana compact encoding)
+- Configurable endianness (little-endian default, big-endian option)
+- BigInt support for 64-bit and 128-bit integers
+- 152 tests including exhaustive shortU16 roundtrip validation
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+#### Fixes
+
+##### Enhance core SDK packages with additional functionality and tests.
+
+- **Codecs core**: Enhanced `addCodecSizePrefix` with additional functionality
+- **Codecs data structures**: Array codec improvements
+- **Codecs numbers**: `shortU16` codec enhancements
+- **Codecs strings**: UTF-8 codec improvements
+- **Keys**: Key pair and signatures enhancements
+- **RPC transport**: HTTP transport and WebSocket channel updates
+- **Transactions**: Transaction codec enhancements
+
+---
+
+## solana_kit_codecs_data_structures
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for codec and umbrella packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement codecs_strings and codecs_data_structures packages ported from the
+
+TypeScript `@solana/codecs-strings` and `@solana/codecs-data-structures`.
+
+**codecs_strings** (15 tests):
+
+- UTF-8 codec using dart:convert with null character stripping
+- Base16 (hex) codec with optimized nibble conversion
+- Base58 codec using BigInt arithmetic for Solana address encoding
+- Base64 codec tolerant of missing padding (matches Node.js behavior)
+- Base10 codec for decimal string encoding
+- Generic baseX codec for arbitrary alphabets
+- BaseX reslice codec for power-of-2 bases using bit accumulator
+
+**codecs_data_structures** (90 tests):
+
+- Unit (void), boolean, and raw bytes codecs
+- Array codec with prefix/fixed/remainder sizing (sealed ArrayLikeCodecSize)
+- Tuple codec for heterogeneous fixed-length lists
+- Struct codec using Map<String, Object?> for named fields
+- Map and Set codecs built on array internals
+- Nullable codec with configurable none representation (sealed NoneValue)
+- Bit array codec with forward/backward bit ordering
+- Constant, hidden prefix, and hidden suffix codecs
+- Union, discriminated union, and literal union codecs
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+#### Fixes
+
+##### Enhance core SDK packages with additional functionality and tests.
+
+- **Codecs core**: Enhanced `addCodecSizePrefix` with additional functionality
+- **Codecs data structures**: Array codec improvements
+- **Codecs numbers**: `shortU16` codec enhancements
+- **Codecs strings**: UTF-8 codec improvements
+- **Keys**: Key pair and signatures enhancements
+- **RPC transport**: HTTP transport and WebSocket channel updates
+- **Transactions**: Transaction codec enhancements
+
+---
+
+## solana_kit_codecs_numbers
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for codec and umbrella packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement `solana_kit_codecs_core` and `solana_kit_codecs_numbers` packages, ported
+
+from `@solana/codecs-core` and `@solana/codecs-numbers` in the TypeScript SDK.
+
+**solana_kit_codecs_core** provides the foundational codec interfaces and utilities:
+
+- Sealed class hierarchy: `Encoder<T>`, `Decoder<T>`, `Codec<TFrom, TTo>` with
+  fixed-size and variable-size variants
+- Composition utilities: `combineCodec`, `transformCodec`, `fixCodecSize`,
+  `reverseCodec`, `addCodecSentinel`, `addCodecSizePrefix`, `offsetCodec`,
+  `padCodec`, `resizeCodec`
+- Byte utilities: `mergeBytes`, `padBytes`, `fixBytes`, `containsBytes`
+- Assertion helpers for byte array validation
+- 135 tests covering all codec operations
+
+**solana_kit_codecs_numbers** provides number encoding/decoding:
+
+- Integer codecs: u8, i8, u16, i16, u32, i32, u64, i64, u128, i128
+- Float codecs: f32, f64
+- Variable-size shortU16 codec (Solana compact encoding)
+- Configurable endianness (little-endian default, big-endian option)
+- BigInt support for 64-bit and 128-bit integers
+- 152 tests including exhaustive shortU16 roundtrip validation
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+#### Fixes
+
+##### Enhance core SDK packages with additional functionality and tests.
+
+- **Codecs core**: Enhanced `addCodecSizePrefix` with additional functionality
+- **Codecs data structures**: Array codec improvements
+- **Codecs numbers**: `shortU16` codec enhancements
+- **Codecs strings**: UTF-8 codec improvements
+- **Keys**: Key pair and signatures enhancements
+- **RPC transport**: HTTP transport and WebSocket channel updates
+- **Transactions**: Transaction codec enhancements
+
+---
+
+## solana_kit_codecs_strings
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for codec and umbrella packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement codecs_strings and codecs_data_structures packages ported from the
+
+TypeScript `@solana/codecs-strings` and `@solana/codecs-data-structures`.
+
+**codecs_strings** (15 tests):
+
+- UTF-8 codec using dart:convert with null character stripping
+- Base16 (hex) codec with optimized nibble conversion
+- Base58 codec using BigInt arithmetic for Solana address encoding
+- Base64 codec tolerant of missing padding (matches Node.js behavior)
+- Base10 codec for decimal string encoding
+- Generic baseX codec for arbitrary alphabets
+- BaseX reslice codec for power-of-2 bases using bit accumulator
+
+**codecs_data_structures** (90 tests):
+
+- Unit (void), boolean, and raw bytes codecs
+- Array codec with prefix/fixed/remainder sizing (sealed ArrayLikeCodecSize)
+- Tuple codec for heterogeneous fixed-length lists
+- Struct codec using Map<String, Object?> for named fields
+- Map and Set codecs built on array internals
+- Nullable codec with configurable none representation (sealed NoneValue)
+- Bit array codec with forward/backward bit ordering
+- Constant, hidden prefix, and hidden suffix codecs
+- Union, discriminated union, and literal union codecs
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+#### Fixes
+
+##### Enhance core SDK packages with additional functionality and tests.
+
+- **Codecs core**: Enhanced `addCodecSizePrefix` with additional functionality
+- **Codecs data structures**: Array codec improvements
+- **Codecs numbers**: `shortU16` codec enhancements
+- **Codecs strings**: UTF-8 codec improvements
+- **Keys**: Key pair and signatures enhancements
+- **RPC transport**: HTTP transport and WebSocket channel updates
+- **Transactions**: Transaction codec enhancements
+
+---
+
+## solana_kit_errors
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for foundational utility packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial release of the error handling foundation package. Implements the complete
+
+Solana error system ported from `@solana/errors` in the TypeScript SDK:
+
+- `SolanaError` class with numeric error codes and typed context maps
+- `SolanaErrorCode` with 200+ categorized error constants covering addresses,
+  accounts, codecs, crypto, instructions, keys, RPC, signers, transactions,
+  and invariant violations
+- Error message templates with `$variable` interpolation for all error codes
+- JSON-RPC error conversion with preflight failure unwrapping
+- Instruction error mapping for all 54 Solana runtime instruction errors
+- Transaction error mapping for all 37 Solana runtime transaction errors
+- Simulation error unwrapping for preflight and compute limit estimation
+- Context encoding/decoding via base64 URL-safe serialization
+- Comprehensive test suite with 7 test files covering all conversion paths
+
+#### Fixes
+
+##### Add `solana_kit_helius` package — a Dart port of the Helius TypeScript SDK.
+
+Provides 12 sub-clients: DAS API, Priority Fees, RPC V2, Enhanced Transactions, Webhooks, ZK Compression, Smart Transactions, Staking, Wallet API, WebSockets, and Auth. Includes 150 unit tests across 80 test files.
+
+Adds 6 Helius-specific error codes (8600000–8600005) to `solana_kit_errors`.
+
+##### Add Mobile Wallet Adapter packages for Solana.
+
+**solana_kit_mobile_wallet_adapter_protocol**: Pure Dart MWA v2.0 protocol with P-256 ECDH/ECDSA, AES-128-GCM encryption, HKDF-SHA256, HELLO handshake, JSON-RPC messaging, association URIs, SIWS, and JWS.
+
+**solana_kit_mobile_wallet_adapter**: Flutter plugin for Android MWA with `transact()`, local/remote association scenarios, wallet-side callbacks, Kit-integrated typed APIs, and platform method channels.
+
+Adds 20 MWA-specific error codes (8400000-8400105) to `solana_kit_errors`.
+
+---
+
+## solana_kit_fast_stable_stringify
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for foundational utility packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement foundation utility packages ported from the `@solana/functional` and
+
+`@solana/fast-stable-stringify` TypeScript packages.
+
+**solana_kit_functional**: Adds the `Pipe` extension which provides a `.pipe()`
+method on any value for composable functional pipelines. This is the idiomatic
+Dart equivalent of the TS `pipe()` function, used extensively for building
+transaction messages. Includes 28 tests covering single/multiple transforms,
+type changes, object mutation, combining, nested pipes, and error propagation.
+
+**solana_kit_fast_stable_stringify**: Adds `fastStableStringify()` for
+deterministic JSON serialization with sorted object keys. Handles all Dart
+primitives, BigInt (serialized as `<value>n`), nested maps, lists, and objects
+implementing `ToJsonable`. Includes 15 tests matching the upstream SDK's
+`json-stable-stringify` reference output.
+
+---
+
+## solana_kit_functional
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for foundational utility packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement foundation utility packages ported from the `@solana/functional` and
+
+`@solana/fast-stable-stringify` TypeScript packages.
+
+**solana_kit_functional**: Adds the `Pipe` extension which provides a `.pipe()`
+method on any value for composable functional pipelines. This is the idiomatic
+Dart equivalent of the TS `pipe()` function, used extensively for building
+transaction messages. Includes 28 tests covering single/multiple transforms,
+type changes, object mutation, combining, nested pipes, and error propagation.
+
+**solana_kit_fast_stable_stringify**: Adds `fastStableStringify()` for
+deterministic JSON serialization with sorted object keys. Handles all Dart
+primitives, BigInt (serialized as `<value>n`), nested maps, lists, and objects
+implementing `ToJsonable`. Includes 15 tests matching the upstream SDK's
+`json-stable-stringify` reference output.
+
+---
+
+## solana_kit_helius
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Add runnable examples for specialized and mobile-focused packages, including websocket subscriptions, sysvars, and transaction confirmation flows.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Add `solana_kit_helius` package — a Dart port of the Helius TypeScript SDK.
+
+Provides 12 sub-clients: DAS API, Priority Fees, RPC V2, Enhanced Transactions, Webhooks, ZK Compression, Smart Transactions, Staking, Wallet API, WebSockets, and Auth. Includes 150 unit tests across 80 test files.
+
+Adds 6 Helius-specific error codes (8600000–8600005) to `solana_kit_errors`.
+
+---
+
+## solana_kit_instruction_plans
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for program and transaction planning packages.
+- Document fix: resolve fatal analyzer infos across workspace.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement instruction plans package ported from `@solana/instruction-plans`.
+
+**solana_kit_instruction_plans** (215 tests):
+
+- `InstructionPlan` sealed class hierarchy: `SingleInstructionPlan`, `SequentialInstructionPlan`, `ParallelInstructionPlan`, `MessagePackerInstructionPlan`
+- `TransactionPlan` sealed class hierarchy: `SingleTransactionPlan`, `SequentialTransactionPlan`, `ParallelTransactionPlan`
+- `TransactionPlanResult` sealed class hierarchy with successful, failed, canceled, sequential, and parallel result types
+- `createTransactionPlanner` converting instruction plans to transaction plans with size-aware message packing
+- `createTransactionPlanExecutor` for executing transaction plans with context propagation
+- `MessagePacker` with linear, instruction-based, and realloc message packer factories
+- Tree traversal utilities: `findInstructionPlan`, `everyInstructionPlan`, `transformInstructionPlan`, `flattenTransactionPlan`
+- Type guards and assertions for all plan types
+- `appendTransactionMessageInstructionPlan` helper for adding instructions to messages
+- `passthroughFailedTransactionPlanExecution` for error handling passthrough
+- `TransactionPlanResultSummary` with `summarizeTransactionPlanResult` for result aggregation
+
+---
+
+## solana_kit_instructions
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for address and signer packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement instructions and programs packages ported from `@solana/instructions` and `@solana/programs`.
+
+**solana_kit_instructions** (56 tests):
+
+- `AccountRole` enhanced enum with bitflag values (readonly, writable, readonlySigner, writableSigner)
+- 7 role manipulation functions: upgrade/downgrade signer/writable, merge, query
+- `AccountMeta` and `AccountLookupMeta` immutable classes with const constructors
+- `Instruction` class with optional accounts and data fields
+- 6 instruction validation functions: isInstructionForProgram, isInstructionWithAccounts, isInstructionWithData (with assert variants)
+
+**solana_kit_programs** (5 tests):
+
+- `isProgramError` function to identify custom program errors from transaction failures
+- Matches error code, instruction index, and program address against transaction message
+- `TransactionMessageInput` and `InstructionInput` minimal types for error checking
+
+#### Fixes
+
+##### Implement transaction messages package ported from `@solana/transaction-messages`.
+
+**solana_kit_transaction_messages** (99 tests):
+
+- `TransactionMessage` immutable class with `TransactionVersion` (legacy, v0), fee payer, lifetime constraint, and instruction management
+- `LifetimeConstraint` sealed class with `BlockhashLifetimeConstraint` and `DurableNonceLifetimeConstraint` subtypes
+- Transaction message creation, fee payer setting, and instruction append/prepend
+- Blockhash lifetime: validation (`isTransactionMessageWithBlockhashLifetime`), assertion, and setter
+- Durable nonce lifetime: validation, assertion, and setter with automatic `AdvanceNonceAccount` instruction management
+- `compileTransactionMessage`: compiles high-level messages to wire-format `CompiledTransactionMessage`
+- Account compilation with correct ordering (fee payer, writable signers, readonly signers, writable non-signers, readonly non-signers)
+- Address lookup table compression (`compressTransactionMessageUsingAddressLookupTables`)
+- Message decompilation (`decompileTransactionMessage`) to reconstruct from compiled format
+- Full codec suite: transaction version, header (3-byte), instruction, address table lookup, and complete message encoder/decoder
+
+**solana_kit_instructions** (patch):
+
+- `AccountLookupMeta` now extends `AccountMeta` for type compatibility in instruction accounts lists
+
+---
+
+## solana_kit_keys
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for address and signer packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement addresses and keys packages ported from `@solana/addresses` and `@solana/keys`.
+
+**solana_kit_addresses** (65 tests):
+
+- `Address` extension type wrapping validated base58-encoded 32-byte strings
+- Address codec (`getAddressEncoder`/`getAddressDecoder`/`getAddressCodec`) for 32-byte fixed-size encoding
+- Address comparator with base58 collation rules matching Solana runtime ordering
+- Ed25519 curve checking (`compressedPointBytesAreOnCurve`, `isOnCurveAddress`, `isOffCurveAddress`)
+- PDA derivation (`getProgramDerivedAddress`) with SHA-256, bump seed search, and seed validation
+- `createAddressWithSeed` for deterministic address derivation
+- Public key to/from address conversion utilities
+
+**solana_kit_keys** (36 tests):
+
+- `Signature` and `SignatureBytes` extension types for Ed25519 signatures
+- Key pair generation, creation from bytes, and creation from private key bytes
+- Ed25519 sign/verify operations using `ed25519_edwards` package
+- Signature validation (string length, byte length, base58 decoding)
+- Private key validation and public key derivation
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+#### Fixes
+
+##### Enhance core SDK packages with additional functionality and tests.
+
+- **Codecs core**: Enhanced `addCodecSizePrefix` with additional functionality
+- **Codecs data structures**: Array codec improvements
+- **Codecs numbers**: `shortU16` codec enhancements
+- **Codecs strings**: UTF-8 codec improvements
+- **Keys**: Key pair and signatures enhancements
+- **RPC transport**: HTTP transport and WebSocket channel updates
+- **Transactions**: Transaction codec enhancements
+
+---
+
+## solana_kit_lints
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Add runnable, non-placeholder examples for `solana_kit_lints` and `solana_kit_test_matchers`, including analyzer configuration guidance for lint usage and direct matcher usage examples.
+
+##### Add a `solana_kit_lints` workspace dependency checker and run it as part of
+
+`lint:all` to ensure internal package dependencies use `workspace: true` in
+`pubspec.yaml` files.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial release of shared lint configuration package. Extends `very_good_analysis`
+
+with project-specific overrides: disables `public_member_api_docs` (docs will be
+added incrementally) and `lines_longer_than_80_chars` (allows longer lines for
+readability in codec/RPC code). All 37 packages in the workspace depend on this
+package via `dev_dependencies` for consistent static analysis.
+
+#### Fixes
+
+- CI/tooling improvements: add devenv composite action, refactor CI to use devenv shell, add dprint exec plugins, and enable additional lint rules.
+
+---
+
+## solana_kit_mobile_wallet_adapter
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Add runnable examples for specialized and mobile-focused packages, including websocket subscriptions, sysvars, and transaction confirmation flows.
+- Document fix: resolve fatal analyzer infos across workspace.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Add Mobile Wallet Adapter packages for Solana.
+
+**solana_kit_mobile_wallet_adapter_protocol**: Pure Dart MWA v2.0 protocol with P-256 ECDH/ECDSA, AES-128-GCM encryption, HKDF-SHA256, HELLO handshake, JSON-RPC messaging, association URIs, SIWS, and JWS.
+
+**solana_kit_mobile_wallet_adapter**: Flutter plugin for Android MWA with `transact()`, local/remote association scenarios, wallet-side callbacks, Kit-integrated typed APIs, and platform method channels.
+
+Adds 20 MWA-specific error codes (8400000-8400105) to `solana_kit_errors`.
+
+---
+
+## solana_kit_mobile_wallet_adapter_protocol
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Add runnable examples for specialized and mobile-focused packages, including websocket subscriptions, sysvars, and transaction confirmation flows.
+- Document fix: resolve fatal analyzer infos across workspace.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Add Mobile Wallet Adapter packages for Solana.
+
+**solana_kit_mobile_wallet_adapter_protocol**: Pure Dart MWA v2.0 protocol with P-256 ECDH/ECDSA, AES-128-GCM encryption, HKDF-SHA256, HELLO handshake, JSON-RPC messaging, association URIs, SIWS, and JWS.
+
+**solana_kit_mobile_wallet_adapter**: Flutter plugin for Android MWA with `transact()`, local/remote association scenarios, wallet-side callbacks, Kit-integrated typed APIs, and platform method channels.
+
+Adds 20 MWA-specific error codes (8400000-8400105) to `solana_kit_errors`.
+
+---
+
+## solana_kit_offchain_messages
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Add runnable examples for specialized and mobile-focused packages, including websocket subscriptions, sysvars, and transaction confirmation flows.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement offchain messages package ported from `@solana/offchain-message`.
+
+**solana_kit_offchain_messages** (1082 tests):
+
+- `OffchainMessage` sealed class with `OffchainMessageV0` and `OffchainMessageV1` subtypes
+- V0: application domain, three content formats (restricted ASCII 1232, UTF-8 1232, UTF-8 65535), signatory list
+- V1: simplified with auto-sorted signatories and arbitrary UTF-8 content
+- Content validation: ASCII character range (0x20-0x7E), size limits, format enforcement
+- Application domain validation (must be valid 32-byte base58 address)
+- Full codec suite: V0/V1/unified message codecs, envelope codec with signature handling
+- `compileOffchainMessageEnvelope` to create signable envelopes from messages
+- `partiallySignOffchainMessageEnvelope` and `signOffchainMessageEnvelope` for Ed25519 signing
+- `verifyOffchainMessageEnvelope` for cryptographic signature verification
+- Missing signatures encoded as 64 zero bytes in wire format
+
+---
+
+## solana_kit_options
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for foundational utility packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement options package and codecs umbrella re-export.
+
+**solana_kit_options** (90 tests):
+
+- Rust-like `Option<T>` sealed class with `Some<T>` and `None<T>` subclasses
+- Option codec with 6 encoding modes: prefix-based, zeroes, custom none value,
+  combined prefix+zeroes, combined prefix+custom, and absence-based detection
+- `unwrapOption()` and `unwrapOptionOr()` for extracting values with fallback
+- `wrapNullable()` for converting `T?` to `Option<T>`
+- `unwrapOptionRecursively()` for deep unwrapping of nested Options in Maps/Lists
+
+**solana_kit_codecs** (umbrella):
+
+- Re-exports all codec sub-packages: core, numbers, strings, data structures
+- Re-exports options package (matching TypeScript `@solana/codecs` behavior)
+
+---
+
+## solana_kit_program_client_core
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for program and transaction planning packages.
+- Document fix: harden self-plan-and-send program client flows.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement program client core package ported from `@solana/program-client-core`.
+
+**solana_kit_program_client_core** (31 tests):
+
+- `InstructionWithByteDelta` mixin for tracking account storage size changes
+- `ResolvedInstructionAccount` type for resolved instruction account values
+- `getNonNullResolvedInstructionInput` null-safety validation with descriptive errors
+- `getAddressFromResolvedInstructionAccount` extracts Address from Address/PDA/TransactionSigner
+- `getResolvedInstructionAccountAsProgramDerivedAddress` validates and extracts PDA
+- `getResolvedInstructionAccountAsTransactionSigner` validates and extracts TransactionSigner
+- `getAccountMetaFactory` factory converting ResolvedInstructionAccount to AccountMeta with omitted/programId strategies
+- `SelfFetchFunctions` augmenting codecs with fetch/fetchMaybe/fetchAll/fetchAllMaybe methods
+- Stub for self-plan-and-send functions (pending instruction_plans implementation)
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+---
+
+## solana_kit_programs
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for program and transaction planning packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement instructions and programs packages ported from `@solana/instructions` and `@solana/programs`.
+
+**solana_kit_instructions** (56 tests):
+
+- `AccountRole` enhanced enum with bitflag values (readonly, writable, readonlySigner, writableSigner)
+- 7 role manipulation functions: upgrade/downgrade signer/writable, merge, query
+- `AccountMeta` and `AccountLookupMeta` immutable classes with const constructors
+- `Instruction` class with optional accounts and data fields
+- 6 instruction validation functions: isInstructionForProgram, isInstructionWithAccounts, isInstructionWithData (with assert variants)
+
+**solana_kit_programs** (5 tests):
+
+- `isProgramError` function to identify custom program errors from transaction failures
+- Matches error code, instruction index, and program address against transaction message
+- `TransactionMessageInput` and `InstructionInput` minimal types for error checking
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+---
+
+## solana_kit_rpc
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc runtime packages.
+- Document fix: harden rpc transports and subscription channels.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Implement RPC client package ported from `@solana/rpc`.
+
+**solana_kit_rpc** (125 tests):
+
+- `createSolanaRpc` and `createSolanaRpcFromTransport` factory functions combining API + transport + transformers
+- `createDefaultRpcTransport` with `solana-client: dart/0.0.1` header and request coalescing
+- Request coalescing: deduplicates identical JSON-RPC requests within the same microtask
+- Deduplication key generation using `fastStableStringify` for deterministic request hashing
+- Integer overflow error creation with human-readable ordinal argument labels
+- Default RPC config: `confirmed` commitment, integer overflow handler
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+---
+
+## solana_kit_rpc_api
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc spec and type packages.
+- Document test: add rpc contract and model regression suites.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC API package ported from `@solana/rpc-api`.
+
+**solana_kit_rpc_api** (75 tests):
+
+- Config and params classes for all 52 Solana RPC methods (getAccountInfo, getBalance, getBlock, sendTransaction, simulateTransaction, etc.)
+- `solanaRpcMethodsForAllClusters` (51 methods) and `solanaRpcMethodsForTestClusters` (52 methods, includes requestAirdrop)
+- `getAllowedNumericKeypaths()` for response transformer numeric value whitelisting
+- Cluster-variant helpers: `isSolanaRpcMethodForMainnet`, `isSolanaRpcMethodForTestClusters`
+- Per-method `toJson()` serialization and params builder functions
+
+---
+
+## solana_kit_rpc_parsed_types
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc spec and type packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC parsed types package ported from `@solana/rpc-parsed-types`.
+
+**solana_kit_rpc_parsed_types** (32 tests):
+
+- Typed representations of JSON-parsed account data from the Solana RPC
+- Address lookup table, BPF upgradeable loader, config, nonce, stake, sysvar, token, and vote account types
+- Sealed class hierarchies for discriminated unions enabling exhaustive pattern matching
+- `RpcParsedType<TType, TInfo>` and `RpcParsedInfo<TInfo>` base classes
+- All 10 sysvar account types: clock, epochRewards, epochSchedule, fees, lastRestartSlot, recentBlockhashes, rent, slotHashes, slotHistory, stakeHistory
+- Token program accounts: account, mint, multisig with `TokenAccountState` enum
+
+---
+
+## solana_kit_rpc_spec
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc spec and type packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC spec package ported from `@solana/rpc-spec`.
+
+**solana_kit_rpc_spec** (23 tests):
+
+- `JsonRpcApi` with configurable request/response transformers creating `RpcPlan` objects
+- `RpcPlan<T>` describing how to execute an RPC request with lazy execution
+- `RpcTransport` typedef for pluggable transport layer
+- `Rpc` client that wraps API + transport, returning `PendingRpcRequest` objects
+- `PendingRpcRequest<T>` with `send()` method for deferred execution
+- `isJsonRpcPayload` type guard for JSON-RPC 2.0 payload validation
+- `RpcApi` abstract class with `JsonRpcApiAdapter` and `MapRpcApi` implementations
+
+---
+
+## solana_kit_rpc_spec_types
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc spec and type packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC spec types package ported from `@solana/rpc-spec-types`.
+
+**solana_kit_rpc_spec_types** (96 tests):
+
+- `RpcRequest<TParams>` class with method name and typed parameters
+- `RpcRequestTransformer` and `RpcResponseTransformer` function typedefs
+- `RpcErrorResponsePayload` with code, message, and optional data
+- `RpcResponseData` sealed class with `RpcResponseResult` and `RpcResponseError` subtypes
+- `createRpcMessage` for JSON-RPC 2.0 message creation with auto-incrementing IDs
+- `parseJsonWithBigInts` for JSON parsing that preserves large integers as `BigInt`
+- `stringifyJsonWithBigInts` for JSON serialization that renders `BigInt` values as bare numbers
+
+---
+
+## solana_kit_rpc_subscriptions
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc runtime packages.
+- Document fix: harden rpc transports and subscription channels.
+- Document fix: resolve fatal analyzer infos across workspace.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC subscriptions composition package ported from `@solana/rpc-subscriptions`.
+
+**solana_kit_rpc_subscriptions** (144 tests):
+
+- `createSolanaRpcSubscriptions` and `createSolanaRpcSubscriptionsUnstable` factory functions
+- `createSolanaRpcSubscriptionsFromTransport` for custom transport usage
+- `getRpcSubscriptionsTransportWithSubscriptionCoalescing` deduplicating identical subscriptions via fastStableStringify hashing
+- `getRpcSubscriptionsChannelWithAutoping` periodic keep-alive ping messages with timer reset on activity
+- `getChannelPoolingChannelCreator` channel reuse with maxSubscriptionsPerChannel limits and automatic cleanup
+- `getRpcSubscriptionsChannelWithJsonSerialization` and `getRpcSubscriptionsChannelWithBigIntJsonSerialization`
+- `createDefaultSolanaRpcSubscriptionsChannelCreator` composing JSON + autopinger + pooling
+- `createSolanaJsonRpcIntegerOverflowError` with ordinal argument labels
+- Default RPC subscription configuration with `confirmed` commitment
+
+---
+
+## solana_kit_rpc_subscriptions_api
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc runtime packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC subscriptions API package ported from `@solana/rpc-subscriptions-api`.
+
+**solana_kit_rpc_subscriptions_api** (61 tests):
+
+- 6 stable subscription methods: `accountNotifications`, `logsNotifications`, `programNotifications`, `rootNotifications`, `signatureNotifications`, `slotNotifications`
+- 3 unstable subscription methods: `blockNotifications`, `slotsUpdatesNotifications`, `voteNotifications`
+- Sealed `LogsFilter` type (All/AllWithVotes/Mentions) with JSON serialization
+- Sealed `BlockNotificationsFilter` type (All/MentionsAccountOrProgram)
+- `solanaRpcSubscriptionsMethodsStable` and `solanaRpcSubscriptionsMethodsUnstable` composition
+- Helper functions: `notificationNameToSubscribeMethod()`, `notificationNameToUnsubscribeMethod()`
+- Config types for each subscription with proper encoding commitment/maxSupportedTransactionVersion
+
+---
+
+## solana_kit_rpc_subscriptions_channel_websocket
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Add runnable examples for specialized and mobile-focused packages, including websocket subscriptions, sysvars, and transaction confirmation flows.
+- Document fix: harden rpc transports and subscription channels.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC subscriptions WebSocket channel package ported from `@solana/rpc-subscriptions-channel-websocket`.
+
+**solana_kit_rpc_subscriptions_channel_websocket** (23 tests):
+
+- `createWebSocketChannel` factory for creating WebSocket RPC subscription channels
+- `RpcSubscriptionsChannel` interface extending `DataPublisher` with `send()` method
+- `AbortSignal` / `AbortController` for clean channel shutdown
+- `WebSocketChannelConfig` with URL, sendBufferHighWatermark, and optional abort signal
+- Message forwarding via DataPublisher `'message'` channel
+- Error publishing on abnormal WebSocket closure (non-1000 codes)
+- Integration tests using real `HttpServer` with `WebSocketTransformer`
+
+#### Fixes
+
+##### Enhance core SDK packages with additional functionality and tests.
+
+- **Codecs core**: Enhanced `addCodecSizePrefix` with additional functionality
+- **Codecs data structures**: Array codec improvements
+- **Codecs numbers**: `shortU16` codec enhancements
+- **Codecs strings**: UTF-8 codec improvements
+- **Keys**: Key pair and signatures enhancements
+- **RPC transport**: HTTP transport and WebSocket channel updates
+- **Transactions**: Transaction codec enhancements
+
+---
+
+## solana_kit_rpc_transport_http
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc runtime packages.
+- Document fix: harden rpc transports and subscription channels.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC transport HTTP package ported from `@solana/rpc-transport-http`.
+
+**solana_kit_rpc_transport_http** (129 tests):
+
+- `createHttpTransport` factory for JSON-RPC POST requests with configurable headers, custom JSON serialization/deserialization
+- `createHttpTransportForSolanaRpc` wrapping transport with BigInt-aware JSON handling via `parseJsonWithBigInts`/`stringifyJsonWithBigInts`
+- `isSolanaRequest` type guard checking against 55 known Solana RPC methods
+- Header validation: forbidden headers (MDN spec), disallowed headers (Accept, Content-Type, Content-Length, Solana-Client), proxy-\_/sec-\_ prefix matching
+- HTTP error handling with `SolanaError` context preservation (status code, message)
+
+#### Fixes
+
+##### Enhance core SDK packages with additional functionality and tests.
+
+- **Codecs core**: Enhanced `addCodecSizePrefix` with additional functionality
+- **Codecs data structures**: Array codec improvements
+- **Codecs numbers**: `shortU16` codec enhancements
+- **Codecs strings**: UTF-8 codec improvements
+- **Keys**: Key pair and signatures enhancements
+- **RPC transport**: HTTP transport and WebSocket channel updates
+- **Transactions**: Transaction codec enhancements
+
+---
+
+## solana_kit_rpc_transformers
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc runtime packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC transformers package ported from `@solana/rpc-transformers`.
+
+**solana_kit_rpc_transformers** (524 tests):
+
+- Request transformers: BigInt downcast, integer overflow detection, default commitment injection
+- Response transformers: BigInt upcast, JSON-RPC error throwing with Solana error unwrapping, result extraction
+- Tree traversal utilities with key path wildcards for deep object walking
+- Default commitment handling for 39 RPC methods with per-method config position mapping
+- Preflight error unwrapping from `-32002` JSON-RPC errors
+- Composable transformer pipelines via `getDefaultRequestTransformerForSolanaRpc` and `getDefaultResponseTransformerForSolanaRpc`
+
+---
+
+## solana_kit_rpc_types
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc spec and type packages.
+- Document fix: resolve fatal analyzer infos across workspace.
+- Document test: add rpc contract and model regression suites.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement RPC types package ported from `@solana/rpc-types`.
+
+**solana_kit_rpc_types** (85 tests):
+
+- `Blockhash` extension type with validation, codec (32-byte base58), and comparator
+- `Lamports` extension type (0 to 2^64-1) with generic encoder/decoder/codec wrappers
+- `UnixTimestamp` extension type (i64 range) with validation
+- `StringifiedBigInt` and `StringifiedNumber` extension types with validation
+- `Commitment` enum (processed, confirmed, finalized) with comparator
+- `MicroLamports`, `SignedLamports`, `Slot`, `Epoch` type aliases
+- Encoded data types: `Base58EncodedBytes`, `Base64EncodedBytes`, data response records
+- Account info types: `AccountInfoBase` and encoding-specific variants
+- `TokenAmount`, `TokenBalance` for SPL token data
+- `TransactionError` and `InstructionError` sealed class hierarchies
+- `TransactionVersion`, `Reward`, `TransactionStatus` types
+- Cluster URL types: `MainnetUrl`, `DevnetUrl`, `TestnetUrl`
+- `SolanaRpcResponse<T>` wrapper with slot context
+- Account filter types: `DataSlice`, memcmp and datasize filters
+
+---
+
+## solana_kit_signers
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for address and signer packages.
+- Document fix: resolve fatal analyzer infos across workspace.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement signers package ported from `@solana/signers`.
+
+**solana_kit_signers** (88 tests):
+
+- Five core signer interfaces: `MessagePartialSigner`, `MessageModifyingSigner`, `TransactionPartialSigner`, `TransactionModifyingSigner`, `TransactionSendingSigner`
+- Composite types: `MessageSigner`, `TransactionSigner`, `KeyPairSigner` with Ed25519 signing
+- `NoopSigner` for adding signature slots without actual signing
+- `partiallySignTransactionMessageWithSigners` and `signTransactionMessageWithSigners` for signing transaction messages using attached signers
+- `signAndSendTransactionMessageWithSigners` for combined sign-and-send workflow
+- Signer extraction from instructions and transaction messages via account meta
+- Fee payer signer utilities
+- Signer deduplication and assertion helpers
+
+---
+
+## solana_kit_subscribable
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for rpc runtime packages.
+- Document fix: resolve fatal analyzer infos across workspace.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement subscribable package ported from `@solana/subscribable`.
+
+**solana_kit_subscribable** (33 tests):
+
+- `DataPublisher` interface with `on(channelName, subscriber)` returning unsubscribe function
+- `WritableDataPublisher` concrete implementation with `publish(channelName, data)` for testing
+- `createStreamFromDataPublisher` converting DataPublisher to Dart `Stream<TData>` with error channel support
+- `createAsyncIterableFromDataPublisher` with AbortSignal support, message queuing, and pre-poll message dropping
+- `demultiplexDataPublisher` splitting single channel into multiple typed channels with lazy subscription and reference counting
+- Idempotent unsubscribe and proper cleanup on abort
+
+---
+
+## solana_kit_sysvars
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Add runnable examples for specialized and mobile-focused packages, including websocket subscriptions, sysvars, and transaction confirmation flows.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement sysvars package ported from `@solana/sysvars`.
+
+**solana_kit_sysvars** (52 tests):
+
+- 10 sysvar address constants (Clock, EpochRewards, EpochSchedule, Instructions, LastRestartSlot, RecentBlockhashes, Rent, SlotHashes, SlotHistory, StakeHistory)
+- `SysvarClock` codec (40 bytes): slot, epochStartTimestamp, epoch, leaderScheduleEpoch, unixTimestamp
+- `SysvarEpochSchedule` codec (33 bytes): slotsPerEpoch, leaderScheduleSlotOffset, warmup, firstNormalEpoch, firstNormalSlot
+- `SysvarEpochRewards` codec (81 bytes): distributionStartingBlockHeight, numPartitions, parentBlockhash, totalPoints (u128), totalRewards, distributedRewards, active
+- `SysvarRent` codec (17 bytes): lamportsPerByteYear, exemptionThreshold (f64), burnPercent
+- `SysvarLastRestartSlot` codec (8 bytes), `SysvarSlotHashes` variable-size array codec
+- `SysvarSlotHistory` bitvector codec (131,097 bytes) with discriminator validation
+- `SysvarRecentBlockhashes` (deprecated) and `SysvarStakeHistory` variable-size array codecs
+- `fetchSysvar*` async RPC functions for each sysvar type
+- `fetchEncodedSysvarAccount` generic fetch function
+
+---
+
+## solana_kit_test_matchers
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Add runnable, non-placeholder examples for `solana_kit_lints` and `solana_kit_test_matchers`, including analyzer configuration guidance for lint usage and direct matcher usage examples.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement test matchers package with Solana-specific test assertions.
+
+**solana_kit_test_matchers** (33 tests):
+
+- `isSolanaErrorWithCode` / `throwsSolanaErrorWithCode` for matching SolanaError by error code
+- `isSolanaErrorWithCodeAndContext` for matching error code and context entries
+- `isSolanaErrorMatcher` / `throwsSolanaError` for matching any SolanaError
+- `equalsBytes` for byte-for-byte Uint8List comparison with detailed mismatch reporting
+- `hasByteLength` / `startsWithBytes` for byte array assertions
+- `isValidSolanaAddress` / `equalsAddress` for Address validation and comparison
+- `isFullySignedTransactionMatcher` / `hasSignatureCount` for Transaction signature verification
+
+---
+
+## solana_kit_transaction_confirmation
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Add runnable examples for specialized and mobile-focused packages, including websocket subscriptions, sysvars, and transaction confirmation flows.
+- Document fix: resolve fatal analyzer infos across workspace.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 17 higher-level packages including the full RPC stack,
+
+program interaction layers, and the umbrella package. Each package has its
+pubspec.yaml with correct workspace dependencies, shared analysis_options.yaml,
+and an empty barrel export file ready for implementation.
+
+Package groups scaffolded:
+
+- **RPC Stack**: rpc_types (base types), rpc_spec_types, rpc_spec (specification),
+  rpc_api (method definitions), rpc_parsed_types, rpc_transformers (response
+  processing), rpc_transport_http (HTTP transport), rpc (primary client)
+- **RPC Subscriptions**: rpc_subscriptions_api, rpc_subscriptions_channel_websocket,
+  rpc_subscriptions (WebSocket subscription client)
+- **Programs & Accounts**: accounts (fetching/decoding), programs (utilities),
+  program_client_core (base client), sysvars (system variables)
+- **Transaction Lifecycle**: transaction_confirmation (polling/confirmation)
+- **Umbrella**: solana_kit (re-exports all packages for convenience)
+
+##### Implement transaction confirmation package ported from `@solana/transaction-confirmation`.
+
+**solana_kit_transaction_confirmation** (60 tests):
+
+- `createRecentSignatureConfirmationPromiseFactory` with dual-pronged subscription + one-shot query
+- `createBlockHeightExceedencePromiseFactory` monitoring slot notifications for block height tracking
+- `createNonceInvalidationPromiseFactory` detecting durable nonce advancement
+- `getTimeoutPromise` with commitment-based timeouts (30s processed, 60s confirmed/finalized)
+- `raceStrategies` core strategy racing with safe future handling
+- `waitForRecentTransactionConfirmation` high-level blockhash-based confirmation
+- `waitForDurableNonceTransactionConfirmation` high-level nonce-based confirmation
+- `waitForRecentTransactionConfirmationUntilTimeout` (deprecated) timeout-based fallback
+- Dependency injection pattern for RPC functions to keep dependencies minimal
+
+---
+
+## solana_kit_transaction_messages
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for program and transaction planning packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement transaction messages package ported from `@solana/transaction-messages`.
+
+**solana_kit_transaction_messages** (99 tests):
+
+- `TransactionMessage` immutable class with `TransactionVersion` (legacy, v0), fee payer, lifetime constraint, and instruction management
+- `LifetimeConstraint` sealed class with `BlockhashLifetimeConstraint` and `DurableNonceLifetimeConstraint` subtypes
+- Transaction message creation, fee payer setting, and instruction append/prepend
+- Blockhash lifetime: validation (`isTransactionMessageWithBlockhashLifetime`), assertion, and setter
+- Durable nonce lifetime: validation, assertion, and setter with automatic `AdvanceNonceAccount` instruction management
+- `compileTransactionMessage`: compiles high-level messages to wire-format `CompiledTransactionMessage`
+- Account compilation with correct ordering (fee payer, writable signers, readonly signers, writable non-signers, readonly non-signers)
+- Address lookup table compression (`compressTransactionMessageUsingAddressLookupTables`)
+- Message decompilation (`decompileTransactionMessage`) to reconstruct from compiled format
+- Full codec suite: transaction version, header (3-byte), instruction, address table lookup, and complete message encoder/decoder
+
+**solana_kit_instructions** (patch):
+
+- `AccountLookupMeta` now extends `AccountMeta` for type compatibility in instruction accounts lists
+
+---
+
+## solana_kit_transactions
+
+### 0.2.0 (2026-02-27)
+
+#### Breaking Changes
+
+##### Initial Release
+
+The initial release of all libraries.
+
+#### Fixes
+
+- Align knope package scopes, update workspace maintenance dependencies, and apply lint/format cleanup updates across touched packages.
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Document docs: add mdt workspace docs tooling and shared README sections.
+- Document docs: add real examples for program and transaction planning packages.
+- Use `workspace: true` for all internal package dependencies and replace melos with native Dart workspace commands.
+
+### 0.1.0 (2026-02-21)
+
+#### Notes
+
+- First 0.1.0 release of this package.
+
+### 0.0.2 (2026-02-21)
+
+#### Features
+
+##### Initial scaffold for 18 core packages forming the foundation and middle layers of
+
+the Solana Kit dependency graph. Each package has its pubspec.yaml with correct
+workspace dependencies, shared analysis_options.yaml, and an empty barrel export
+file ready for implementation.
+
+Package groups scaffolded:
+
+- **Crypto & Identity**: addresses (base58), keys (Ed25519), signers (interfaces)
+- **Codecs**: core interfaces, numbers, strings, data structures, umbrella re-export
+- **Utilities**: functional (pipe/compose), options (Rust-like Option codec),
+  fast_stable_stringify, subscribable (reactive patterns)
+- **Transaction Building**: instructions, instruction_plans, transaction_messages,
+  transactions (compilation & signing)
+- **Other**: offchain_messages, test_matchers
+
+##### Implement transactions package ported from `@solana/transactions`.
+
+**solana_kit_transactions** (64 tests):
+
+- `Transaction` class with `messageBytes` (Uint8List) and `signatures` (Map<Address, SignatureBytes?>) fields
+- `TransactionWithLifetime` with blockhash and durable nonce lifetime constraints
+- `compileTransaction` to compile a TransactionMessage into a Transaction with signature slots and lifetime constraint
+- `partiallySignTransaction` and `signTransaction` for async Ed25519 signing with key pairs
+- `getSignatureFromTransaction` to extract fee payer signature
+- `isFullySignedTransaction` / `assertIsFullySignedTransaction` for signature completeness checks
+- Transaction size calculations with 1232-byte limit enforcement
+- `isSendableTransaction` / `assertIsSendableTransaction` combining signature and size checks
+- Wire format encoding with `getBase64EncodedWireTransaction`
+- Full transaction codec: signatures encoder (shortU16 prefix + 64 bytes each), transaction encoder/decoder
+
+#### Fixes
+
+##### Enhance core SDK packages with additional functionality and tests.
+
+- **Codecs core**: Enhanced `addCodecSizePrefix` with additional functionality
+- **Codecs data structures**: Array codec improvements
+- **Codecs numbers**: `shortU16` codec enhancements
+- **Codecs strings**: UTF-8 codec improvements
+- **Keys**: Key pair and signatures enhancements
+- **RPC transport**: HTTP transport and WebSocket channel updates
+- **Transactions**: Transaction codec enhancements
+
+---
+
+## codama_renderers_solana_kit_dart
+
+### 0.1.1 (2026-02-27)
+
+#### Features
+
+- Add `codama-renderers-dart` - a Codama renderer that generates Dart code targeting the solana_kit SDK from Codama IDL definitions.
+
+#### Fixes
+
+- Document chore: add nixpkgs tooling and stabilize coverage command.
+- Document ci: add publish and release workflow automation.
+- Document ci: enforce changesets for package modifications.
+- Fix code generation bugs: AccountRole enum names, cross-type imports, transformDecoder callback signature, template literal interpolation, missing codec imports, and nullable field assertions. Add comprehensive e2e test suite with snapshot tests, JS comparison tests, and Dart validation.
+
+### 0.1.0
+
+#### Features
+
+- Initial release of `codama-renderers-dart`
+- Generate Dart code from Codama IDL targeting the solana_kit SDK
+- Support for accounts, instructions, defined types, errors, PDAs, and programs
+- Type manifest visitor mapping all Codama type nodes to Dart types and codecs
+- Fragment-based code generation with automatic import tracking
+- Comprehensive test suite with 261 tests
+
+## 0.3.1 (2026-03-30)
+
+### Fixes
+
+- Improve documentation reuse and guidance across the workspace by expanding shared `mdt` blocks, projecting them into synchronized Dart library doc comments, adding analyzable doc-comment snippet tests, and broadening accounts/signers/codecs examples in the docs site and package READMEs.
+- Fix release tooling portability on macOS/BSD userlands by removing the Bash 4 `mapfile` dependency and GNU-awk-specific parsing from the workspace sync scripts. Also fix the mobile wallet adapter example and Android compile check to use local workspace overrides so CI can resolve unreleased `solana_kit_*` package versions correctly.
+
+## 0.3.0 (2026-03-29)
+
+### Breaking Changes
+
+#### Sync with upstream @solana/kit v6.1.0 → v6.5.0 changes.
+
+#### solana_kit_errors (minor)
+
+- Add new error codes: `failedToSendTransaction`, `failedToSendTransactions`, `signerWalletAccountCannotSignTransaction`, 8 new transaction error codes (`transactionCannotEncodeWithEmptyMessageBytes`, `transactionCannotDecodeEmptyTransactionBytes`, `transactionVersionZeroMustBeEncodedWithSignaturesFirst`, `transactionSignatureCountTooHighForTransactionBytes`, `transactionInvalidConfigMaskPriorityFeeBits`, `transactionInvalidNonceAccountIndex`, `transactionInvalidConfigValueKind`, `transactionInstructionHeadersPayloadsMismatch`), and 2 new codec error codes (`codecsInvalidPatternMatchValue`, `codecsInvalidPatternMatchBytes`).
+- Capitalize all instruction error messages for consistency.
+- Fix BORSH_IO_ERROR: remove stale `$encodedData` interpolation.
+- Fix `instructionErrorUnknown` message: was empty, now `'The instruction failed with the error: $errorName'`.
+- Update `transactionVersionNumberNotSupported` max supported version from 0 to 1.
+
+#### solana_kit_codecs_data_structures (minor)
+
+- Add `getPatternMatchEncoder`, `getPatternMatchDecoder`, and `getPatternMatchCodec` functions for selecting codecs based on value/byte pattern matching.
+
+#### solana_kit_codecs_core (patch)
+
+- Fix `containsBytes` to avoid unnecessary array slicing/cloning when using negative offsets matching the array length.
+- Fix `addDecoderSentinel` to handle negative offsets properly.
+
+#### solana_kit_codecs_strings (patch)
+
+- Fix `getBaseXDecoder` and `getBaseXResliceDecoder` to avoid unnecessary array slicing/cloning when using negative offsets matching the array length.
+
+#### solana_kit_signers (minor)
+
+- Add `partiallySignTransactionWithSigners`, `signTransactionWithSigners`, and `signAndSendTransactionWithSigners` functions that accept a set of signers and a compiled `Transaction` directly, without requiring signers to be embedded in a transaction message.
+- Add `assertContainsResolvableTransactionSendingSigner` to validate that a set of signers contains an unambiguously resolvable sending signer.
+- The existing transaction message helpers now delegate to these new functions internally.
+
+#### solana_kit_instruction_plans (patch)
+
+- Add `abortReason` and `transactionPlanResult` to the `instructionPlansFailedToExecuteTransactionPlan` error context.
+
+### Features
+
+#### Add additive next-step ergonomics and maintenance tooling without breaking the existing lower-level APIs.
+
+- Add `Rpc.getEpochInfo()` to the typed RPC convenience surface.
+- Add polling-based `waitForTransactionConfirmation(...)` and `sendAndConfirmTransaction(...)` helpers for signed transactions.
+- Add local benchmark scripts for address validation, transaction wire encoding, and BigInt-aware JSON parsing.
+- Add an upstream compatibility metadata check script plus CI coverage.
+- Complete Codama PDA rendering by generating `getProgramDerivedAddress(...)` calls instead of `UnimplementedError` placeholders.
+- Expand READMEs and docs to explain the new workflows.
+
+#### Improve Android native wallet adapter parity and add CI Android compile verification.
+
+- Replace wallet stub behavior with walletlib-backed scenario/request handling.
+- Add Digital Asset Links native bridge and Dart API surface.
+- Harden local/remote transport behavior and request routing.
+- Add a CI check that compiles a temporary Flutter Android app using the plugin.
+
+#### Add a typed RPC convenience facade for common Solana JSON-RPC calls.
+
+- Add generic `Rpc.request<TResponse>()` support in `solana_kit_rpc_spec`.
+- Add `SolanaRpcMethods` extension helpers in `solana_kit_rpc` for common RPC methods.
+- Expand docs with reusable markdown templates (`mdt`) and reusable Dart doc templates.
+
+#### Harden transaction lifetime typing and compilation invariants.
+
+- Replace `TransactionLifetimeConstraint` `Object` alias with a sealed hierarchy.
+- Remove the internal `_NoLifetime` fallback from `compileTransaction`.
+- Enforce lifetime presence during compile and throw explicit `SolanaErrorCode`
+  values for invalid lifetime states.
+- Expand transaction compile tests for missing and invalid lifetime paths.
+
+#### Add Phase 4 advanced ergonomics and performance improvements.
+
+- Add typed union helpers (`Union2`/`Union3`) with strongly-typed codec helpers.
+- Add optional isolate-backed BigInt JSON decoding via
+  `parseJsonWithBigIntsAsync` and Solana HTTP transport flags.
+- Add typed error-domain helpers layered over numeric `SolanaErrorCode`
+  values (`SolanaErrorDomain`, domain classifiers, and extensions).
+- Expand README/API docs and shared mdt templates for these features.
+
+### Fixes
+
+- Move renderer Node tooling to a root pnpm workspace, pin workspace pnpm/node versions, and run renderer publish through workspace-aware pnpm commands.
+- Update all upstream `@solana/kit` version references from 6.1.0 to 6.5.0 in documentation and README files.
+- Improve workspace documentation with richer getting-started guides, stronger docs-site coverage, expanded package library doc comments, and deeper mdt integration for shared README and site content.
+- Remove duplicate renderer devDependencies that are already provided by the root workspace, and update renderer scripts to invoke shared tools via `pnpm exec`.
+- Replace internal workspace dependency constraints with explicit semver constraints (for example, `^0.2.0`) across workspace packages, and remove the workspace dependency lint enforcement added previously.
+- Add comprehensive tests across multiple packages to increase code coverage toward 90%.
+
+#### Add explicit repository and package homepage metadata to package pubspecs, and
+
+consolidate package changelogs into a single root `CHANGELOG.md`.
+
+#### Fix workspace lint analysis scope so CI no longer fails when scanning
+
+non-workspace docs sources and nested example app files.
+
+#### Add fluent extension methods to `TransactionMessage` for Dart-idiomatic
+
+composition without requiring function + `.pipe` style.
+
+- `withFeePayer`
+- `withBlockhashLifetime`
+- `withDurableNonceLifetime`
+- `appendInstruction` / `appendInstructions`
+- `prependInstruction` / `prependInstructions`
+
+#### Port `@solana/kit` `v6.1.0` parity updates for predicate codecs and
+
+transaction encoding behavior.
+
+- Add `getPredicateEncoder`, `getPredicateDecoder`, and `getPredicateCodec`.
+- Add v1 message-first transaction encoding with fixed-length signatures.
+- Add transaction malformed message bytes error parity (`5663023`).
+
+#### Fixes CI regressions in the mobile wallet adapter example and Android compile check.
+
+- Renames the Android example package namespace to satisfy `ktlint` package-name rules.
+- Hardens `check-mobile-wallet-adapter-android-compile.sh` to use local workspace `solana_kit_*` dependency overrides during temp-app resolution.
+
+## 0.2.1 (2026-02-28)
+
+### Fixes
+
+#### chore: add ktlint to devenv format/lint and CI lint pipeline
+
+##72 by @ifiokjr
+
+### Summary
+
+Adds Kotlin lint/format support to the repository `devenv` workflows and ensures CI runs those checks.
+
+### What changed
+
+- Added `ktlint` to `packages` in `devenv.nix`.
+- Updated `fix:format` to run Kotlin formatting via:
+  - `ktlint --relative --format` on tracked `*.kt` and `*.kts` files.
+- Added a new `lint:kotlin` script that runs:
+  - `ktlint --relative` on tracked Kotlin files.
+- Updated `lint:all` to include `lint:kotlin` so Kotlin linting is part of the standard CI lint command.
+- Updated CI lint step label to explicitly indicate ktlint is included.
+
+### Why
+
+The repo already linted and formatted Dart/Markdown/JSON/YAML paths, but Kotlin files were not covered by the same developer and CI workflows. This aligns Kotlin quality gates with the rest of the codebase.
+
+### Validation
+
+- `dprint check .github/workflows/ci.yml`
+- Structural verification of `devenv.nix` script blocks for:
+  - `fix:format`
+  - `lint:kotlin`
+  - `lint:all`
+
+#### chore: add flutter example app for mobile wallet adapter manual testing
+
+### Summary
+
+Adds a runnable Flutter Android example app under `packages/solana_kit_mobile_wallet_adapter/example/` for manual Mobile Wallet Adapter (MWA) testing on device/emulator.
+
+### What changed
+
+- Scaffolded a full Flutter Android example app for `solana_kit_mobile_wallet_adapter`.
+- Added manual-test UI flows for:
+  - Wallet endpoint detection
+  - `authorize`
+  - `getCapabilities`
+  - `signMessages`
+  - `deauthorize`
+- Added `example/README.md` with setup instructions and mock wallet installation guidance based on Solana Mobile docs.
+- Updated package README with a dedicated "Manual testing app" section linking to the new example and setup guide.
+
+### Why
+
+The previous example was not a runnable Flutter app for end-to-end manual testing with real/emulated wallets. This adds a practical test harness for validating adapter behavior in development.
+
+### Validation
+
+- `flutter pub get` (example app)
+- `flutter analyze` (example app)
+- `flutter test` (example app)
+- `devenv shell -- docs:check`

--- a/packages/solana_kit_address_lookup_table/LICENSE
+++ b/packages/solana_kit_address_lookup_table/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ifiok Jr.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/solana_kit_address_lookup_table/README.md
+++ b/packages/solana_kit_address_lookup_table/README.md
@@ -1,0 +1,73 @@
+# solana_kit_address_lookup_table
+
+Address Lookup Table program client for the
+[Solana Kit](https://github.com/openbudgetfun/solana_kit) Dart SDK.
+
+Provides instruction builders, codecs, account decoders, and parsers for the
+Address Lookup Table program, which manages lookup tables used in versioned
+(v0) transactions.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_address_lookup_table: ^0.3.1
+```
+
+## Usage
+
+```dart
+import 'package:solana_kit_address_lookup_table/solana_kit_address_lookup_table.dart';
+
+// Create a new address lookup table
+final createIx = getCreateLookupTableInstruction(
+  address: tableAddress,
+  authority: authorityAddress,
+  payer: payerAddress,
+  recentSlot: BigInt.from(slot),
+  bump: bump,
+);
+
+// Extend a lookup table with new addresses
+final extendIx = getExtendLookupTableInstruction(
+  address: tableAddress,
+  authority: authorityAddress,
+  payer: payerAddress,
+  addresses: [addr1, addr2],
+);
+
+// Deactivate a lookup table
+final deactivateIx = getDeactivateLookupTableInstruction(
+  address: tableAddress,
+  authority: authorityAddress,
+);
+
+// Close a deactivated lookup table
+final closeIx = getCloseLookupTableInstruction(
+  address: tableAddress,
+  authority: authorityAddress,
+  recipient: recipientAddress,
+);
+```
+
+## Instructions
+
+| Instruction             | Discriminator | Description                                              |
+| ----------------------- | ------------- | -------------------------------------------------------- |
+| `CreateLookupTable`     | 0             | Create a new address lookup table.                       |
+| `FreezeLookupTable`     | 1             | Freeze a lookup table, preventing further modifications. |
+| `ExtendLookupTable`     | 2             | Extend a lookup table with additional addresses.         |
+| `DeactivateLookupTable` | 3             | Deactivate a lookup table before closing.                |
+| `CloseLookupTable`      | 4             | Close a deactivated lookup table and reclaim lamports.   |
+
+## Account
+
+The `AddressLookupTableAccountData` decoder can decode on-chain account data
+for lookup tables, including the authority, deactivation slot, and stored
+addresses.
+
+## Upstream reference
+
+Generated layer mirrors
+[solana-program/address-lookup-table](https://github.com/solana-program/address-lookup-table)
+at `js@v0.11.0`.

--- a/packages/solana_kit_address_lookup_table/lib/solana_kit_address_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/solana_kit_address_lookup_table.dart
@@ -1,0 +1,31 @@
+/// Address Lookup Table program client for the Solana Kit Dart SDK.
+///
+/// Provides instruction builders, codecs, account decoders, and parsers for the
+/// Address Lookup Table program, which manages lookup tables used in versioned
+/// (v0) transactions.
+///
+/// ## Quick start
+///
+/// ```dart
+/// import 'package:solana_kit_address_lookup_table/solana_kit_address_lookup_table.dart';
+///
+/// // Create a lookup table
+/// final createIx = getCreateLookupTableInstruction(
+///   address: tableAddress,
+///   authority: authorityAddress,
+///   payer: payerAddress,
+///   recentSlot: BigInt.from(slot),
+///   bump: bump,
+/// );
+///
+/// // Extend a lookup table with new addresses
+/// final extendIx = getExtendLookupTableInstruction(
+///   address: tableAddress,
+///   authority: authorityAddress,
+///   payer: payerAddress,
+///   addresses: [addr1, addr2],
+/// );
+/// ```
+library;
+
+export 'src/generated/address_lookup_table.dart';

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/accounts/accounts.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/accounts/accounts.dart
@@ -1,0 +1,3 @@
+// ignore_for_file: public_member_api_docs
+
+export 'address_lookup_table.dart';

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/accounts/address_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/accounts/address_lookup_table.dart
@@ -1,0 +1,163 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+/// Account discriminator for the AddressLookupTable account.
+const addressLookupTableAccountDiscriminator = 1;
+
+/// Decoded data for an AddressLookupTable account.
+@immutable
+class AddressLookupTableAccountData {
+  /// Creates [AddressLookupTableAccountData].
+  const AddressLookupTableAccountData({
+    required this.deactivationSlot,
+    required this.lastExtendedSlot,
+    required this.lastExtendedSlotStartIndex,
+    required this.addresses,
+    this.discriminator = addressLookupTableAccountDiscriminator,
+    this.authority,
+  });
+
+  /// The account discriminator (u32).
+  final int discriminator;
+
+  /// The slot at which this table was deactivated, or `u64::MAX` if active.
+  final BigInt deactivationSlot;
+
+  /// The most recent slot in which the table was extended.
+  final BigInt lastExtendedSlot;
+
+  /// The start index of addresses added in the last extension.
+  final int lastExtendedSlotStartIndex;
+
+  /// The authority that can modify this table, or `null` if frozen.
+  final Address? authority;
+
+  /// The addresses stored in this lookup table.
+  final List<Address> addresses;
+
+  @override
+  String toString() =>
+      'AddressLookupTableAccountData('
+      'discriminator: $discriminator, '
+      'deactivationSlot: $deactivationSlot, '
+      'lastExtendedSlot: $lastExtendedSlot, '
+      'lastExtendedSlotStartIndex: $lastExtendedSlotStartIndex, '
+      'authority: $authority, '
+      'addresses: $addresses)';
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! AddressLookupTableAccountData) return false;
+    if (other.discriminator != discriminator) return false;
+    if (other.deactivationSlot != deactivationSlot) return false;
+    if (other.lastExtendedSlot != lastExtendedSlot) return false;
+    if (other.lastExtendedSlotStartIndex != lastExtendedSlotStartIndex) {
+      return false;
+    }
+    if (other.authority != authority) return false;
+    if (other.addresses.length != addresses.length) return false;
+    for (var i = 0; i < addresses.length; i++) {
+      if (other.addresses[i] != addresses[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    discriminator,
+    deactivationSlot,
+    lastExtendedSlot,
+    lastExtendedSlotStartIndex,
+    authority,
+    Object.hashAll(addresses),
+  );
+}
+
+/// Returns the encoder for [AddressLookupTableAccountData].
+Encoder<AddressLookupTableAccountData>
+getAddressLookupTableAccountDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+    ('deactivationSlot', getU64Encoder()),
+    ('lastExtendedSlot', getU64Encoder()),
+    ('lastExtendedSlotStartIndex', getU8Encoder()),
+    (
+      'authority',
+      getNullableEncoder<Address>(
+        getAddressEncoder(),
+        noneValue: const ZeroesNoneValue(),
+      ),
+    ),
+    ('padding', getU16Encoder()),
+    (
+      'addresses',
+      getArrayEncoder(getAddressEncoder(), size: const RemainderArraySize()),
+    ),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (AddressLookupTableAccountData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+      'deactivationSlot': value.deactivationSlot,
+      'lastExtendedSlot': value.lastExtendedSlot,
+      'lastExtendedSlotStartIndex': value.lastExtendedSlotStartIndex,
+      'authority': value.authority,
+      'padding': 0,
+      'addresses': value.addresses,
+    },
+  );
+}
+
+/// Returns the decoder for [AddressLookupTableAccountData].
+Decoder<AddressLookupTableAccountData>
+getAddressLookupTableAccountDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+    ('deactivationSlot', getU64Decoder()),
+    ('lastExtendedSlot', getU64Decoder()),
+    ('lastExtendedSlotStartIndex', getU8Decoder()),
+    (
+      'authority',
+      getNullableDecoder<Address>(
+        getAddressDecoder(),
+        noneValue: const ZeroesNoneValue(),
+      ),
+    ),
+    ('padding', getU16Decoder()),
+    (
+      'addresses',
+      getArrayDecoder(getAddressDecoder(), size: const RemainderArraySize()),
+    ),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, Uint8List bytes, int offset) =>
+        AddressLookupTableAccountData(
+          discriminator: map['discriminator']! as int,
+          deactivationSlot: map['deactivationSlot']! as BigInt,
+          lastExtendedSlot: map['lastExtendedSlot']! as BigInt,
+          lastExtendedSlotStartIndex:
+              map['lastExtendedSlotStartIndex']! as int,
+          authority: map['authority'] as Address?,
+          addresses: (map['addresses']! as List).cast<Address>(),
+        ),
+  );
+}
+
+/// Returns the codec for [AddressLookupTableAccountData].
+Codec<AddressLookupTableAccountData, AddressLookupTableAccountData>
+getAddressLookupTableAccountDataCodec() {
+  return combineCodec(
+    getAddressLookupTableAccountDataEncoder(),
+    getAddressLookupTableAccountDataDecoder(),
+  );
+}

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/accounts/address_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/accounts/address_lookup_table.dart
@@ -3,10 +3,14 @@
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/constants.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/pdas/address_lookup_table.dart';
 import 'package:solana_kit_addresses/solana_kit_addresses.dart';
 import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
 import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
 import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_rpc_spec/solana_kit_rpc_spec.dart';
 
 /// Account discriminator for the AddressLookupTable account.
 const addressLookupTableAccountDiscriminator = 1;
@@ -145,8 +149,7 @@ getAddressLookupTableAccountDataDecoder() {
           discriminator: map['discriminator']! as int,
           deactivationSlot: map['deactivationSlot']! as BigInt,
           lastExtendedSlot: map['lastExtendedSlot']! as BigInt,
-          lastExtendedSlotStartIndex:
-              map['lastExtendedSlotStartIndex']! as int,
+          lastExtendedSlotStartIndex: map['lastExtendedSlotStartIndex']! as int,
           authority: map['authority'] as Address?,
           addresses: (map['addresses']! as List).cast<Address>(),
         ),
@@ -160,4 +163,81 @@ getAddressLookupTableAccountDataCodec() {
     getAddressLookupTableAccountDataEncoder(),
     getAddressLookupTableAccountDataDecoder(),
   );
+}
+
+/// Decodes an encoded Address Lookup Table account.
+Account<AddressLookupTableAccountData> decodeAddressLookupTable(
+  EncodedAccount encodedAccount,
+) {
+  return decodeAccount(
+    encodedAccount,
+    getAddressLookupTableAccountDataDecoder(),
+  );
+}
+
+/// Fetches and decodes an Address Lookup Table account.
+Future<Account<AddressLookupTableAccountData>> fetchAddressLookupTable(
+  Rpc rpc,
+  Address address, {
+  FetchAccountConfig? config,
+}) async {
+  final maybeAccount = await fetchMaybeAddressLookupTable(
+    rpc,
+    address,
+    config: config,
+  );
+  assertAccountExists(maybeAccount);
+  return (maybeAccount as ExistingAccount<AddressLookupTableAccountData>)
+      .account;
+}
+
+/// Fetches and decodes an Address Lookup Table account if it exists.
+Future<MaybeAccount<AddressLookupTableAccountData>>
+fetchMaybeAddressLookupTable(
+  Rpc rpc,
+  Address address, {
+  FetchAccountConfig? config,
+}) async {
+  final maybeEncodedAccount = await fetchEncodedAccount(
+    rpc,
+    address,
+    config: config,
+  );
+  return decodeMaybeAccount(
+    maybeEncodedAccount,
+    getAddressLookupTableAccountDataDecoder(),
+  );
+}
+
+/// Derives, fetches, and decodes an Address Lookup Table account.
+Future<Account<AddressLookupTableAccountData>> fetchAddressLookupTableFromSeeds(
+  Rpc rpc, {
+  required Address authority,
+  required BigInt recentSlot,
+  Address programAddress = addressLookupTableProgramAddress,
+  FetchAccountConfig? config,
+}) async {
+  final (address, _) = await findAddressLookupTablePda(
+    authority: authority,
+    recentSlot: recentSlot,
+    programAddress: programAddress,
+  );
+  return fetchAddressLookupTable(rpc, address, config: config);
+}
+
+/// Derives, fetches, and decodes an Address Lookup Table account if it exists.
+Future<MaybeAccount<AddressLookupTableAccountData>>
+fetchMaybeAddressLookupTableFromSeeds(
+  Rpc rpc, {
+  required Address authority,
+  required BigInt recentSlot,
+  Address programAddress = addressLookupTableProgramAddress,
+  FetchAccountConfig? config,
+}) async {
+  final (address, _) = await findAddressLookupTablePda(
+    authority: authority,
+    recentSlot: recentSlot,
+    programAddress: programAddress,
+  );
+  return fetchMaybeAddressLookupTable(rpc, address, config: config);
 }

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/address_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/address_lookup_table.dart
@@ -1,0 +1,10 @@
+// ignore_for_file: public_member_api_docs
+
+/// Generated Address Lookup Table program layer.
+///
+/// Mirrors the upstream Codama-generated TypeScript at `js@v0.11.0`.
+library;
+
+export 'accounts/accounts.dart';
+export 'instructions/instructions.dart';
+export 'programs/programs.dart';

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/address_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/address_lookup_table.dart
@@ -6,5 +6,7 @@
 library;
 
 export 'accounts/accounts.dart';
+export 'constants.dart';
 export 'instructions/instructions.dart';
+export 'pdas/pdas.dart';
 export 'programs/programs.dart';

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/constants.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/constants.dart
@@ -1,0 +1,28 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+/// The canonical Address Lookup Table program address.
+const addressLookupTableProgramAddress = Address(
+  'AddressLookupTab1e1111111111111111111111111',
+);
+
+/// Number of bytes used by the lookup table metadata before stored addresses.
+const addressLookupTableMetaSize = 56;
+
+/// Number of bytes used by the lookup table metadata before stored addresses.
+const lookupTableMetaSize = addressLookupTableMetaSize;
+
+/// Maximum number of addresses an Address Lookup Table can hold.
+const addressLookupTableMaxAddresses = 256;
+
+/// Maximum number of addresses an Address Lookup Table can hold.
+const lookupTableMaxAddresses = addressLookupTableMaxAddresses;
+
+/// Maximum number of addresses that fit in one extend instruction before the
+/// lookup table reaches [addressLookupTableMaxAddresses].
+const addressLookupTableMaxNewAddresses = addressLookupTableMaxAddresses;
+
+/// Maximum number of addresses that fit in one extend instruction before the
+/// lookup table reaches [lookupTableMaxAddresses].
+const lookupTableMaxNewAddresses = addressLookupTableMaxNewAddresses;

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/close_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/close_lookup_table.dart
@@ -1,0 +1,109 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/programs/address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+/// Discriminator value for the CloseLookupTable instruction.
+const closeLookupTableDiscriminator = 4;
+
+/// Data for the CloseLookupTable instruction.
+@immutable
+class CloseLookupTableInstructionData {
+  /// Creates [CloseLookupTableInstructionData].
+  const CloseLookupTableInstructionData({
+    this.discriminator = closeLookupTableDiscriminator,
+  });
+
+  /// The instruction discriminator (u32).
+  final int discriminator;
+
+  @override
+  String toString() =>
+      'CloseLookupTableInstructionData(discriminator: $discriminator)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is CloseLookupTableInstructionData &&
+      other.discriminator == discriminator;
+
+  @override
+  int get hashCode => discriminator.hashCode;
+}
+
+/// Returns the encoder for [CloseLookupTableInstructionData].
+Encoder<CloseLookupTableInstructionData>
+getCloseLookupTableInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (CloseLookupTableInstructionData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+    },
+  );
+}
+
+/// Returns the decoder for [CloseLookupTableInstructionData].
+Decoder<CloseLookupTableInstructionData>
+getCloseLookupTableInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, Uint8List bytes, int offset) =>
+        CloseLookupTableInstructionData(
+          discriminator: map['discriminator']! as int,
+        ),
+  );
+}
+
+/// Returns the codec for [CloseLookupTableInstructionData].
+Codec<CloseLookupTableInstructionData, CloseLookupTableInstructionData>
+getCloseLookupTableInstructionDataCodec() {
+  return combineCodec(
+    getCloseLookupTableInstructionDataEncoder(),
+    getCloseLookupTableInstructionDataDecoder(),
+  );
+}
+
+/// Creates a CloseLookupTable instruction.
+///
+/// Closes the deactivated lookup table at [address] and transfers reclaimed
+/// lamports to [recipient]. Only the [authority] can close the table.
+Instruction getCloseLookupTableInstruction({
+  required Address address,
+  required Address authority,
+  required Address recipient,
+  Address programAddress = addressLookupTableProgramAddress,
+}) {
+  const data = CloseLookupTableInstructionData();
+  return Instruction(
+    programAddress: programAddress,
+    accounts: [
+      AccountMeta(address: address, role: AccountRole.writable),
+      AccountMeta(address: authority, role: AccountRole.readonlySigner),
+      AccountMeta(address: recipient, role: AccountRole.writable),
+    ],
+    data: getCloseLookupTableInstructionDataEncoder().encode(data),
+  );
+}
+
+/// Parses a CloseLookupTable instruction from [instruction].
+CloseLookupTableInstructionData parseCloseLookupTableInstruction(
+  Instruction instruction,
+) {
+  return getCloseLookupTableInstructionDataDecoder().decode(
+    instruction.data!,
+  );
+}

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/create_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/create_lookup_table.dart
@@ -1,0 +1,140 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/programs/address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+/// Discriminator value for the CreateLookupTable instruction.
+const createLookupTableDiscriminator = 0;
+
+/// Data for the CreateLookupTable instruction.
+@immutable
+class CreateLookupTableInstructionData {
+  /// Creates [CreateLookupTableInstructionData].
+  const CreateLookupTableInstructionData({
+    required this.recentSlot,
+    required this.bump,
+    this.discriminator = createLookupTableDiscriminator,
+  });
+
+  /// The instruction discriminator (u32).
+  final int discriminator;
+
+  /// A recent slot used to derive the lookup table address.
+  final BigInt recentSlot;
+
+  /// The PDA bump seed for the lookup table address.
+  final int bump;
+
+  @override
+  String toString() =>
+      'CreateLookupTableInstructionData('
+      'discriminator: $discriminator, '
+      'recentSlot: $recentSlot, '
+      'bump: $bump)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is CreateLookupTableInstructionData &&
+      other.discriminator == discriminator &&
+      other.recentSlot == recentSlot &&
+      other.bump == bump;
+
+  @override
+  int get hashCode => Object.hash(discriminator, recentSlot, bump);
+}
+
+/// Returns the encoder for [CreateLookupTableInstructionData].
+Encoder<CreateLookupTableInstructionData>
+getCreateLookupTableInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+    ('recentSlot', getU64Encoder()),
+    ('bump', getU8Encoder()),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (CreateLookupTableInstructionData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+      'recentSlot': value.recentSlot,
+      'bump': value.bump,
+    },
+  );
+}
+
+/// Returns the decoder for [CreateLookupTableInstructionData].
+Decoder<CreateLookupTableInstructionData>
+getCreateLookupTableInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+    ('recentSlot', getU64Decoder()),
+    ('bump', getU8Decoder()),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, Uint8List bytes, int offset) =>
+        CreateLookupTableInstructionData(
+          discriminator: map['discriminator']! as int,
+          recentSlot: map['recentSlot']! as BigInt,
+          bump: map['bump']! as int,
+        ),
+  );
+}
+
+/// Returns the codec for [CreateLookupTableInstructionData].
+Codec<CreateLookupTableInstructionData, CreateLookupTableInstructionData>
+getCreateLookupTableInstructionDataCodec() {
+  return combineCodec(
+    getCreateLookupTableInstructionDataEncoder(),
+    getCreateLookupTableInstructionDataDecoder(),
+  );
+}
+
+/// Creates a CreateLookupTable instruction.
+///
+/// Creates a new address lookup table derived from [authority] and
+/// [recentSlot]. The [address] parameter is the PDA of the new table and
+/// [bump] is its bump seed.
+Instruction getCreateLookupTableInstruction({
+  required Address address,
+  required Address authority,
+  required Address payer,
+  required BigInt recentSlot,
+  required int bump,
+  Address programAddress = addressLookupTableProgramAddress,
+  Address systemProgramAddress = const Address(
+    '11111111111111111111111111111111',
+  ),
+}) {
+  final data = CreateLookupTableInstructionData(
+    recentSlot: recentSlot,
+    bump: bump,
+  );
+  return Instruction(
+    programAddress: programAddress,
+    accounts: [
+      AccountMeta(address: address, role: AccountRole.writable),
+      AccountMeta(address: authority, role: AccountRole.readonly),
+      AccountMeta(address: payer, role: AccountRole.writableSigner),
+      AccountMeta(address: systemProgramAddress, role: AccountRole.readonly),
+    ],
+    data: getCreateLookupTableInstructionDataEncoder().encode(data),
+  );
+}
+
+/// Parses a CreateLookupTable instruction from [instruction].
+CreateLookupTableInstructionData parseCreateLookupTableInstruction(
+  Instruction instruction,
+) {
+  return getCreateLookupTableInstructionDataDecoder().decode(
+    instruction.data!,
+  );
+}

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/create_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/create_lookup_table.dart
@@ -3,6 +3,7 @@
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/pdas/address_lookup_table.dart';
 import 'package:solana_kit_address_lookup_table/src/generated/programs/address_lookup_table.dart';
 import 'package:solana_kit_addresses/solana_kit_addresses.dart';
 import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
@@ -130,11 +131,35 @@ Instruction getCreateLookupTableInstruction({
   );
 }
 
+/// Creates a CreateLookupTable instruction after deriving its PDA and bump.
+Future<Instruction> getCreateLookupTableInstructionWithPda({
+  required Address authority,
+  required Address payer,
+  required BigInt recentSlot,
+  Address programAddress = addressLookupTableProgramAddress,
+  Address systemProgramAddress = const Address(
+    '11111111111111111111111111111111',
+  ),
+}) async {
+  final (address, bump) = await findAddressLookupTablePda(
+    authority: authority,
+    recentSlot: recentSlot,
+    programAddress: programAddress,
+  );
+  return getCreateLookupTableInstruction(
+    address: address,
+    authority: authority,
+    payer: payer,
+    recentSlot: recentSlot,
+    bump: bump,
+    programAddress: programAddress,
+    systemProgramAddress: systemProgramAddress,
+  );
+}
+
 /// Parses a CreateLookupTable instruction from [instruction].
 CreateLookupTableInstructionData parseCreateLookupTableInstruction(
   Instruction instruction,
 ) {
-  return getCreateLookupTableInstructionDataDecoder().decode(
-    instruction.data!,
-  );
+  return getCreateLookupTableInstructionDataDecoder().decode(instruction.data!);
 }

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/deactivate_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/deactivate_lookup_table.dart
@@ -1,0 +1,108 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/programs/address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+/// Discriminator value for the DeactivateLookupTable instruction.
+const deactivateLookupTableDiscriminator = 3;
+
+/// Data for the DeactivateLookupTable instruction.
+@immutable
+class DeactivateLookupTableInstructionData {
+  /// Creates [DeactivateLookupTableInstructionData].
+  const DeactivateLookupTableInstructionData({
+    this.discriminator = deactivateLookupTableDiscriminator,
+  });
+
+  /// The instruction discriminator (u32).
+  final int discriminator;
+
+  @override
+  String toString() =>
+      'DeactivateLookupTableInstructionData(discriminator: $discriminator)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is DeactivateLookupTableInstructionData &&
+      other.discriminator == discriminator;
+
+  @override
+  int get hashCode => discriminator.hashCode;
+}
+
+/// Returns the encoder for [DeactivateLookupTableInstructionData].
+Encoder<DeactivateLookupTableInstructionData>
+getDeactivateLookupTableInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (DeactivateLookupTableInstructionData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+    },
+  );
+}
+
+/// Returns the decoder for [DeactivateLookupTableInstructionData].
+Decoder<DeactivateLookupTableInstructionData>
+getDeactivateLookupTableInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, Uint8List bytes, int offset) =>
+        DeactivateLookupTableInstructionData(
+          discriminator: map['discriminator']! as int,
+        ),
+  );
+}
+
+/// Returns the codec for [DeactivateLookupTableInstructionData].
+Codec<DeactivateLookupTableInstructionData,
+    DeactivateLookupTableInstructionData>
+getDeactivateLookupTableInstructionDataCodec() {
+  return combineCodec(
+    getDeactivateLookupTableInstructionDataEncoder(),
+    getDeactivateLookupTableInstructionDataDecoder(),
+  );
+}
+
+/// Creates a DeactivateLookupTable instruction.
+///
+/// Deactivates the lookup table at [address]. Only the [authority] can
+/// deactivate. The table must be deactivated before it can be closed.
+Instruction getDeactivateLookupTableInstruction({
+  required Address address,
+  required Address authority,
+  Address programAddress = addressLookupTableProgramAddress,
+}) {
+  const data = DeactivateLookupTableInstructionData();
+  return Instruction(
+    programAddress: programAddress,
+    accounts: [
+      AccountMeta(address: address, role: AccountRole.writable),
+      AccountMeta(address: authority, role: AccountRole.readonlySigner),
+    ],
+    data: getDeactivateLookupTableInstructionDataEncoder().encode(data),
+  );
+}
+
+/// Parses a DeactivateLookupTable instruction from [instruction].
+DeactivateLookupTableInstructionData parseDeactivateLookupTableInstruction(
+  Instruction instruction,
+) {
+  return getDeactivateLookupTableInstructionDataDecoder().decode(
+    instruction.data!,
+  );
+}

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/extend_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/extend_lookup_table.dart
@@ -1,0 +1,153 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/programs/address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+/// Discriminator value for the ExtendLookupTable instruction.
+const extendLookupTableDiscriminator = 2;
+
+/// Data for the ExtendLookupTable instruction.
+@immutable
+class ExtendLookupTableInstructionData {
+  /// Creates [ExtendLookupTableInstructionData].
+  const ExtendLookupTableInstructionData({
+    required this.addresses,
+    this.discriminator = extendLookupTableDiscriminator,
+  });
+
+  /// The instruction discriminator (u32).
+  final int discriminator;
+
+  /// The list of addresses to add to the lookup table.
+  final List<Address> addresses;
+
+  @override
+  String toString() =>
+      'ExtendLookupTableInstructionData('
+      'discriminator: $discriminator, '
+      'addresses: $addresses)';
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! ExtendLookupTableInstructionData) return false;
+    if (other.discriminator != discriminator) return false;
+    if (other.addresses.length != addresses.length) return false;
+    for (var i = 0; i < addresses.length; i++) {
+      if (other.addresses[i] != addresses[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(discriminator, Object.hashAll(addresses));
+}
+
+/// Returns the encoder for [ExtendLookupTableInstructionData].
+///
+/// Wire format: u32 LE discriminator + u64 LE address count + N * 32-byte
+/// addresses.
+Encoder<ExtendLookupTableInstructionData>
+getExtendLookupTableInstructionDataEncoder() {
+  final discEncoder = getU32Encoder();
+  final countEncoder = getU64Encoder();
+  final addrEncoder = getAddressEncoder();
+
+  return VariableSizeEncoder<ExtendLookupTableInstructionData>(
+    getSizeFromValue: (value) =>
+        4 + 8 + value.addresses.length * 32, // disc + count + addrs
+    write: (value, bytes, offset) {
+      var pos = offset;
+      pos = discEncoder.write(value.discriminator, bytes, pos);
+      pos = countEncoder.write(
+        BigInt.from(value.addresses.length),
+        bytes,
+        pos,
+      );
+      for (final addr in value.addresses) {
+        pos = addrEncoder.write(addr, bytes, pos);
+      }
+      return pos;
+    },
+  );
+}
+
+/// Returns the decoder for [ExtendLookupTableInstructionData].
+Decoder<ExtendLookupTableInstructionData>
+getExtendLookupTableInstructionDataDecoder() {
+  final discDecoder = getU32Decoder();
+  final countDecoder = getU64Decoder();
+  final addrDecoder = getAddressDecoder();
+
+  return VariableSizeDecoder<ExtendLookupTableInstructionData>(
+    read: (bytes, offset) {
+      var pos = offset;
+      final (discriminator, nextPos1) = discDecoder.read(bytes, pos);
+      pos = nextPos1;
+      final (count, nextPos2) = countDecoder.read(bytes, pos);
+      pos = nextPos2;
+      final numAddresses = count.toInt();
+      final addresses = <Address>[];
+      for (var i = 0; i < numAddresses; i++) {
+        final (addr, nextPos) = addrDecoder.read(bytes, pos);
+        pos = nextPos;
+        addresses.add(addr);
+      }
+      return (
+        ExtendLookupTableInstructionData(
+          discriminator: discriminator,
+          addresses: addresses,
+        ),
+        pos,
+      );
+    },
+  );
+}
+
+/// Returns the codec for [ExtendLookupTableInstructionData].
+Codec<ExtendLookupTableInstructionData, ExtendLookupTableInstructionData>
+getExtendLookupTableInstructionDataCodec() {
+  return combineCodec(
+    getExtendLookupTableInstructionDataEncoder(),
+    getExtendLookupTableInstructionDataDecoder(),
+  );
+}
+
+/// Creates an ExtendLookupTable instruction.
+///
+/// Extends the lookup table at [address] with the given [addresses].
+/// The [authority] must sign, and [payer] pays for the reallocation.
+Instruction getExtendLookupTableInstruction({
+  required Address address,
+  required Address authority,
+  required Address payer,
+  required List<Address> addresses,
+  Address programAddress = addressLookupTableProgramAddress,
+  Address systemProgramAddress = const Address(
+    '11111111111111111111111111111111',
+  ),
+}) {
+  final data = ExtendLookupTableInstructionData(addresses: addresses);
+  return Instruction(
+    programAddress: programAddress,
+    accounts: [
+      AccountMeta(address: address, role: AccountRole.writable),
+      AccountMeta(address: authority, role: AccountRole.readonlySigner),
+      AccountMeta(address: payer, role: AccountRole.writableSigner),
+      AccountMeta(address: systemProgramAddress, role: AccountRole.readonly),
+    ],
+    data: getExtendLookupTableInstructionDataEncoder().encode(data),
+  );
+}
+
+/// Parses an ExtendLookupTable instruction from [instruction].
+ExtendLookupTableInstructionData parseExtendLookupTableInstruction(
+  Instruction instruction,
+) {
+  return getExtendLookupTableInstructionDataDecoder().decode(
+    instruction.data!,
+  );
+}

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/freeze_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/freeze_lookup_table.dart
@@ -1,0 +1,107 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/programs/address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+/// Discriminator value for the FreezeLookupTable instruction.
+const freezeLookupTableDiscriminator = 1;
+
+/// Data for the FreezeLookupTable instruction.
+@immutable
+class FreezeLookupTableInstructionData {
+  /// Creates [FreezeLookupTableInstructionData].
+  const FreezeLookupTableInstructionData({
+    this.discriminator = freezeLookupTableDiscriminator,
+  });
+
+  /// The instruction discriminator (u32).
+  final int discriminator;
+
+  @override
+  String toString() =>
+      'FreezeLookupTableInstructionData(discriminator: $discriminator)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is FreezeLookupTableInstructionData &&
+      other.discriminator == discriminator;
+
+  @override
+  int get hashCode => discriminator.hashCode;
+}
+
+/// Returns the encoder for [FreezeLookupTableInstructionData].
+Encoder<FreezeLookupTableInstructionData>
+getFreezeLookupTableInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (FreezeLookupTableInstructionData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+    },
+  );
+}
+
+/// Returns the decoder for [FreezeLookupTableInstructionData].
+Decoder<FreezeLookupTableInstructionData>
+getFreezeLookupTableInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, Uint8List bytes, int offset) =>
+        FreezeLookupTableInstructionData(
+          discriminator: map['discriminator']! as int,
+        ),
+  );
+}
+
+/// Returns the codec for [FreezeLookupTableInstructionData].
+Codec<FreezeLookupTableInstructionData, FreezeLookupTableInstructionData>
+getFreezeLookupTableInstructionDataCodec() {
+  return combineCodec(
+    getFreezeLookupTableInstructionDataEncoder(),
+    getFreezeLookupTableInstructionDataDecoder(),
+  );
+}
+
+/// Creates a FreezeLookupTable instruction.
+///
+/// Freezes the lookup table at [address], preventing further modifications.
+/// Only the [authority] can freeze the table.
+Instruction getFreezeLookupTableInstruction({
+  required Address address,
+  required Address authority,
+  Address programAddress = addressLookupTableProgramAddress,
+}) {
+  const data = FreezeLookupTableInstructionData();
+  return Instruction(
+    programAddress: programAddress,
+    accounts: [
+      AccountMeta(address: address, role: AccountRole.writable),
+      AccountMeta(address: authority, role: AccountRole.readonlySigner),
+    ],
+    data: getFreezeLookupTableInstructionDataEncoder().encode(data),
+  );
+}
+
+/// Parses a FreezeLookupTable instruction from [instruction].
+FreezeLookupTableInstructionData parseFreezeLookupTableInstruction(
+  Instruction instruction,
+) {
+  return getFreezeLookupTableInstructionDataDecoder().decode(
+    instruction.data!,
+  );
+}

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/instructions.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/instructions.dart
@@ -1,0 +1,7 @@
+// ignore_for_file: public_member_api_docs
+
+export 'close_lookup_table.dart';
+export 'create_lookup_table.dart';
+export 'deactivate_lookup_table.dart';
+export 'extend_lookup_table.dart';
+export 'freeze_lookup_table.dart';

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/pdas/address_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/pdas/address_lookup_table.dart
@@ -1,0 +1,29 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:solana_kit_address_lookup_table/src/generated/constants.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+/// Finds the Address Lookup Table PDA for [authority] and [recentSlot].
+///
+/// The PDA seeds match the upstream program client: the authority public key
+/// bytes followed by the recent slot encoded as little-endian `u64`.
+Future<ProgramDerivedAddress> findAddressLookupTablePda({
+  required Address authority,
+  required BigInt recentSlot,
+  Address programAddress = addressLookupTableProgramAddress,
+}) {
+  return getProgramDerivedAddress(
+    programAddress: programAddress,
+    seeds: [
+      getPublicKeyFromAddress(authority),
+      _encodeRecentSlotSeed(recentSlot),
+    ],
+  );
+}
+
+Uint8List _encodeRecentSlotSeed(BigInt recentSlot) {
+  return getU64Encoder().encode(recentSlot);
+}

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/pdas/pdas.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/pdas/pdas.dart
@@ -1,0 +1,3 @@
+// ignore_for_file: public_member_api_docs
+
+export 'address_lookup_table.dart';

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/programs/address_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/programs/address_lookup_table.dart
@@ -1,0 +1,175 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:solana_kit_address_lookup_table/src/generated/instructions/close_lookup_table.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/instructions/create_lookup_table.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/instructions/deactivate_lookup_table.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/instructions/extend_lookup_table.dart';
+import 'package:solana_kit_address_lookup_table/src/generated/instructions/freeze_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+/// The canonical Address Lookup Table program address.
+const addressLookupTableProgramAddress = Address(
+  'AddressLookupTab1e1111111111111111111111111',
+);
+
+/// Known instruction types for the Address Lookup Table program.
+enum AddressLookupTableInstruction {
+  /// Create a new address lookup table (discriminator 0).
+  createLookupTable,
+
+  /// Freeze a lookup table, preventing further modifications (discriminator 1).
+  freezeLookupTable,
+
+  /// Extend a lookup table with additional addresses (discriminator 2).
+  extendLookupTable,
+
+  /// Deactivate a lookup table (discriminator 3).
+  deactivateLookupTable,
+
+  /// Close a deactivated lookup table and reclaim lamports (discriminator 4).
+  closeLookupTable,
+}
+
+/// Identifies the instruction type from raw instruction [data].
+///
+/// Returns the matching [AddressLookupTableInstruction] variant based on the
+/// u32 LE discriminator at offset 0.
+///
+/// Throws [ArgumentError] if the discriminator is unrecognized.
+AddressLookupTableInstruction identifyAddressLookupTableInstruction(
+  Uint8List data,
+) {
+  if (data.length < 4) {
+    throw ArgumentError('Instruction data too short for u32 discriminator');
+  }
+  final discriminator =
+      data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
+  return switch (discriminator) {
+    0 => AddressLookupTableInstruction.createLookupTable,
+    1 => AddressLookupTableInstruction.freezeLookupTable,
+    2 => AddressLookupTableInstruction.extendLookupTable,
+    3 => AddressLookupTableInstruction.deactivateLookupTable,
+    4 => AddressLookupTableInstruction.closeLookupTable,
+    _ => throw ArgumentError(
+      'Unrecognized Address Lookup Table instruction discriminator: '
+      '$discriminator',
+    ),
+  };
+}
+
+/// A parsed Address Lookup Table instruction with its identified type and data.
+sealed class ParsedAddressLookupTableInstruction {
+  /// The instruction type.
+  AddressLookupTableInstruction get instructionType;
+}
+
+/// A parsed [AddressLookupTableInstruction.createLookupTable] instruction.
+class ParsedCreateLookupTable
+    implements ParsedAddressLookupTableInstruction {
+  /// Creates a [ParsedCreateLookupTable].
+  const ParsedCreateLookupTable(this.data);
+
+  @override
+  AddressLookupTableInstruction get instructionType =>
+      AddressLookupTableInstruction.createLookupTable;
+
+  /// The decoded instruction data.
+  final CreateLookupTableInstructionData data;
+}
+
+/// A parsed [AddressLookupTableInstruction.freezeLookupTable] instruction.
+class ParsedFreezeLookupTable
+    implements ParsedAddressLookupTableInstruction {
+  /// Creates a [ParsedFreezeLookupTable].
+  const ParsedFreezeLookupTable(this.data);
+
+  @override
+  AddressLookupTableInstruction get instructionType =>
+      AddressLookupTableInstruction.freezeLookupTable;
+
+  /// The decoded instruction data.
+  final FreezeLookupTableInstructionData data;
+}
+
+/// A parsed [AddressLookupTableInstruction.extendLookupTable] instruction.
+class ParsedExtendLookupTable
+    implements ParsedAddressLookupTableInstruction {
+  /// Creates a [ParsedExtendLookupTable].
+  const ParsedExtendLookupTable(this.data);
+
+  @override
+  AddressLookupTableInstruction get instructionType =>
+      AddressLookupTableInstruction.extendLookupTable;
+
+  /// The decoded instruction data.
+  final ExtendLookupTableInstructionData data;
+}
+
+/// A parsed [AddressLookupTableInstruction.deactivateLookupTable] instruction.
+class ParsedDeactivateLookupTable
+    implements ParsedAddressLookupTableInstruction {
+  /// Creates a [ParsedDeactivateLookupTable].
+  const ParsedDeactivateLookupTable(this.data);
+
+  @override
+  AddressLookupTableInstruction get instructionType =>
+      AddressLookupTableInstruction.deactivateLookupTable;
+
+  /// The decoded instruction data.
+  final DeactivateLookupTableInstructionData data;
+}
+
+/// A parsed [AddressLookupTableInstruction.closeLookupTable] instruction.
+class ParsedCloseLookupTable
+    implements ParsedAddressLookupTableInstruction {
+  /// Creates a [ParsedCloseLookupTable].
+  const ParsedCloseLookupTable(this.data);
+
+  @override
+  AddressLookupTableInstruction get instructionType =>
+      AddressLookupTableInstruction.closeLookupTable;
+
+  /// The decoded instruction data.
+  final CloseLookupTableInstructionData data;
+}
+
+/// Parses an Address Lookup Table [instruction] into a typed
+/// [ParsedAddressLookupTableInstruction].
+///
+/// Throws [ArgumentError] if the instruction cannot be identified.
+ParsedAddressLookupTableInstruction parseAddressLookupTableInstruction(
+  Instruction instruction,
+) {
+  final data = instruction.data;
+  if (data == null || data.length < 4) {
+    throw ArgumentError('Instruction has no data or data too short');
+  }
+
+  final type = identifyAddressLookupTableInstruction(data);
+
+  return switch (type) {
+    AddressLookupTableInstruction.createLookupTable =>
+      ParsedCreateLookupTable(
+        getCreateLookupTableInstructionDataDecoder().decode(data),
+      ),
+    AddressLookupTableInstruction.freezeLookupTable =>
+      ParsedFreezeLookupTable(
+        getFreezeLookupTableInstructionDataDecoder().decode(data),
+      ),
+    AddressLookupTableInstruction.extendLookupTable =>
+      ParsedExtendLookupTable(
+        getExtendLookupTableInstructionDataDecoder().decode(data),
+      ),
+    AddressLookupTableInstruction.deactivateLookupTable =>
+      ParsedDeactivateLookupTable(
+        getDeactivateLookupTableInstructionDataDecoder().decode(data),
+      ),
+    AddressLookupTableInstruction.closeLookupTable =>
+      ParsedCloseLookupTable(
+        getCloseLookupTableInstructionDataDecoder().decode(data),
+      ),
+  };
+}

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/programs/address_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/programs/address_lookup_table.dart
@@ -2,6 +2,7 @@
 
 import 'dart:typed_data';
 
+import 'package:solana_kit_address_lookup_table/src/generated/constants.dart';
 import 'package:solana_kit_address_lookup_table/src/generated/instructions/close_lookup_table.dart';
 import 'package:solana_kit_address_lookup_table/src/generated/instructions/create_lookup_table.dart';
 import 'package:solana_kit_address_lookup_table/src/generated/instructions/deactivate_lookup_table.dart';
@@ -10,10 +11,32 @@ import 'package:solana_kit_address_lookup_table/src/generated/instructions/freez
 import 'package:solana_kit_addresses/solana_kit_addresses.dart';
 import 'package:solana_kit_instructions/solana_kit_instructions.dart';
 
-/// The canonical Address Lookup Table program address.
-const addressLookupTableProgramAddress = Address(
-  'AddressLookupTab1e1111111111111111111111111',
-);
+export 'package:solana_kit_address_lookup_table/src/generated/constants.dart';
+
+/// Number of bytes added by a CreateLookupTable instruction.
+const createLookupTableInstructionByteDelta = lookupTableMetaSize;
+
+/// Number of bytes added by an ExtendLookupTable instruction for [addresses].
+int getExtendLookupTableInstructionByteDelta(List<Address> addresses) {
+  return addresses.length * 32;
+}
+
+/// Address Lookup Table byte-delta metadata for instructions.
+extension AddressLookupTableInstructionByteDelta on Instruction {
+  /// Returns the byte delta for create and extend instructions, if known.
+  int? get byteDelta {
+    if (programAddress != addressLookupTableProgramAddress || data == null) {
+      return null;
+    }
+    final parsedInstruction = parseAddressLookupTableInstruction(this);
+    return switch (parsedInstruction) {
+      ParsedCreateLookupTable() => createLookupTableInstructionByteDelta,
+      ParsedExtendLookupTable(:final data) =>
+        getExtendLookupTableInstructionByteDelta(data.addresses),
+      _ => null,
+    };
+  }
+}
 
 /// Known instruction types for the Address Lookup Table program.
 enum AddressLookupTableInstruction {
@@ -67,8 +90,7 @@ sealed class ParsedAddressLookupTableInstruction {
 }
 
 /// A parsed [AddressLookupTableInstruction.createLookupTable] instruction.
-class ParsedCreateLookupTable
-    implements ParsedAddressLookupTableInstruction {
+class ParsedCreateLookupTable implements ParsedAddressLookupTableInstruction {
   /// Creates a [ParsedCreateLookupTable].
   const ParsedCreateLookupTable(this.data);
 
@@ -81,8 +103,7 @@ class ParsedCreateLookupTable
 }
 
 /// A parsed [AddressLookupTableInstruction.freezeLookupTable] instruction.
-class ParsedFreezeLookupTable
-    implements ParsedAddressLookupTableInstruction {
+class ParsedFreezeLookupTable implements ParsedAddressLookupTableInstruction {
   /// Creates a [ParsedFreezeLookupTable].
   const ParsedFreezeLookupTable(this.data);
 
@@ -95,8 +116,7 @@ class ParsedFreezeLookupTable
 }
 
 /// A parsed [AddressLookupTableInstruction.extendLookupTable] instruction.
-class ParsedExtendLookupTable
-    implements ParsedAddressLookupTableInstruction {
+class ParsedExtendLookupTable implements ParsedAddressLookupTableInstruction {
   /// Creates a [ParsedExtendLookupTable].
   const ParsedExtendLookupTable(this.data);
 
@@ -123,8 +143,7 @@ class ParsedDeactivateLookupTable
 }
 
 /// A parsed [AddressLookupTableInstruction.closeLookupTable] instruction.
-class ParsedCloseLookupTable
-    implements ParsedAddressLookupTableInstruction {
+class ParsedCloseLookupTable implements ParsedAddressLookupTableInstruction {
   /// Creates a [ParsedCloseLookupTable].
   const ParsedCloseLookupTable(this.data);
 
@@ -151,25 +170,21 @@ ParsedAddressLookupTableInstruction parseAddressLookupTableInstruction(
   final type = identifyAddressLookupTableInstruction(data);
 
   return switch (type) {
-    AddressLookupTableInstruction.createLookupTable =>
-      ParsedCreateLookupTable(
-        getCreateLookupTableInstructionDataDecoder().decode(data),
-      ),
-    AddressLookupTableInstruction.freezeLookupTable =>
-      ParsedFreezeLookupTable(
-        getFreezeLookupTableInstructionDataDecoder().decode(data),
-      ),
-    AddressLookupTableInstruction.extendLookupTable =>
-      ParsedExtendLookupTable(
-        getExtendLookupTableInstructionDataDecoder().decode(data),
-      ),
+    AddressLookupTableInstruction.createLookupTable => ParsedCreateLookupTable(
+      getCreateLookupTableInstructionDataDecoder().decode(data),
+    ),
+    AddressLookupTableInstruction.freezeLookupTable => ParsedFreezeLookupTable(
+      getFreezeLookupTableInstructionDataDecoder().decode(data),
+    ),
+    AddressLookupTableInstruction.extendLookupTable => ParsedExtendLookupTable(
+      getExtendLookupTableInstructionDataDecoder().decode(data),
+    ),
     AddressLookupTableInstruction.deactivateLookupTable =>
       ParsedDeactivateLookupTable(
         getDeactivateLookupTableInstructionDataDecoder().decode(data),
       ),
-    AddressLookupTableInstruction.closeLookupTable =>
-      ParsedCloseLookupTable(
-        getCloseLookupTableInstructionDataDecoder().decode(data),
-      ),
+    AddressLookupTableInstruction.closeLookupTable => ParsedCloseLookupTable(
+      getCloseLookupTableInstructionDataDecoder().decode(data),
+    ),
   };
 }

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/programs/programs.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/programs/programs.dart
@@ -1,0 +1,3 @@
+// ignore_for_file: public_member_api_docs
+
+export 'address_lookup_table.dart';

--- a/packages/solana_kit_address_lookup_table/pubspec.yaml
+++ b/packages/solana_kit_address_lookup_table/pubspec.yaml
@@ -1,0 +1,22 @@
+name: solana_kit_address_lookup_table
+description: Address Lookup Table program client for the Solana Kit Dart SDK.
+version: 0.3.1
+repository: https://github.com/openbudgetfun/solana_kit
+homepage: https://openbudgetfun.github.io/solana_kit/
+
+environment:
+  sdk: ^3.10.1
+
+resolution: workspace
+
+dependencies:
+  meta: ^1.16.0
+  solana_kit_addresses: ^0.3.1
+  solana_kit_codecs_core: ^0.3.1
+  solana_kit_codecs_data_structures: ^0.3.1
+  solana_kit_codecs_numbers: ^0.3.1
+  solana_kit_instructions: ^0.3.1
+
+dev_dependencies:
+  solana_kit_lints: ^0.3.1
+  test: ^1.25.0

--- a/packages/solana_kit_address_lookup_table/pubspec.yaml
+++ b/packages/solana_kit_address_lookup_table/pubspec.yaml
@@ -11,12 +11,15 @@ resolution: workspace
 
 dependencies:
   meta: ^1.16.0
+  solana_kit_accounts: ^0.4.0
   solana_kit_addresses: ^0.4.0
   solana_kit_codecs_core: ^0.4.0
   solana_kit_codecs_data_structures: ^0.4.0
   solana_kit_codecs_numbers: ^0.4.0
   solana_kit_instructions: ^0.4.0
+  solana_kit_rpc_spec: ^0.4.0
 
 dev_dependencies:
   solana_kit_lints: ^0.4.0
+  solana_kit_rpc_types: ^0.4.0
   test: ^1.25.0

--- a/packages/solana_kit_address_lookup_table/pubspec.yaml
+++ b/packages/solana_kit_address_lookup_table/pubspec.yaml
@@ -11,12 +11,12 @@ resolution: workspace
 
 dependencies:
   meta: ^1.16.0
-  solana_kit_addresses: ^0.3.1
-  solana_kit_codecs_core: ^0.3.1
-  solana_kit_codecs_data_structures: ^0.3.1
-  solana_kit_codecs_numbers: ^0.3.1
-  solana_kit_instructions: ^0.3.1
+  solana_kit_addresses: ^0.4.0
+  solana_kit_codecs_core: ^0.4.0
+  solana_kit_codecs_data_structures: ^0.4.0
+  solana_kit_codecs_numbers: ^0.4.0
+  solana_kit_instructions: ^0.4.0
 
 dev_dependencies:
-  solana_kit_lints: ^0.3.1
+  solana_kit_lints: ^0.4.0
   test: ^1.25.0

--- a/packages/solana_kit_address_lookup_table/test/account_test.dart
+++ b/packages/solana_kit_address_lookup_table/test/account_test.dart
@@ -1,0 +1,149 @@
+import 'package:solana_kit_address_lookup_table/solana_kit_address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AddressLookupTableAccountData', () {
+    test('encode/decode round-trips with authority', () {
+      const authority = Address('Auth111111111111111111111111111111111111111');
+      const addr1 = Address('11111111111111111111111111111111');
+      const addr2 = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+
+      final original = AddressLookupTableAccountData(
+        deactivationSlot: BigInt.parse('18446744073709551615'), // u64::MAX
+        lastExtendedSlot: BigInt.from(42),
+        lastExtendedSlotStartIndex: 0,
+        authority: authority,
+        addresses: const [addr1, addr2],
+      );
+
+      final codec = getAddressLookupTableAccountDataCodec();
+      final encoded = codec.encode(original);
+      final decoded = codec.decode(encoded);
+      expect(decoded, equals(original));
+      expect(
+        decoded.discriminator,
+        equals(addressLookupTableAccountDiscriminator),
+      );
+      expect(decoded.authority, equals(authority));
+      expect(decoded.addresses, hasLength(2));
+      expect(decoded.addresses[0], equals(addr1));
+      expect(decoded.addresses[1], equals(addr2));
+    });
+
+    test('encode/decode round-trips without authority (frozen)', () {
+      final original = AddressLookupTableAccountData(
+        deactivationSlot: BigInt.parse('18446744073709551615'),
+        lastExtendedSlot: BigInt.from(100),
+        lastExtendedSlotStartIndex: 5,
+        addresses: const [],
+      );
+
+      final codec = getAddressLookupTableAccountDataCodec();
+      final encoded = codec.encode(original);
+      final decoded = codec.decode(encoded);
+      expect(decoded, equals(original));
+      expect(decoded.authority, isNull);
+      expect(decoded.addresses, isEmpty);
+    });
+
+    test('header is 56 bytes without addresses', () {
+      final encoder = getAddressLookupTableAccountDataEncoder();
+      final bytes = encoder.encode(
+        AddressLookupTableAccountData(
+          deactivationSlot: BigInt.zero,
+          lastExtendedSlot: BigInt.zero,
+          lastExtendedSlotStartIndex: 0,
+          addresses: const [],
+        ),
+      );
+      // u32(4) + u64(8) + u64(8) + u8(1) + option(33) + padding(2) = 56
+      expect(bytes.length, equals(56));
+    });
+
+    test('each address adds 32 bytes', () {
+      const addr = Address('11111111111111111111111111111111');
+      final encoder = getAddressLookupTableAccountDataEncoder();
+      final bytesEmpty = encoder.encode(
+        AddressLookupTableAccountData(
+          deactivationSlot: BigInt.zero,
+          lastExtendedSlot: BigInt.zero,
+          lastExtendedSlotStartIndex: 0,
+          addresses: const [],
+        ),
+      );
+      final bytesOne = encoder.encode(
+        AddressLookupTableAccountData(
+          deactivationSlot: BigInt.zero,
+          lastExtendedSlot: BigInt.zero,
+          lastExtendedSlotStartIndex: 0,
+          addresses: const [addr],
+        ),
+      );
+      final bytesTwo = encoder.encode(
+        AddressLookupTableAccountData(
+          deactivationSlot: BigInt.zero,
+          lastExtendedSlot: BigInt.zero,
+          lastExtendedSlotStartIndex: 0,
+          addresses: const [addr, addr],
+        ),
+      );
+      expect(bytesOne.length - bytesEmpty.length, equals(32));
+      expect(bytesTwo.length - bytesOne.length, equals(32));
+    });
+
+    test('discriminator is 1 at offset 0', () {
+      final encoder = getAddressLookupTableAccountDataEncoder();
+      final bytes = encoder.encode(
+        AddressLookupTableAccountData(
+          deactivationSlot: BigInt.zero,
+          lastExtendedSlot: BigInt.zero,
+          lastExtendedSlotStartIndex: 0,
+          addresses: const [],
+        ),
+      );
+      // u32 LE: 1
+      expect(bytes[0], equals(1));
+      expect(bytes[1], equals(0));
+      expect(bytes[2], equals(0));
+      expect(bytes[3], equals(0));
+    });
+
+    test('value equality', () {
+      final a = AddressLookupTableAccountData(
+        deactivationSlot: BigInt.from(100),
+        lastExtendedSlot: BigInt.from(50),
+        lastExtendedSlotStartIndex: 3,
+        addresses: const [],
+      );
+      final b = AddressLookupTableAccountData(
+        deactivationSlot: BigInt.from(100),
+        lastExtendedSlot: BigInt.from(50),
+        lastExtendedSlotStartIndex: 3,
+        addresses: const [],
+      );
+      final c = AddressLookupTableAccountData(
+        deactivationSlot: BigInt.from(200),
+        lastExtendedSlot: BigInt.from(50),
+        lastExtendedSlotStartIndex: 3,
+        addresses: const [],
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes field values', () {
+      final data = AddressLookupTableAccountData(
+        deactivationSlot: BigInt.from(42),
+        lastExtendedSlot: BigInt.from(10),
+        lastExtendedSlotStartIndex: 0,
+        addresses: const [],
+      );
+      final str = data.toString();
+      expect(str, contains('deactivationSlot: 42'));
+      expect(str, contains('lastExtendedSlot: 10'));
+      expect(str, contains('discriminator: 1'));
+    });
+  });
+}

--- a/packages/solana_kit_address_lookup_table/test/account_test.dart
+++ b/packages/solana_kit_address_lookup_table/test/account_test.dart
@@ -1,5 +1,7 @@
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
 import 'package:solana_kit_address_lookup_table/solana_kit_address_lookup_table.dart';
 import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_rpc_types/solana_kit_rpc_types.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -59,6 +61,9 @@ void main() {
       );
       // u32(4) + u64(8) + u64(8) + u8(1) + option(33) + padding(2) = 56
       expect(bytes.length, equals(56));
+      expect(lookupTableMetaSize, equals(56));
+      expect(lookupTableMaxAddresses, equals(256));
+      expect(lookupTableMaxNewAddresses, equals(256));
     });
 
     test('each address adds 32 bytes', () {
@@ -131,6 +136,29 @@ void main() {
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
       expect(a, isNot(equals(c)));
+    });
+
+    test('decodeAddressLookupTable decodes encoded account data', () {
+      const address = Address('11111111111111111111111111111111');
+      final data = AddressLookupTableAccountData(
+        deactivationSlot: BigInt.zero,
+        lastExtendedSlot: BigInt.one,
+        lastExtendedSlotStartIndex: 0,
+        addresses: const [],
+      );
+      final encodedAccount = EncodedAccount(
+        address: address,
+        data: getAddressLookupTableAccountDataEncoder().encode(data),
+        executable: false,
+        lamports: lamports(BigInt.from(123)),
+        programAddress: addressLookupTableProgramAddress,
+        space: BigInt.from(lookupTableMetaSize),
+      );
+
+      final decoded = decodeAddressLookupTable(encodedAccount);
+
+      expect(decoded.address, equals(address));
+      expect(decoded.data, equals(data));
     });
 
     test('toString includes field values', () {

--- a/packages/solana_kit_address_lookup_table/test/barrel_test.dart
+++ b/packages/solana_kit_address_lookup_table/test/barrel_test.dart
@@ -1,0 +1,75 @@
+import 'package:solana_kit_address_lookup_table/solana_kit_address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('barrel exports', () {
+    test('program address is accessible', () {
+      expect(addressLookupTableProgramAddress.value, isNotEmpty);
+    });
+
+    test('instruction enum has all variants', () {
+      expect(AddressLookupTableInstruction.values, hasLength(5));
+    });
+
+    test('instruction builders are callable', () {
+      const addr = Address('11111111111111111111111111111111');
+
+      final createIx = getCreateLookupTableInstruction(
+        address: addr,
+        authority: addr,
+        payer: addr,
+        recentSlot: BigInt.one,
+        bump: 0,
+      );
+      expect(
+        createIx.programAddress,
+        equals(addressLookupTableProgramAddress),
+      );
+
+      final freezeIx = getFreezeLookupTableInstruction(
+        address: addr,
+        authority: addr,
+      );
+      expect(
+        freezeIx.programAddress,
+        equals(addressLookupTableProgramAddress),
+      );
+
+      final extendIx = getExtendLookupTableInstruction(
+        address: addr,
+        authority: addr,
+        payer: addr,
+        addresses: const [addr],
+      );
+      expect(
+        extendIx.programAddress,
+        equals(addressLookupTableProgramAddress),
+      );
+
+      final deactivateIx = getDeactivateLookupTableInstruction(
+        address: addr,
+        authority: addr,
+      );
+      expect(
+        deactivateIx.programAddress,
+        equals(addressLookupTableProgramAddress),
+      );
+
+      final closeIx = getCloseLookupTableInstruction(
+        address: addr,
+        authority: addr,
+        recipient: addr,
+      );
+      expect(
+        closeIx.programAddress,
+        equals(addressLookupTableProgramAddress),
+      );
+    });
+
+    test('account data codec is accessible', () {
+      final codec = getAddressLookupTableAccountDataCodec();
+      expect(codec, isNotNull);
+    });
+  });
+}

--- a/packages/solana_kit_address_lookup_table/test/instructions_test.dart
+++ b/packages/solana_kit_address_lookup_table/test/instructions_test.dart
@@ -1,0 +1,334 @@
+import 'package:solana_kit_address_lookup_table/solana_kit_address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CreateLookupTable', () {
+    test('encode/decode round-trips', () {
+      final original = CreateLookupTableInstructionData(
+        recentSlot: BigInt.from(123456789),
+        bump: 255,
+      );
+      final codec = getCreateLookupTableInstructionDataCodec();
+      final encoded = codec.encode(original);
+      final decoded = codec.decode(encoded);
+      expect(decoded, equals(original));
+      expect(decoded.discriminator, equals(createLookupTableDiscriminator));
+      expect(decoded.recentSlot, equals(BigInt.from(123456789)));
+      expect(decoded.bump, equals(255));
+    });
+
+    test('encodes discriminator 0 as u32 LE at offset 0', () {
+      final encoder = getCreateLookupTableInstructionDataEncoder();
+      final bytes = encoder.encode(
+        CreateLookupTableInstructionData(
+          recentSlot: BigInt.zero,
+          bump: 0,
+        ),
+      );
+      // u32 LE discriminator: 0x00 0x00 0x00 0x00
+      expect(bytes[0], equals(0));
+      expect(bytes[1], equals(0));
+      expect(bytes[2], equals(0));
+      expect(bytes[3], equals(0));
+    });
+
+    test('encodes recentSlot as little-endian u64', () {
+      final encoder = getCreateLookupTableInstructionDataEncoder();
+      final bytes = encoder.encode(
+        CreateLookupTableInstructionData(
+          recentSlot: BigInt.one,
+          bump: 0,
+        ),
+      );
+      // discriminator(4) + u64 LE(8) + bump(1) = 13
+      expect(bytes.length, equals(13));
+      expect(bytes[4], equals(1));
+      for (var i = 5; i < 12; i++) {
+        expect(bytes[i], equals(0));
+      }
+    });
+
+    test('instruction builder produces correct data and accounts', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+      const payer = Address('Payer11111111111111111111111111111111111111');
+
+      final ix = getCreateLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+        payer: payer,
+        recentSlot: BigInt.from(42),
+        bump: 254,
+      );
+      expect(ix.programAddress, equals(addressLookupTableProgramAddress));
+      expect(ix.accounts, hasLength(4));
+      expect(ix.accounts![0].address, equals(tableAddr));
+      expect(ix.accounts![1].address, equals(authority));
+      expect(ix.accounts![2].address, equals(payer));
+
+      final parsed = parseCreateLookupTableInstruction(ix);
+      expect(parsed.recentSlot, equals(BigInt.from(42)));
+      expect(parsed.bump, equals(254));
+      expect(parsed.discriminator, equals(0));
+    });
+
+    test('value equality', () {
+      final a = CreateLookupTableInstructionData(
+        recentSlot: BigInt.from(100),
+        bump: 1,
+      );
+      final b = CreateLookupTableInstructionData(
+        recentSlot: BigInt.from(100),
+        bump: 1,
+      );
+      final c = CreateLookupTableInstructionData(
+        recentSlot: BigInt.from(200),
+        bump: 1,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes field values', () {
+      final data = CreateLookupTableInstructionData(
+        recentSlot: BigInt.from(42),
+        bump: 7,
+      );
+      final str = data.toString();
+      expect(str, contains('recentSlot: 42'));
+      expect(str, contains('bump: 7'));
+      expect(str, contains('discriminator: 0'));
+    });
+  });
+
+  group('FreezeLookupTable', () {
+    test('encode/decode round-trips', () {
+      const original = FreezeLookupTableInstructionData();
+      final codec = getFreezeLookupTableInstructionDataCodec();
+      final encoded = codec.encode(original);
+      final decoded = codec.decode(encoded);
+      expect(decoded, equals(original));
+      expect(decoded.discriminator, equals(freezeLookupTableDiscriminator));
+    });
+
+    test('encodes discriminator 1 as u32 LE', () {
+      final encoder = getFreezeLookupTableInstructionDataEncoder();
+      final bytes = encoder.encode(const FreezeLookupTableInstructionData());
+      expect(bytes.length, equals(4));
+      expect(bytes[0], equals(1));
+      expect(bytes[1], equals(0));
+      expect(bytes[2], equals(0));
+      expect(bytes[3], equals(0));
+    });
+
+    test('instruction builder produces correct data and accounts', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+
+      final ix = getFreezeLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+      );
+      expect(ix.programAddress, equals(addressLookupTableProgramAddress));
+      expect(ix.accounts, hasLength(2));
+      expect(ix.accounts![0].address, equals(tableAddr));
+      expect(ix.accounts![1].address, equals(authority));
+
+      final parsed = parseFreezeLookupTableInstruction(ix);
+      expect(parsed.discriminator, equals(1));
+    });
+
+    test('value equality', () {
+      const a = FreezeLookupTableInstructionData();
+      const b = FreezeLookupTableInstructionData();
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('ExtendLookupTable', () {
+    test('encode/decode round-trips', () {
+      const addr1 = Address('11111111111111111111111111111111');
+      const addr2 = Address('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+      const original = ExtendLookupTableInstructionData(
+        addresses: [addr1, addr2],
+      );
+      final codec = getExtendLookupTableInstructionDataCodec();
+      final encoded = codec.encode(original);
+      final decoded = codec.decode(encoded);
+      expect(decoded, equals(original));
+      expect(decoded.discriminator, equals(extendLookupTableDiscriminator));
+      expect(decoded.addresses, hasLength(2));
+      expect(decoded.addresses[0], equals(addr1));
+      expect(decoded.addresses[1], equals(addr2));
+    });
+
+    test('encodes discriminator 2 as u32 LE', () {
+      final encoder = getExtendLookupTableInstructionDataEncoder();
+      final bytes = encoder.encode(
+        const ExtendLookupTableInstructionData(addresses: []),
+      );
+      expect(bytes[0], equals(2));
+      expect(bytes[1], equals(0));
+      expect(bytes[2], equals(0));
+      expect(bytes[3], equals(0));
+    });
+
+    test('encodes address count as u64 LE prefix', () {
+      const addr = Address('11111111111111111111111111111111');
+      final encoder = getExtendLookupTableInstructionDataEncoder();
+      final bytes = encoder.encode(
+        const ExtendLookupTableInstructionData(addresses: [addr, addr]),
+      );
+      // discriminator(4) + count u64(8) + 2 * address(32) = 76
+      expect(bytes.length, equals(76));
+      // count = 2 as u64 LE
+      expect(bytes[4], equals(2));
+      for (var i = 5; i < 12; i++) {
+        expect(bytes[i], equals(0));
+      }
+    });
+
+    test('instruction builder produces correct data and accounts', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+      const payer = Address('Payer11111111111111111111111111111111111111');
+      const addr1 = Address('11111111111111111111111111111111');
+
+      final ix = getExtendLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+        payer: payer,
+        addresses: [addr1],
+      );
+      expect(ix.programAddress, equals(addressLookupTableProgramAddress));
+      expect(ix.accounts, hasLength(4));
+      expect(ix.accounts![0].address, equals(tableAddr));
+      expect(ix.accounts![1].address, equals(authority));
+      expect(ix.accounts![2].address, equals(payer));
+
+      final parsed = parseExtendLookupTableInstruction(ix);
+      expect(parsed.addresses, hasLength(1));
+      expect(parsed.addresses[0], equals(addr1));
+    });
+
+    test('handles empty addresses list', () {
+      final codec = getExtendLookupTableInstructionDataCodec();
+      const data = ExtendLookupTableInstructionData(addresses: []);
+      final decoded = codec.decode(codec.encode(data));
+      expect(decoded.addresses, isEmpty);
+    });
+
+    test('value equality', () {
+      const addr = Address('11111111111111111111111111111111');
+      const a = ExtendLookupTableInstructionData(addresses: [addr]);
+      const b = ExtendLookupTableInstructionData(addresses: [addr]);
+      const c = ExtendLookupTableInstructionData(addresses: []);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+  });
+
+  group('DeactivateLookupTable', () {
+    test('encode/decode round-trips', () {
+      const original = DeactivateLookupTableInstructionData();
+      final codec = getDeactivateLookupTableInstructionDataCodec();
+      final encoded = codec.encode(original);
+      final decoded = codec.decode(encoded);
+      expect(decoded, equals(original));
+      expect(
+        decoded.discriminator,
+        equals(deactivateLookupTableDiscriminator),
+      );
+    });
+
+    test('encodes discriminator 3 as u32 LE', () {
+      final encoder = getDeactivateLookupTableInstructionDataEncoder();
+      final bytes = encoder.encode(
+        const DeactivateLookupTableInstructionData(),
+      );
+      expect(bytes.length, equals(4));
+      expect(bytes[0], equals(3));
+      expect(bytes[1], equals(0));
+      expect(bytes[2], equals(0));
+      expect(bytes[3], equals(0));
+    });
+
+    test('instruction builder produces correct data and accounts', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+
+      final ix = getDeactivateLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+      );
+      expect(ix.programAddress, equals(addressLookupTableProgramAddress));
+      expect(ix.accounts, hasLength(2));
+      expect(ix.accounts![0].address, equals(tableAddr));
+      expect(ix.accounts![1].address, equals(authority));
+
+      final parsed = parseDeactivateLookupTableInstruction(ix);
+      expect(parsed.discriminator, equals(3));
+    });
+
+    test('value equality', () {
+      const a = DeactivateLookupTableInstructionData();
+      const b = DeactivateLookupTableInstructionData();
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('CloseLookupTable', () {
+    test('encode/decode round-trips', () {
+      const original = CloseLookupTableInstructionData();
+      final codec = getCloseLookupTableInstructionDataCodec();
+      final encoded = codec.encode(original);
+      final decoded = codec.decode(encoded);
+      expect(decoded, equals(original));
+      expect(decoded.discriminator, equals(closeLookupTableDiscriminator));
+    });
+
+    test('encodes discriminator 4 as u32 LE', () {
+      final encoder = getCloseLookupTableInstructionDataEncoder();
+      final bytes = encoder.encode(
+        const CloseLookupTableInstructionData(),
+      );
+      expect(bytes.length, equals(4));
+      expect(bytes[0], equals(4));
+      expect(bytes[1], equals(0));
+      expect(bytes[2], equals(0));
+      expect(bytes[3], equals(0));
+    });
+
+    test('instruction builder produces correct data and accounts', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+      const recipient = Address('Recip11111111111111111111111111111111111111');
+
+      final ix = getCloseLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+        recipient: recipient,
+      );
+      expect(ix.programAddress, equals(addressLookupTableProgramAddress));
+      expect(ix.accounts, hasLength(3));
+      expect(ix.accounts![0].address, equals(tableAddr));
+      expect(ix.accounts![1].address, equals(authority));
+      expect(ix.accounts![2].address, equals(recipient));
+
+      final parsed = parseCloseLookupTableInstruction(ix);
+      expect(parsed.discriminator, equals(4));
+    });
+
+    test('value equality', () {
+      const a = CloseLookupTableInstructionData();
+      const b = CloseLookupTableInstructionData();
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/solana_kit_address_lookup_table/test/instructions_test.dart
+++ b/packages/solana_kit_address_lookup_table/test/instructions_test.dart
@@ -21,10 +21,7 @@ void main() {
     test('encodes discriminator 0 as u32 LE at offset 0', () {
       final encoder = getCreateLookupTableInstructionDataEncoder();
       final bytes = encoder.encode(
-        CreateLookupTableInstructionData(
-          recentSlot: BigInt.zero,
-          bump: 0,
-        ),
+        CreateLookupTableInstructionData(recentSlot: BigInt.zero, bump: 0),
       );
       // u32 LE discriminator: 0x00 0x00 0x00 0x00
       expect(bytes[0], equals(0));
@@ -36,10 +33,7 @@ void main() {
     test('encodes recentSlot as little-endian u64', () {
       final encoder = getCreateLookupTableInstructionDataEncoder();
       final bytes = encoder.encode(
-        CreateLookupTableInstructionData(
-          recentSlot: BigInt.one,
-          bump: 0,
-        ),
+        CreateLookupTableInstructionData(recentSlot: BigInt.one, bump: 0),
       );
       // discriminator(4) + u64 LE(8) + bump(1) = 13
       expect(bytes.length, equals(13));
@@ -146,6 +140,11 @@ void main() {
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
     });
+
+    test('toString includes discriminator', () {
+      const data = FreezeLookupTableInstructionData();
+      expect(data.toString(), contains('discriminator: 1'));
+    });
   });
 
   group('ExtendLookupTable', () {
@@ -230,6 +229,14 @@ void main() {
       expect(a.hashCode, equals(b.hashCode));
       expect(a, isNot(equals(c)));
     });
+
+    test('toString includes field values', () {
+      const addr = Address('11111111111111111111111111111111');
+      const data = ExtendLookupTableInstructionData(addresses: [addr]);
+      final str = data.toString();
+      expect(str, contains('discriminator: 2'));
+      expect(str, contains('addresses: [11111111111111111111111111111111]'));
+    });
   });
 
   group('DeactivateLookupTable', () {
@@ -239,10 +246,7 @@ void main() {
       final encoded = codec.encode(original);
       final decoded = codec.decode(encoded);
       expect(decoded, equals(original));
-      expect(
-        decoded.discriminator,
-        equals(deactivateLookupTableDiscriminator),
-      );
+      expect(decoded.discriminator, equals(deactivateLookupTableDiscriminator));
     });
 
     test('encodes discriminator 3 as u32 LE', () {
@@ -280,6 +284,11 @@ void main() {
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
     });
+
+    test('toString includes discriminator', () {
+      const data = DeactivateLookupTableInstructionData();
+      expect(data.toString(), contains('discriminator: 3'));
+    });
   });
 
   group('CloseLookupTable', () {
@@ -294,9 +303,7 @@ void main() {
 
     test('encodes discriminator 4 as u32 LE', () {
       final encoder = getCloseLookupTableInstructionDataEncoder();
-      final bytes = encoder.encode(
-        const CloseLookupTableInstructionData(),
-      );
+      final bytes = encoder.encode(const CloseLookupTableInstructionData());
       expect(bytes.length, equals(4));
       expect(bytes[0], equals(4));
       expect(bytes[1], equals(0));
@@ -329,6 +336,11 @@ void main() {
       const b = CloseLookupTableInstructionData();
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('toString includes discriminator', () {
+      const data = CloseLookupTableInstructionData();
+      expect(data.toString(), contains('discriminator: 4'));
     });
   });
 }

--- a/packages/solana_kit_address_lookup_table/test/instructions_test.dart
+++ b/packages/solana_kit_address_lookup_table/test/instructions_test.dart
@@ -65,6 +65,26 @@ void main() {
       expect(parsed.recentSlot, equals(BigInt.from(42)));
       expect(parsed.bump, equals(254));
       expect(parsed.discriminator, equals(0));
+      expect(ix.byteDelta, equals(lookupTableMetaSize));
+    });
+
+    test('derives PDA and bump for convenience builder', () async {
+      const authority = Address('11111111111111111111111111111111');
+      const payer = Address('Payer11111111111111111111111111111111111111');
+      final recentSlot = BigInt.from(42);
+
+      final pda = await findAddressLookupTablePda(
+        authority: authority,
+        recentSlot: recentSlot,
+      );
+      final instruction = await getCreateLookupTableInstructionWithPda(
+        authority: authority,
+        payer: payer,
+        recentSlot: recentSlot,
+      );
+
+      expect(instruction.accounts![0].address, equals(pda.$1));
+      expect(parseCreateLookupTableInstruction(instruction).bump, pda.$2);
     });
 
     test('value equality', () {
@@ -211,6 +231,16 @@ void main() {
       final parsed = parseExtendLookupTableInstruction(ix);
       expect(parsed.addresses, hasLength(1));
       expect(parsed.addresses[0], equals(addr1));
+      expect(ix.byteDelta, equals(32));
+    });
+
+    test('reports byte delta from address count', () {
+      const addr = Address('11111111111111111111111111111111');
+      expect(getExtendLookupTableInstructionByteDelta(const []), equals(0));
+      expect(
+        getExtendLookupTableInstructionByteDelta(const [addr, addr]),
+        equals(64),
+      );
     });
 
     test('handles empty addresses list', () {

--- a/packages/solana_kit_address_lookup_table/test/program_test.dart
+++ b/packages/solana_kit_address_lookup_table/test/program_test.dart
@@ -1,0 +1,223 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_address_lookup_table/solana_kit_address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('identifyAddressLookupTableInstruction', () {
+    test('identifies CreateLookupTable (disc 0)', () {
+      final data = Uint8List.fromList([0, 0, 0, 0, ...List.filled(9, 0)]);
+      expect(
+        identifyAddressLookupTableInstruction(data),
+        equals(AddressLookupTableInstruction.createLookupTable),
+      );
+    });
+
+    test('identifies FreezeLookupTable (disc 1)', () {
+      final data = Uint8List.fromList([1, 0, 0, 0]);
+      expect(
+        identifyAddressLookupTableInstruction(data),
+        equals(AddressLookupTableInstruction.freezeLookupTable),
+      );
+    });
+
+    test('identifies ExtendLookupTable (disc 2)', () {
+      final data = Uint8List.fromList([2, 0, 0, 0, ...List.filled(8, 0)]);
+      expect(
+        identifyAddressLookupTableInstruction(data),
+        equals(AddressLookupTableInstruction.extendLookupTable),
+      );
+    });
+
+    test('identifies DeactivateLookupTable (disc 3)', () {
+      final data = Uint8List.fromList([3, 0, 0, 0]);
+      expect(
+        identifyAddressLookupTableInstruction(data),
+        equals(AddressLookupTableInstruction.deactivateLookupTable),
+      );
+    });
+
+    test('identifies CloseLookupTable (disc 4)', () {
+      final data = Uint8List.fromList([4, 0, 0, 0]);
+      expect(
+        identifyAddressLookupTableInstruction(data),
+        equals(AddressLookupTableInstruction.closeLookupTable),
+      );
+    });
+
+    test('throws on data too short for u32 discriminator', () {
+      expect(
+        () => identifyAddressLookupTableInstruction(Uint8List.fromList([0])),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws on empty data', () {
+      expect(
+        () => identifyAddressLookupTableInstruction(Uint8List(0)),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws on unknown discriminator', () {
+      final data = Uint8List.fromList([255, 0, 0, 0]);
+      expect(
+        () => identifyAddressLookupTableInstruction(data),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('parseAddressLookupTableInstruction', () {
+    test('parses CreateLookupTable instruction', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+      const payer = Address('Payer11111111111111111111111111111111111111');
+
+      final ix = getCreateLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+        payer: payer,
+        recentSlot: BigInt.from(999),
+        bump: 128,
+      );
+      final parsed = parseAddressLookupTableInstruction(ix);
+      expect(parsed, isA<ParsedCreateLookupTable>());
+      final typed = parsed as ParsedCreateLookupTable;
+      expect(
+        typed.instructionType,
+        equals(AddressLookupTableInstruction.createLookupTable),
+      );
+      expect(typed.data.recentSlot, equals(BigInt.from(999)));
+      expect(typed.data.bump, equals(128));
+    });
+
+    test('parses FreezeLookupTable instruction', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+
+      final ix = getFreezeLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+      );
+      final parsed = parseAddressLookupTableInstruction(ix);
+      expect(parsed, isA<ParsedFreezeLookupTable>());
+      final typed = parsed as ParsedFreezeLookupTable;
+      expect(
+        typed.instructionType,
+        equals(AddressLookupTableInstruction.freezeLookupTable),
+      );
+    });
+
+    test('parses ExtendLookupTable instruction', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+      const payer = Address('Payer11111111111111111111111111111111111111');
+      const addr1 = Address('11111111111111111111111111111111');
+
+      final ix = getExtendLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+        payer: payer,
+        addresses: [addr1],
+      );
+      final parsed = parseAddressLookupTableInstruction(ix);
+      expect(parsed, isA<ParsedExtendLookupTable>());
+      final typed = parsed as ParsedExtendLookupTable;
+      expect(
+        typed.instructionType,
+        equals(AddressLookupTableInstruction.extendLookupTable),
+      );
+      expect(typed.data.addresses, hasLength(1));
+      expect(typed.data.addresses[0], equals(addr1));
+    });
+
+    test('parses DeactivateLookupTable instruction', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+
+      final ix = getDeactivateLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+      );
+      final parsed = parseAddressLookupTableInstruction(ix);
+      expect(parsed, isA<ParsedDeactivateLookupTable>());
+      final typed = parsed as ParsedDeactivateLookupTable;
+      expect(
+        typed.instructionType,
+        equals(AddressLookupTableInstruction.deactivateLookupTable),
+      );
+    });
+
+    test('parses CloseLookupTable instruction', () {
+      const tableAddr = Address('Tab1eLookupTab1e111111111111111111111111111');
+      const authority = Address('Auth111111111111111111111111111111111111111');
+      const recipient = Address('Recip11111111111111111111111111111111111111');
+
+      final ix = getCloseLookupTableInstruction(
+        address: tableAddr,
+        authority: authority,
+        recipient: recipient,
+      );
+      final parsed = parseAddressLookupTableInstruction(ix);
+      expect(parsed, isA<ParsedCloseLookupTable>());
+      final typed = parsed as ParsedCloseLookupTable;
+      expect(
+        typed.instructionType,
+        equals(AddressLookupTableInstruction.closeLookupTable),
+      );
+    });
+
+    test('throws on instruction with no data', () {
+      const ix = Instruction(
+        programAddress: addressLookupTableProgramAddress,
+        accounts: [],
+      );
+      expect(
+        () => parseAddressLookupTableInstruction(ix),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws on instruction with unknown discriminator', () {
+      final ix = Instruction(
+        programAddress: addressLookupTableProgramAddress,
+        accounts: const [],
+        data: Uint8List.fromList([99, 0, 0, 0]),
+      );
+      expect(
+        () => parseAddressLookupTableInstruction(ix),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('custom program address', () {
+    test('CreateLookupTable uses custom address when provided', () {
+      const custom = Address('11111111111111111111111111111111');
+      final ix = getCreateLookupTableInstruction(
+        address: custom,
+        authority: custom,
+        payer: custom,
+        recentSlot: BigInt.one,
+        bump: 0,
+        programAddress: custom,
+      );
+      expect(ix.programAddress, equals(custom));
+    });
+
+    test('ExtendLookupTable uses custom address when provided', () {
+      const custom = Address('11111111111111111111111111111111');
+      final ix = getExtendLookupTableInstruction(
+        address: custom,
+        authority: custom,
+        payer: custom,
+        addresses: const [],
+        programAddress: custom,
+      );
+      expect(ix.programAddress, equals(custom));
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ workspace:
   - packages/solana_kit
   - packages/solana_kit_accounts
   - packages/solana_kit_addresses
+  - packages/solana_kit_address_lookup_table
   - packages/solana_kit_associated_token_account
   - packages/solana_kit_codecs
   - packages/solana_kit_compute_budget

--- a/readme.md
+++ b/readme.md
@@ -270,7 +270,7 @@ The merged LCOV report is written to `coverage/lcov.info`.
 
 <!-- workspace-summary:start -->
 
-This monorepo contains **45 packages** under `packages/`: **43 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
+This monorepo contains **46 packages** under `packages/`: **44 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
 
 <!-- workspace-summary:end -->
 
@@ -829,6 +829,7 @@ Generated from package `pubspec.yaml` files with `scripts/workspace-doc-drift.sh
 ```text
 solana_kit -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs, solana_kit_errors, solana_kit_fast_stable_stringify, solana_kit_instruction_plans, solana_kit_instructions, solana_kit_keys, solana_kit_offchain_messages, solana_kit_options, solana_kit_program_client_core, solana_kit_programs, solana_kit_rpc, solana_kit_rpc_parsed_types, solana_kit_rpc_spec_types, solana_kit_rpc_subscriptions, solana_kit_rpc_transport_http, solana_kit_rpc_types, solana_kit_signers, solana_kit_subscribable, solana_kit_sysvars, solana_kit_transaction_confirmation, solana_kit_transaction_messages, solana_kit_transactions
 solana_kit_accounts -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors, solana_kit_rpc, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_types
+solana_kit_address_lookup_table -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_addresses -> solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
 solana_kit_associated_token_account -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_errors, solana_kit_instructions
 solana_kit_codecs -> solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_codecs_strings, solana_kit_options


### PR DESCRIPTION
## Summary

Closes #134.

Adds `solana_kit_address_lookup_table` — a full Address Lookup Table program client following the two-tier generated+helpers pattern.

## What's included

### Generated layer (Tier 1)
All five Address Lookup Table instructions with immutable data classes, encoder/decoder/codec pairs, instruction builders, and parsers:

| Instruction | Disc | Fields |
|---|---|---|
| `CreateLookupTable` | 0 | `recentSlot` (u64), `bump` (u8) |
| `FreezeLookupTable` | 1 | — |
| `ExtendLookupTable` | 2 | `addresses` (Address[]) |
| `DeactivateLookupTable` | 3 | — |
| `CloseLookupTable` | 4 | — |

### Account decoder
- `AddressLookupTableAccountData` — decodes the full on-chain account including authority (optional), deactivation slot, and stored addresses (remainder array).

### Program identification
- `identifyAddressLookupTableInstruction` — u32 discriminator dispatch
- `parseAddressLookupTableInstruction` — sealed typed return (`ParsedAddressLookupTableInstruction`)

### Tests
- **52 tests** covering codec round-trips, byte-level encoding, instruction builders, parsers, discriminator identification, account decode (with/without authority), equality/hashCode, and edge cases (empty addresses, unknown discriminator, short data)

## Validation
- `dart analyze --fatal-infos .` — no issues
- `dart test` — all 52 tests passed
- `dprint check` — clean
- `changeset-frontmatter` — validated

## Upstream reference
Mirrors [solana-program/address-lookup-table](https://github.com/solana-program/address-lookup-table) at `js@v0.11.0`.