### PR TITLE
ci: add Codecov package coverage

### DIFF
--- a/.changeset/codecov-package-coverage.md
+++ b/.changeset/codecov-package-coverage.md
@@ -1,0 +1,5 @@
+---
+main: patch
+---
+
+Add Codecov patch coverage and package-level coverage flags for Dart and renderer packages.

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   check:
     timeout-minutes: 15
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: install NPM dependencies
+        run: pnpm install --frozen-lockfile
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -129,7 +137,6 @@ jobs:
         shell: devenv shell -- bash -e {0}
       - name: NPM renderer coverage
         run: pnpm --filter codama-renderers-dart test:coverage
-        shell: devenv shell -- bash -e {0}
       - name: prepare Codecov flag reports
         id: prepare-codecov-flags
         run: dart run scripts/prepare_codecov_flags.dart --lcov coverage/lcov.info --out-dir coverage/flags --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
         shell: devenv shell -- bash -e {0}
       - name: NPM renderer coverage
         run: pnpm --filter codama-renderers-dart test:coverage
+        shell: devenv shell -- bash -e {0}
       - name: prepare Codecov flag reports
         id: prepare-codecov-flags
         run: dart run scripts/prepare_codecov_flags.dart --lcov coverage/lcov.info --out-dir coverage/flags --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   docs-drift:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
@@ -19,7 +19,7 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
   docs-site:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
@@ -30,7 +30,7 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
   upstream-compatibility:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
@@ -41,7 +41,7 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
   lint:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
@@ -56,7 +56,7 @@ jobs:
         shell: devenv shell -- bash -e {0}
 
   test:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
@@ -66,19 +66,8 @@ jobs:
         run: test:all
         shell: devenv shell -- bash -e {0}
 
-  coverage-risk-tiers:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/devenv
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enforce risk-tier coverage floors
-        run: coverage:check
-        shell: devenv shell -- bash -e {0}
-
   android-plugin-compile:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -102,7 +91,7 @@ jobs:
         run: ./scripts/check-mobile-wallet-adapter-android-compile.sh
 
   renderer-test:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: packages/codama-renderers-dart
@@ -122,23 +111,74 @@ jobs:
         run: pnpm test
 
   coverage:
-    if: github.ref == 'refs/heads/main'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
+    outputs:
+      codecov-flags: ${{ steps.prepare-codecov-flags.outputs.flags }}
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: coverage
+      - name: Dart coverage
         run: test:coverage
         shell: devenv shell -- bash -e {0}
+      - name: NPM renderer coverage
+        run: pnpm --filter codama-renderers-dart test:coverage
+      - name: prepare Codecov flag reports
+        id: prepare-codecov-flags
+        run: dart run scripts/prepare_codecov_flags.dart --lcov coverage/lcov.info --out-dir coverage/flags --github-output "$GITHUB_OUTPUT"
+        shell: devenv shell -- bash -e {0}
+      - name: upload Codecov flag reports artifact
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: codecov-flag-reports
+          path: coverage/flags/*.lcov
+          if-no-files-found: error
+          retention-days: 7
       - name: upload coverage
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v5
         with:
-          files: ./coverage/lcov.info
-          fail_ci_if_error: false
+          files: ./coverage/lcov.info,./packages/codama-renderers-dart/coverage/lcov.info
+          disable_search: true
+          fail_ci_if_error: true
+          name: solana-kit-workspace
           token: ${{ secrets.CODECOV_TOKEN }}
           use_oidc: true
+          verbose: true
+
+  coverage-flags:
+    runs-on: ubuntu-latest
+    needs: coverage
+    if: ${{ needs.coverage.outputs.codecov-flags != '[]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        flag: ${{ fromJson(needs.coverage.outputs.codecov-flags) }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: download Codecov flag reports artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: codecov-flag-reports
+          path: coverage/flags
+      - name: upload package coverage flag to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/flags/${{ matrix.flag }}.lcov
+          disable_search: true
+          fail_ci_if_error: true
+          flags: ${{ matrix.flag }}
+          name: ${{ matrix.flag }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
+          verbose: true

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/devenv
@@ -68,7 +68,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,174 @@
+codecov:
+  require_ci_to_pass: true
+
+ignore:
+  - "**/*.g.dart"
+  - "**/*.freezed.dart"
+  - "**/*.mocks.dart"
+  - "**/generated/**"
+  - "**/.dart_tool/**"
+  - "**/build/**"
+  - "**/dist/**"
+  - "docs/**"
+  - "examples/**"
+
+flags:
+  solana_kit:
+    paths:
+      - packages/solana_kit
+  solana_kit_accounts:
+    paths:
+      - packages/solana_kit_accounts
+  solana_kit_addresses:
+    paths:
+      - packages/solana_kit_addresses
+  solana_kit_associated_token_account:
+    paths:
+      - packages/solana_kit_associated_token_account
+  solana_kit_codecs:
+    paths:
+      - packages/solana_kit_codecs
+  solana_kit_codecs_core:
+    paths:
+      - packages/solana_kit_codecs_core
+  solana_kit_codecs_data_structures:
+    paths:
+      - packages/solana_kit_codecs_data_structures
+  solana_kit_codecs_numbers:
+    paths:
+      - packages/solana_kit_codecs_numbers
+  solana_kit_codecs_strings:
+    paths:
+      - packages/solana_kit_codecs_strings
+  solana_kit_compute_budget:
+    paths:
+      - packages/solana_kit_compute_budget
+  solana_kit_errors:
+    paths:
+      - packages/solana_kit_errors
+  solana_kit_fast_stable_stringify:
+    paths:
+      - packages/solana_kit_fast_stable_stringify
+  solana_kit_functional:
+    paths:
+      - packages/solana_kit_functional
+  solana_kit_helius:
+    paths:
+      - packages/solana_kit_helius
+  solana_kit_instruction_plans:
+    paths:
+      - packages/solana_kit_instruction_plans
+  solana_kit_instructions:
+    paths:
+      - packages/solana_kit_instructions
+  solana_kit_keys:
+    paths:
+      - packages/solana_kit_keys
+  solana_kit_lints:
+    paths:
+      - packages/solana_kit_lints
+  solana_kit_mobile_wallet_adapter:
+    paths:
+      - packages/solana_kit_mobile_wallet_adapter
+  solana_kit_mobile_wallet_adapter_protocol:
+    paths:
+      - packages/solana_kit_mobile_wallet_adapter_protocol
+  solana_kit_offchain_messages:
+    paths:
+      - packages/solana_kit_offchain_messages
+  solana_kit_options:
+    paths:
+      - packages/solana_kit_options
+  solana_kit_program_client_core:
+    paths:
+      - packages/solana_kit_program_client_core
+  solana_kit_programs:
+    paths:
+      - packages/solana_kit_programs
+  solana_kit_rpc:
+    paths:
+      - packages/solana_kit_rpc
+  solana_kit_rpc_api:
+    paths:
+      - packages/solana_kit_rpc_api
+  solana_kit_rpc_parsed_types:
+    paths:
+      - packages/solana_kit_rpc_parsed_types
+  solana_kit_rpc_spec:
+    paths:
+      - packages/solana_kit_rpc_spec
+  solana_kit_rpc_spec_types:
+    paths:
+      - packages/solana_kit_rpc_spec_types
+  solana_kit_rpc_subscriptions:
+    paths:
+      - packages/solana_kit_rpc_subscriptions
+  solana_kit_rpc_subscriptions_api:
+    paths:
+      - packages/solana_kit_rpc_subscriptions_api
+  solana_kit_rpc_subscriptions_channel_websocket:
+    paths:
+      - packages/solana_kit_rpc_subscriptions_channel_websocket
+  solana_kit_rpc_transformers:
+    paths:
+      - packages/solana_kit_rpc_transformers
+  solana_kit_rpc_transport_http:
+    paths:
+      - packages/solana_kit_rpc_transport_http
+  solana_kit_rpc_types:
+    paths:
+      - packages/solana_kit_rpc_types
+  solana_kit_signers:
+    paths:
+      - packages/solana_kit_signers
+  solana_kit_subscribable:
+    paths:
+      - packages/solana_kit_subscribable
+  solana_kit_system:
+    paths:
+      - packages/solana_kit_system
+  solana_kit_sysvars:
+    paths:
+      - packages/solana_kit_sysvars
+  solana_kit_test_matchers:
+    paths:
+      - packages/solana_kit_test_matchers
+  solana_kit_token:
+    paths:
+      - packages/solana_kit_token
+  solana_kit_token_2022:
+    paths:
+      - packages/solana_kit_token_2022
+  solana_kit_transaction_confirmation:
+    paths:
+      - packages/solana_kit_transaction_confirmation
+  solana_kit_transaction_messages:
+    paths:
+      - packages/solana_kit_transaction_messages
+  solana_kit_transactions:
+    paths:
+      - packages/solana_kit_transactions
+  codama_renderers_dart:
+    paths:
+      - packages/codama-renderers-dart
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 95%
+        threshold: 0%
+        if_ci_failed: error
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false

--- a/devenv.nix
+++ b/devenv.nix
@@ -21,6 +21,7 @@ in
       libiconv
       nixfmt
       osv-scanner
+      ripgrep
       shfmt
       extra.knope
       extra.mdt

--- a/packages/codama-renderers-dart/package.json
+++ b/packages/codama-renderers-dart/package.json
@@ -26,6 +26,7 @@
     "build": "pnpm exec rimraf dist && pnpm exec tsup && pnpm exec tsc -p tsconfig.declarations.json",
     "lint": "eslint --ext .ts src",
     "test": "pnpm exec vitest run",
+    "test:coverage": "pnpm exec vitest run --coverage.enabled --coverage.reporter=lcov",
     "test:watch": "pnpm exec vitest",
     "typecheck": "pnpm exec tsc --noEmit"
   },
@@ -50,7 +51,8 @@
   },
   "devDependencies": {
     "@codama/nodes-from-anchor": "^1.3.9",
-    "@codama/renderers-js": "^2.0.2"
+    "@codama/renderers-js": "^2.0.2",
+    "@vitest/coverage-v8": "3.2.4"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,48 @@ importers:
       "@codama/renderers-js":
         specifier: ^2.0.2
         version: 2.0.2(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      "@vitest/coverage-v8":
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@25.3.0))
 
 packages:
+  "@ampproject/remapping@2.3.0":
+    resolution: {
+      integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==,
+    }
+    engines: { node: ">=6.0.0" }
+
+  "@babel/helper-string-parser@7.29.7":
+    resolution: {
+      integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
+    }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-validator-identifier@7.29.7":
+    resolution: {
+      integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
+    }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/parser@7.29.7":
+    resolution: {
+      integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
+    }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
+
+  "@babel/types@7.29.7":
+    resolution: {
+      integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
+    }
+    engines: { node: ">=6.9.0" }
+
+  "@bcoe/v8-coverage@1.0.2":
+    resolution: {
+      integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==,
+    }
+    engines: { node: ">=18" }
+
   "@codama/errors@1.5.1":
     resolution: {
       integrity: sha512-kdLk/OSLBt03DoViRU1Xr0M7NZ7J/CSqaXV8fooF9qMRGPRJdgUeW2VkCGlLXDQSaIALrls3HkHmKRKbqqjSOA==,
@@ -296,6 +336,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  "@isaacs/cliui@8.0.2":
+    resolution: {
+      integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==,
+    }
+    engines: { node: ">=12" }
+
+  "@istanbuljs/schema@0.1.6":
+    resolution: {
+      integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==,
+    }
+    engines: { node: ">=8" }
+
   "@jridgewell/gen-mapping@0.3.13":
     resolution: {
       integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
@@ -322,6 +374,12 @@ packages:
       integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==,
     }
     engines: { node: ">= 20.19.0" }
+
+  "@pkgjs/parseargs@0.11.0":
+    resolution: {
+      integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==,
+    }
+    engines: { node: ">=14" }
 
   "@rollup/rollup-android-arm-eabi@4.59.0":
     resolution: {
@@ -660,6 +718,17 @@ packages:
       integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==,
     }
 
+  "@vitest/coverage-v8@3.2.4":
+    resolution: {
+      integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==,
+    }
+    peerDependencies:
+      "@vitest/browser": 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      "@vitest/browser":
+        optional: true
+
   "@vitest/expect@3.2.4":
     resolution: {
       integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==,
@@ -710,6 +779,30 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
+  ansi-regex@5.0.1:
+    resolution: {
+      integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
+    }
+    engines: { node: ">=8" }
+
+  ansi-regex@6.2.2:
+    resolution: {
+      integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
+    }
+    engines: { node: ">=12" }
+
+  ansi-styles@4.3.0:
+    resolution: {
+      integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+    }
+    engines: { node: ">=8" }
+
+  ansi-styles@6.2.3:
+    resolution: {
+      integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
+    }
+    engines: { node: ">=12" }
+
   any-promise@1.3.0:
     resolution: {
       integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
@@ -721,11 +814,26 @@ packages:
     }
     engines: { node: ">=12" }
 
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {
+      integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==,
+    }
+
+  balanced-match@1.0.2:
+    resolution: {
+      integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+    }
+
   balanced-match@4.0.4:
     resolution: {
       integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
     }
     engines: { node: 18 || 20 || >=22 }
+
+  brace-expansion@2.1.1:
+    resolution: {
+      integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==,
+    }
 
   brace-expansion@5.0.3:
     resolution: {
@@ -789,6 +897,17 @@ packages:
     }
     engines: { node: ">= 14.16.0" }
 
+  color-convert@2.0.1:
+    resolution: {
+      integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+    }
+    engines: { node: ">=7.0.0" }
+
+  color-name@1.1.4:
+    resolution: {
+      integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+    }
+
   commander@14.0.2:
     resolution: {
       integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==,
@@ -818,6 +937,12 @@ packages:
     }
     engines: { node: ^14.18.0 || >=16.10.0 }
 
+  cross-spawn@7.0.6:
+    resolution: {
+      integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+    }
+    engines: { node: ">= 8" }
+
   debug@4.4.3:
     resolution: {
       integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
@@ -846,6 +971,21 @@ packages:
       integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
     }
     engines: { node: ">= 0.4" }
+
+  eastasianwidth@0.2.0:
+    resolution: {
+      integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
+    }
+
+  emoji-regex@8.0.0:
+    resolution: {
+      integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+    }
+
+  emoji-regex@9.2.2:
+    resolution: {
+      integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
+    }
 
   es-define-property@1.0.1:
     resolution: {
@@ -909,6 +1049,12 @@ packages:
       integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==,
     }
 
+  foreground-child@3.3.1:
+    resolution: {
+      integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
+    }
+    engines: { node: ">=14" }
+
   fsevents@2.3.3:
     resolution: {
       integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
@@ -933,6 +1079,13 @@ packages:
     }
     engines: { node: ">= 0.4" }
 
+  glob@10.5.0:
+    resolution: {
+      integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==,
+    }
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@13.0.6:
     resolution: {
       integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==,
@@ -944,6 +1097,12 @@ packages:
       integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
     }
     engines: { node: ">= 0.4" }
+
+  has-flag@4.0.0:
+    resolution: {
+      integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+    }
+    engines: { node: ">=8" }
 
   has-property-descriptors@1.0.2:
     resolution: {
@@ -962,9 +1121,54 @@ packages:
     }
     engines: { node: ">= 0.4" }
 
+  html-escaper@2.0.2:
+    resolution: {
+      integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
+    }
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {
+      integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+    }
+    engines: { node: ">=8" }
+
   isarray@2.0.5:
     resolution: {
       integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==,
+    }
+
+  isexe@2.0.0:
+    resolution: {
+      integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+    }
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {
+      integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==,
+    }
+    engines: { node: ">=8" }
+
+  istanbul-lib-report@3.0.1:
+    resolution: {
+      integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==,
+    }
+    engines: { node: ">=10" }
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {
+      integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==,
+    }
+    engines: { node: ">=10" }
+
+  istanbul-reports@3.2.0:
+    resolution: {
+      integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==,
+    }
+    engines: { node: ">=8" }
+
+  jackspeak@3.4.3:
+    resolution: {
+      integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==,
     }
 
   joycon@3.1.1:
@@ -972,6 +1176,11 @@ packages:
       integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
     }
     engines: { node: ">=10" }
+
+  js-tokens@10.0.0:
+    resolution: {
+      integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==,
+    }
 
   js-tokens@9.0.1:
     resolution: {
@@ -1011,6 +1220,11 @@ packages:
       integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
     }
 
+  lru-cache@10.4.3:
+    resolution: {
+      integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==,
+    }
+
   lru-cache@11.2.6:
     resolution: {
       integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==,
@@ -1021,6 +1235,17 @@ packages:
     resolution: {
       integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
     }
+
+  magicast@0.3.5:
+    resolution: {
+      integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==,
+    }
+
+  make-dir@4.0.0:
+    resolution: {
+      integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==,
+    }
+    engines: { node: ">=10" }
 
   math-intrinsics@1.1.0:
     resolution: {
@@ -1033,6 +1258,12 @@ packages:
       integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==,
     }
     engines: { node: 18 || 20 || >=22 }
+
+  minimatch@9.0.9:
+    resolution: {
+      integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==,
+    }
+    engines: { node: ">=16 || 14 >=14.17" }
 
   minipass@7.1.3:
     resolution: {
@@ -1078,6 +1309,18 @@ packages:
     resolution: {
       integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
     }
+
+  path-key@3.1.1:
+    resolution: {
+      integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+    }
+    engines: { node: ">=8" }
+
+  path-scurry@1.11.1:
+    resolution: {
+      integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==,
+    }
+    engines: { node: ">=16 || 14 >=14.18" }
 
   path-scurry@2.0.2:
     resolution: {
@@ -1190,10 +1433,28 @@ packages:
     }
     engines: { node: ">= 0.4" }
 
+  shebang-command@2.0.0:
+    resolution: {
+      integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+    }
+    engines: { node: ">=8" }
+
+  shebang-regex@3.0.0:
+    resolution: {
+      integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+    }
+    engines: { node: ">=8" }
+
   siginfo@2.0.0:
     resolution: {
       integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
     }
+
+  signal-exit@4.1.0:
+    resolution: {
+      integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
+    }
+    engines: { node: ">=14" }
 
   source-map-js@1.2.1:
     resolution: {
@@ -1217,6 +1478,30 @@ packages:
       integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
     }
 
+  string-width@4.2.3:
+    resolution: {
+      integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
+    }
+    engines: { node: ">=8" }
+
+  string-width@5.1.2:
+    resolution: {
+      integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
+    }
+    engines: { node: ">=12" }
+
+  strip-ansi@6.0.1:
+    resolution: {
+      integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
+    }
+    engines: { node: ">=8" }
+
+  strip-ansi@7.2.0:
+    resolution: {
+      integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
+    }
+    engines: { node: ">=12" }
+
   strip-literal@3.1.0:
     resolution: {
       integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==,
@@ -1228,6 +1513,18 @@ packages:
     }
     engines: { node: ">=16 || 14 >=14.17" }
     hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {
+      integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+    }
+    engines: { node: ">=8" }
+
+  test-exclude@7.0.2:
+    resolution: {
+      integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==,
+    }
+    engines: { node: ">=18" }
 
   thenify-all@1.6.0:
     resolution: {
@@ -1402,6 +1699,13 @@ packages:
       jsdom:
         optional: true
 
+  which@2.0.2:
+    resolution: {
+      integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+    }
+    engines: { node: ">= 8" }
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {
       integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
@@ -1409,7 +1713,39 @@ packages:
     engines: { node: ">=8" }
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {
+      integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+    }
+    engines: { node: ">=10" }
+
+  wrap-ansi@8.1.0:
+    resolution: {
+      integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
+    }
+    engines: { node: ">=12" }
+
 snapshots:
+  "@ampproject/remapping@2.3.0":
+    dependencies:
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
+
+  "@babel/helper-string-parser@7.29.7": {}
+
+  "@babel/helper-validator-identifier@7.29.7": {}
+
+  "@babel/parser@7.29.7":
+    dependencies:
+      "@babel/types": 7.29.7
+
+  "@babel/types@7.29.7":
+    dependencies:
+      "@babel/helper-string-parser": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
+
+  "@bcoe/v8-coverage@1.0.2": {}
+
   "@codama/errors@1.5.1":
     dependencies:
       "@codama/node-types": 1.5.1
@@ -1543,6 +1879,17 @@ snapshots:
   "@esbuild/win32-x64@0.27.3":
     optional: true
 
+  "@isaacs/cliui@8.0.2":
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  "@istanbuljs/schema@0.1.6": {}
+
   "@jridgewell/gen-mapping@0.3.13":
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
@@ -1558,6 +1905,9 @@ snapshots:
       "@jridgewell/sourcemap-codec": 1.5.5
 
   "@noble/hashes@2.0.1": {}
+
+  "@pkgjs/parseargs@0.11.0":
+    optional: true
 
   "@rollup/rollup-android-arm-eabi@4.59.0":
     optional: true
@@ -1737,6 +2087,25 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  "@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.3.0))":
+    dependencies:
+      "@ampproject/remapping": 2.3.0
+      "@bcoe/v8-coverage": 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@25.3.0)
+    transitivePeerDependencies:
+      - supports-color
+
   "@vitest/expect@3.2.4":
     dependencies:
       "@types/chai": 5.2.3
@@ -1781,11 +2150,33 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
   any-promise@1.3.0: {}
 
   assertion-error@2.0.1: {}
 
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      "@jridgewell/trace-mapping": 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.3:
     dependencies:
@@ -1831,6 +2222,12 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   commander@14.0.2: {}
 
   commander@14.0.3: {}
@@ -1840,6 +2237,12 @@ snapshots:
   confbox@0.1.8: {}
 
   consola@3.4.2: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   debug@4.4.3:
     dependencies:
@@ -1858,6 +2261,12 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   es-define-property@1.0.1: {}
 
@@ -1917,6 +2326,11 @@ snapshots:
       mlly: 1.8.0
       rollup: 4.59.0
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -1940,6 +2354,15 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.2
@@ -1947,6 +2370,8 @@ snapshots:
       path-scurry: 2.0.2
 
   gopd@1.2.0: {}
+
+  has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
@@ -1958,9 +2383,44 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-escaper@2.0.2: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
   isarray@2.0.5: {}
 
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      "@jridgewell/trace-mapping": 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      "@isaacs/cliui": 8.0.2
+    optionalDependencies:
+      "@pkgjs/parseargs": 0.11.0
+
   joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@9.0.1: {}
 
@@ -1982,17 +2442,33 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.2.6: {}
 
   magic-string@0.30.21:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      "@babel/parser": 7.29.7
+      "@babel/types": 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   math-intrinsics@1.1.0: {}
 
   minimatch@10.2.2:
     dependencies:
       brace-expansion: 5.0.3
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
 
   minipass@7.1.3: {}
 
@@ -2018,6 +2494,13 @@ snapshots:
   object-keys@1.1.1: {}
 
   package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -2105,7 +2588,15 @@ snapshots:
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -2114,6 +2605,26 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-literal@3.1.0:
     dependencies:
@@ -2128,6 +2639,16 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      "@istanbuljs/schema": 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.2
 
   thenify-all@1.6.0:
     dependencies:
@@ -2264,7 +2785,23 @@ snapshots:
       - tsx
       - yaml
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0

--- a/scripts/prepare_codecov_flags.dart
+++ b/scripts/prepare_codecov_flags.dart
@@ -1,0 +1,181 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Split LCOV coverage into Codecov flag files by package path.
+void main(List<String> arguments) {
+  final options = _Options.parse(arguments);
+  final outputDirectory = Directory(options.outputDirectory)
+    ..createSync(recursive: true);
+  final packages = _discoverPackages()
+    ..['codama_renderers_dart'] = 'packages/codama-renderers-dart';
+
+  final recordsByFlag = {for (final flag in packages.keys) flag: <String>[]};
+
+  final lcovFile = File(options.lcovPath);
+  if (lcovFile.existsSync()) {
+    for (final record in _lcovRecords(lcovFile.readAsStringSync())) {
+      final sourcePath = _recordSourcePath(record);
+      if (sourcePath == null) continue;
+
+      for (final entry in packages.entries) {
+        final packagePath = entry.value;
+        if (sourcePath == packagePath ||
+            sourcePath.startsWith('$packagePath/')) {
+          recordsByFlag[entry.key]!.add(record);
+          break;
+        }
+      }
+    }
+  }
+
+  final npmLcovFile = File('packages/codama-renderers-dart/coverage/lcov.info');
+  if (npmLcovFile.existsSync()) {
+    recordsByFlag['codama_renderers_dart']!.addAll(
+      _lcovRecords(npmLcovFile.readAsStringSync()),
+    );
+  }
+
+  final writtenFlags = <String>[];
+  for (final entry in recordsByFlag.entries) {
+    if (entry.value.isEmpty) continue;
+
+    File(
+      '${outputDirectory.path}/${entry.key}.lcov',
+    ).writeAsStringSync(entry.value.join());
+    writtenFlags.add(entry.key);
+  }
+
+  final flagsJson = jsonEncode(writtenFlags);
+  if (options.githubOutputPath != null) {
+    File(
+      options.githubOutputPath!,
+    ).writeAsStringSync('flags=$flagsJson\n', mode: FileMode.append);
+  }
+
+  stdout.writeln(flagsJson);
+}
+
+Map<String, String> _discoverPackages() {
+  final packagesDirectory = Directory('packages');
+  if (!packagesDirectory.existsSync()) return {};
+
+  final packages = <String, String>{};
+  final pubspecs =
+      packagesDirectory
+          .listSync()
+          .whereType<Directory>()
+          .map((directory) => File('${directory.path}/pubspec.yaml'))
+          .where((file) => file.existsSync())
+          .toList()
+        ..sort((left, right) => left.path.compareTo(right.path));
+
+  for (final pubspec in pubspecs) {
+    final name = _packageName(pubspec);
+    if (name != null) {
+      packages[name] = pubspec.parent.path.replaceAll(
+        String.fromCharCode(92),
+        '/',
+      );
+    }
+  }
+
+  return packages;
+}
+
+String? _packageName(File pubspec) {
+  for (final line in pubspec.readAsLinesSync()) {
+    final match = RegExp(r'^name:\s*([^\s#]+)').firstMatch(line);
+    if (match != null) {
+      return match.group(1);
+    }
+  }
+
+  return null;
+}
+
+List<String> _lcovRecords(String contents) {
+  final records = <String>[];
+  final current = <String>[];
+
+  for (final line in const LineSplitter().convert(contents)) {
+    current.add(line);
+    if (line == 'end_of_record') {
+      records.add('${current.join('\n')}\n');
+      current.clear();
+    }
+  }
+
+  return records;
+}
+
+String? _recordSourcePath(String record) {
+  for (final line in const LineSplitter().convert(record)) {
+    if (!line.startsWith('SF:')) {
+      continue;
+    }
+
+    var path = line
+        .substring(3)
+        .trim()
+        .replaceAll(String.fromCharCode(92), '/');
+    const marker = '/packages/';
+    if (path.contains(marker)) {
+      path = 'packages/${path.split(marker).last}';
+    }
+    if (path.startsWith('./')) {
+      path = path.substring(2);
+    }
+    return path;
+  }
+
+  return null;
+}
+
+final class _Options {
+  const _Options({
+    required this.lcovPath,
+    required this.outputDirectory,
+    required this.githubOutputPath,
+  });
+
+  factory _Options.parse(List<String> arguments) {
+    var lcovPath = 'coverage/lcov.info';
+    var outputDirectory = 'coverage/flags';
+    String? githubOutputPath;
+
+    for (var index = 0; index < arguments.length; index += 1) {
+      final argument = arguments[index];
+      switch (argument) {
+        case '--lcov':
+          lcovPath = _requiredValue(arguments, index);
+          index += 1;
+        case '--out-dir':
+          outputDirectory = _requiredValue(arguments, index);
+          index += 1;
+        case '--github-output':
+          githubOutputPath = _requiredValue(arguments, index);
+          index += 1;
+        default:
+          throw ArgumentError('Unknown argument: $argument');
+      }
+    }
+
+    return _Options(
+      lcovPath: lcovPath,
+      outputDirectory: outputDirectory,
+      githubOutputPath: githubOutputPath,
+    );
+  }
+
+  final String lcovPath;
+  final String outputDirectory;
+  final String? githubOutputPath;
+
+  static String _requiredValue(List<String> arguments, int index) {
+    if (index + 1 >= arguments.length) {
+      throw ArgumentError('Missing value for ${arguments[index]}');
+    }
+
+    return arguments[index + 1];
+  }
+}


### PR DESCRIPTION
## Summary
- replace the old coverage-risk-tiers workflow path with Codecov coverage checks
- add package-level Codecov flags for Dart packages and codama-renderers-dart
- add a Dart helper script to split LCOV files for Codecov flag uploads
- move workflows to ubuntu-latest runners

## Validation
- dart analyze scripts/prepare_codecov_flags.dart
- dart run scripts/prepare_codecov_flags.dart --lcov coverage/lcov.info --out-dir /tmp/solana-kit-codecov-flags
- devenv shell -- bash -lc 'mc step:validate'
- pnpm --filter codama-renderers-dart test:coverage
- devenv shell -- bash -lc 'test:coverage'
- git diff --check