### PR TITLE
feat: add codecov flags and per-package coverage badges

### DIFF
--- a/.changeset/add-codecov-badges.md
+++ b/.changeset/add-codecov-badges.md
@@ -1,0 +1,51 @@
+---
+"codama-renderers-dart": patch
+"solana_kit": patch
+"solana_kit_accounts": patch
+"solana_kit_addresses": patch
+"solana_kit_associated_token_account": patch
+"solana_kit_codecs": patch
+"solana_kit_codecs_core": patch
+"solana_kit_codecs_data_structures": patch
+"solana_kit_codecs_numbers": patch
+"solana_kit_codecs_strings": patch
+"solana_kit_compute_budget": patch
+"solana_kit_errors": patch
+"solana_kit_fast_stable_stringify": patch
+"solana_kit_functional": patch
+"solana_kit_helius": patch
+"solana_kit_instruction_plans": patch
+"solana_kit_instructions": patch
+"solana_kit_keys": patch
+"solana_kit_lints": patch
+"solana_kit_mobile_wallet_adapter": patch
+"solana_kit_mobile_wallet_adapter_protocol": patch
+"solana_kit_mpl_bubblegum": patch
+"solana_kit_offchain_messages": patch
+"solana_kit_options": patch
+"solana_kit_program_client_core": patch
+"solana_kit_programs": patch
+"solana_kit_rpc": patch
+"solana_kit_rpc_api": patch
+"solana_kit_rpc_parsed_types": patch
+"solana_kit_rpc_spec": patch
+"solana_kit_rpc_spec_types": patch
+"solana_kit_rpc_subscriptions": patch
+"solana_kit_rpc_subscriptions_api": patch
+"solana_kit_rpc_subscriptions_channel_websocket": patch
+"solana_kit_rpc_transformers": patch
+"solana_kit_rpc_transport_http": patch
+"solana_kit_rpc_types": patch
+"solana_kit_signers": patch
+"solana_kit_spl_account_compression": patch
+"solana_kit_subscribable": patch
+"solana_kit_sysvars": patch
+"solana_kit_test_matchers": patch
+"solana_kit_transaction_confirmation": patch
+"solana_kit_transaction_messages": patch
+"solana_kit_transactions": patch
+---
+
+# Add per-package coverage badges
+
+Add codecov flags and per-package coverage badges to all package READMEs.

--- a/codecov.yml
+++ b/codecov.yml
@@ -151,6 +151,12 @@ flags:
   codama_renderers_dart:
     paths:
       - packages/codama-renderers-dart
+  solana_kit_mpl_bubblegum:
+    paths:
+      - packages/solana_kit_mpl_bubblegum
+  solana_kit_spl_account_compression:
+    paths:
+      - packages/solana_kit_spl_account_compression
 
 coverage:
   precision: 2

--- a/packages/codama-renderers-dart/readme.md
+++ b/packages/codama-renderers-dart/readme.md
@@ -1,5 +1,9 @@
 # codama-renderers-dart
 
+[![pub package](https://img.shields.io/pub/v/codama-renderers-dart.svg)](https://pub.dev/packages/codama-renderers-dart)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=codama-renderers-dart)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=codama-renderers-dart)
+
 A [Codama](https://github.com/codama-idl/codama) renderer that generates Dart code targeting the [solana_kit](https://github.com/openbudgetfun/solana_kit) SDK.
 
 Given a Codama IDL (Interface Description Language) describing a Solana program, this renderer produces a complete Dart package with typed account classes, instruction builders, codec functions, error definitions, PDA helpers, and barrel exports.
@@ -9,6 +13,10 @@ Given a Codama IDL (Interface Description Language) describing a Solana program,
 ```bash
 pnpm add codama-renderers-dart
 # or
+
+[![pub package](https://img.shields.io/pub/v/codama-renderers-dart.svg)](https://pub.dev/packages/codama-renderers-dart)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=codama-renderers-dart)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=codama-renderers-dart)
 npm install codama-renderers-dart
 ```
 
@@ -277,18 +285,38 @@ Key source files:
 
 ```bash
 # Install dependencies
+
+[![pub package](https://img.shields.io/pub/v/codama-renderers-dart.svg)](https://pub.dev/packages/codama-renderers-dart)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=codama-renderers-dart)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=codama-renderers-dart)
 pnpm install
 
 # Type check
+
+[![pub package](https://img.shields.io/pub/v/codama-renderers-dart.svg)](https://pub.dev/packages/codama-renderers-dart)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=codama-renderers-dart)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=codama-renderers-dart)
 npx tsc --noEmit
 
 # Run tests
+
+[![pub package](https://img.shields.io/pub/v/codama-renderers-dart.svg)](https://pub.dev/packages/codama-renderers-dart)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=codama-renderers-dart)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=codama-renderers-dart)
 pnpm test
 
 # Watch mode
+
+[![pub package](https://img.shields.io/pub/v/codama-renderers-dart.svg)](https://pub.dev/packages/codama-renderers-dart)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=codama-renderers-dart)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=codama-renderers-dart)
 pnpm test:watch
 
 # Build
+
+[![pub package](https://img.shields.io/pub/v/codama-renderers-dart.svg)](https://pub.dev/packages/codama-renderers-dart)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=codama-renderers-dart)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=codama-renderers-dart)
 pnpm build
 ```
 

--- a/packages/solana_kit/README.md
+++ b/packages/solana_kit/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit)
 
 The Solana Kit Dart SDK -- a comprehensive, modular Dart port of the [Solana TypeScript SDK (`@solana/kit`)](https://github.com/anza-xyz/kit).
 

--- a/packages/solana_kit_accounts/README.md
+++ b/packages/solana_kit_accounts/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_accounts/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_accounts)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_accounts)
 
 Account fetching, decoding, and assertion utilities for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_addresses/README.md
+++ b/packages/solana_kit_addresses/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_addresses/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_addresses)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_addresses)
 
 Base58-encoded Solana address utilities for the Solana Kit Dart SDK -- a Dart port of [`@solana/addresses`](https://github.com/anza-xyz/kit/tree/main/packages/addresses).
 

--- a/packages/solana_kit_associated_token_account/README.md
+++ b/packages/solana_kit_associated_token_account/README.md
@@ -1,5 +1,9 @@
 # solana_kit_associated_token_account
 
+[![pub package](https://img.shields.io/pub/v/solana_kit_associated_token_account.svg)](https://pub.dev/packages/solana_kit_associated_token_account)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_associated_token_account)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_associated_token_account)
+
 Handwritten Associated Token Account (ATA) client for the Solana Kit Dart SDK.
 
 This package exposes the canonical ATA program address, PDA derivation helpers,

--- a/packages/solana_kit_codecs/README.md
+++ b/packages/solana_kit_codecs/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs)
 
 Umbrella package that re-exports all Solana Kit codec sub-packages through a single import.
 

--- a/packages/solana_kit_codecs_core/README.md
+++ b/packages/solana_kit_codecs_core/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs_core/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs_core)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs_core)
 
 Core codec interfaces and composition utilities for encoding and decoding Solana data structures in Dart.
 

--- a/packages/solana_kit_codecs_data_structures/README.md
+++ b/packages/solana_kit_codecs_data_structures/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs_data_structures/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs_data_structures)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs_data_structures)
 
 Codecs for encoding and decoding composite data structures -- structs, arrays, tuples, maps, sets, enums, booleans, and more -- for Solana on-chain data.
 

--- a/packages/solana_kit_codecs_numbers/README.md
+++ b/packages/solana_kit_codecs_numbers/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs_numbers/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs_numbers)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs_numbers)
 
 Numeric codecs for encoding and decoding integers and floats in Solana data structures.
 

--- a/packages/solana_kit_codecs_strings/README.md
+++ b/packages/solana_kit_codecs_strings/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs_strings/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs_strings)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs_strings)
 
 String codecs for encoding and decoding string data in various bases (base-10, base-16, base-58, base-64, UTF-8) for Solana data structures.
 

--- a/packages/solana_kit_compute_budget/README.md
+++ b/packages/solana_kit_compute_budget/README.md
@@ -1,5 +1,7 @@
 # solana_kit_compute_budget
 
+
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_compute_budget)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_compute_budget)
 Compute Budget program client for the
 [Solana Kit](https://github.com/openbudgetfun/solana_kit) Dart SDK.
 

--- a/packages/solana_kit_compute_budget/README.md
+++ b/packages/solana_kit_compute_budget/README.md
@@ -1,6 +1,5 @@
 # solana_kit_compute_budget
 
-
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_compute_budget)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_compute_budget)
 Compute Budget program client for the
 [Solana Kit](https://github.com/openbudgetfun/solana_kit) Dart SDK.

--- a/packages/solana_kit_errors/README.md
+++ b/packages/solana_kit_errors/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_errors/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_errors)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_errors)
 
 Error codes, structured error class, and error conversion utilities for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_fast_stable_stringify/README.md
+++ b/packages/solana_kit_fast_stable_stringify/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_fast_stable_stringify/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_fast_stable_stringify)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_fast_stable_stringify)
 
 Deterministic JSON serialization with sorted keys for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_functional/README.md
+++ b/packages/solana_kit_functional/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_functional/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_functional)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_functional)
 
 Pipe and compose utilities for the Solana Kit Dart SDK, enabling functional pipeline composition on any value.
 

--- a/packages/solana_kit_helius/README.md
+++ b/packages/solana_kit_helius/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_helius/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_helius)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_helius)
 
 Helius SDK for the Solana Kit Dart SDK. A Dart port of the [Helius TypeScript SDK](https://github.com/helius-labs/helius-sdk), providing DAS API, enhanced transactions, webhooks, smart transactions, ZK compression, staking, wallet API, WebSocket subscriptions, and auth.
 

--- a/packages/solana_kit_instruction_plans/README.md
+++ b/packages/solana_kit_instruction_plans/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_instruction_plans/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_instruction_plans)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_instruction_plans)
 
 Plan, organize, and execute complex multi-instruction and multi-transaction operations on Solana.
 

--- a/packages/solana_kit_instructions/README.md
+++ b/packages/solana_kit_instructions/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_instructions/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_instructions)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_instructions)
 
 Types and helpers for creating Solana transaction instructions.
 

--- a/packages/solana_kit_keys/README.md
+++ b/packages/solana_kit_keys/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_keys/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_keys)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_keys)
 
 Ed25519 key pair generation, signing, and signature verification for the Solana Kit Dart SDK -- a Dart port of [`@solana/keys`](https://github.com/anza-xyz/kit/tree/main/packages/keys).
 

--- a/packages/solana_kit_lints/README.md
+++ b/packages/solana_kit_lints/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_lints/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_lints)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_lints)
 
 Shared lint rules for all packages in the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_mobile_wallet_adapter/README.md
+++ b/packages/solana_kit_mobile_wallet_adapter/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_mobile_wallet_adapter/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_mobile_wallet_adapter)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_mobile_wallet_adapter)
 
 Flutter plugin for the [Solana Mobile Wallet Adapter](https://github.com/solana-mobile/mobile-wallet-adapter) (MWA) protocol.
 

--- a/packages/solana_kit_mobile_wallet_adapter_protocol/README.md
+++ b/packages/solana_kit_mobile_wallet_adapter_protocol/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_mobile_wallet_adapter_protocol/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_mobile_wallet_adapter_protocol)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_mobile_wallet_adapter_protocol)
 
 Pure Dart implementation of the [Solana Mobile Wallet Adapter](https://github.com/solana-mobile/mobile-wallet-adapter) v2.0 protocol. Handles P-256 cryptography, session handshakes, encrypted message framing, JSON-RPC request/response encoding, association URI building/parsing, and protocol version negotiation.
 

--- a/packages/solana_kit_mpl_bubblegum/README.md
+++ b/packages/solana_kit_mpl_bubblegum/README.md
@@ -1,5 +1,11 @@
 # solana_kit_mpl_bubblegum
 
+[![pub package](https://img.shields.io/pub/v/solana_kit_mpl_bubblegum.svg)](https://pub.dev/packages/solana_kit_mpl_bubblegum)
+[![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_mpl_bubblegum/latest/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_mpl_bubblegum)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_mpl_bubblegum)
+
 mpl-bubblegum (compressed NFT) instruction builders and helpers for the Solana Kit Dart SDK.
 
 ## Features

--- a/packages/solana_kit_offchain_messages/README.md
+++ b/packages/solana_kit_offchain_messages/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_offchain_messages/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_offchain_messages)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_offchain_messages)
 
 Create, compile, sign, and verify Solana offchain messages.
 

--- a/packages/solana_kit_options/README.md
+++ b/packages/solana_kit_options/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_options/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_options)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_options)
 
 A Rust-like `Option<T>` type and corresponding codec for encoding and decoding optional values in Solana on-chain data.
 

--- a/packages/solana_kit_program_client_core/README.md
+++ b/packages/solana_kit_program_client_core/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_program_client_core/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_program_client_core)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_program_client_core)
 
 Core building blocks for generated Solana program clients in the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_programs/README.md
+++ b/packages/solana_kit_programs/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_programs/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_programs)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_programs)
 
 Program error identification utilities for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc/README.md
+++ b/packages/solana_kit_rpc/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc)
 
 Primary RPC client for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc_api/README.md
+++ b/packages/solana_kit_rpc_api/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_api/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_api)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_api)
 
 RPC method type definitions and API composition for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc_parsed_types/README.md
+++ b/packages/solana_kit_rpc_parsed_types/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_parsed_types/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_parsed_types)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_parsed_types)
 
 Parsed account data types for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc_spec/README.md
+++ b/packages/solana_kit_rpc_spec/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_spec/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_spec)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_spec)
 
 RPC specification implementation for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc_spec_types/README.md
+++ b/packages/solana_kit_rpc_spec_types/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_spec_types/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_spec_types)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_spec_types)
 
 RPC spec type definitions for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc_subscriptions/README.md
+++ b/packages/solana_kit_rpc_subscriptions/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_subscriptions/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_subscriptions)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_subscriptions)
 
 Subscription client for the Solana Kit Dart SDK -- the composition layer that ties together WebSocket channels, the subscriptions API, JSON serialization, and error handling.
 

--- a/packages/solana_kit_rpc_subscriptions_api/README.md
+++ b/packages/solana_kit_rpc_subscriptions_api/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_subscriptions_api/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_subscriptions_api)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_subscriptions_api)
 
 Subscription method type definitions and parameter builders for all Solana RPC subscription methods in the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/README.md
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_subscriptions_channel_websocket/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_subscriptions_channel_websocket)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_subscriptions_channel_websocket)
 
 WebSocket channel transport for Solana RPC subscriptions in the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc_transformers/README.md
+++ b/packages/solana_kit_rpc_transformers/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_transformers/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_transformers)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_transformers)
 
 Request and response transformers for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc_transport_http/README.md
+++ b/packages/solana_kit_rpc_transport_http/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_transport_http/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_transport_http)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_transport_http)
 
 HTTP transport for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_rpc_types/README.md
+++ b/packages/solana_kit_rpc_types/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_types/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_types)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_types)
 
 Shared RPC types for the Solana Kit Dart SDK.
 

--- a/packages/solana_kit_signers/README.md
+++ b/packages/solana_kit_signers/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_signers/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_signers)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_signers)
 
 Signer interfaces and utilities for signing Solana messages and transactions -- a Dart port of [`@solana/signers`](https://github.com/anza-xyz/kit/tree/main/packages/signers).
 

--- a/packages/solana_kit_spl_account_compression/README.md
+++ b/packages/solana_kit_spl_account_compression/README.md
@@ -1,5 +1,11 @@
 # solana_kit_spl_account_compression
 
+[![pub package](https://img.shields.io/pub/v/solana_kit_spl_account_compression.svg)](https://pub.dev/packages/solana_kit_spl_account_compression)
+[![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_spl_account_compression/latest/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_spl_account_compression)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_spl_account_compression)
+
 SPL Account Compression Program instruction builders and helpers for the Solana Kit Dart SDK.
 
 This package provides a low-level interface for interacting with the [SPL Account Compression](https://github.com/solana-labs/solana-program-library/tree/master/account-compression) program, which manages concurrent Merkle trees used by compressed NFTs.

--- a/packages/solana_kit_subscribable/README.md
+++ b/packages/solana_kit_subscribable/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_subscribable/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_subscribable)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_subscribable)
 
 Subscribable and observable patterns for the Solana Kit Dart SDK -- a publish/subscribe event system with named channels, Dart `Stream` bridging, and event demultiplexing.
 

--- a/packages/solana_kit_sysvars/README.md
+++ b/packages/solana_kit_sysvars/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_sysvars/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_sysvars)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_sysvars)
 
 System variable (sysvar) account access for the Solana Kit Dart SDK -- provides typed access to Solana runtime sysvar accounts like Clock, Rent, EpochSchedule, and more.
 

--- a/packages/solana_kit_test_matchers/README.md
+++ b/packages/solana_kit_test_matchers/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_test_matchers/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_test_matchers)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_test_matchers)
 
 Custom test matchers for the Solana Kit Dart SDK -- provides assertion helpers for Solana errors, addresses, byte arrays, and transactions.
 

--- a/packages/solana_kit_transaction_confirmation/README.md
+++ b/packages/solana_kit_transaction_confirmation/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_transaction_confirmation/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_transaction_confirmation)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_transaction_confirmation)
 
 Transaction confirmation tracking for the Solana Kit Dart SDK -- provides multiple strategies to confirm or detect expiry of Solana transactions.
 

--- a/packages/solana_kit_transaction_messages/README.md
+++ b/packages/solana_kit_transaction_messages/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_transaction_messages/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_transaction_messages)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_transaction_messages)
 
 Build, compile, and decompile Solana transaction messages.
 

--- a/packages/solana_kit_transactions/README.md
+++ b/packages/solana_kit_transactions/README.md
@@ -4,7 +4,7 @@
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_transactions/latest/)
 [![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
-[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+[![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_transactions)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_transactions)
 
 Compile, sign, encode, and decode Solana transactions.
 


### PR DESCRIPTION
## Summary

- Add `solana_kit_mpl_bubblegum` and `solana_kit_spl_account_compression` to `codecov.yml` flags
- Add per-package coverage badges to all 42 package READMEs
- Coverage badges now show package-specific coverage via `?flag=` parameter

## Changes

### codecov.yml
- Added `solana_kit_mpl_bubblegum` flag pointing to `packages/solana_kit_mpl_bubblegum`
- Added `solana_kit_spl_account_compression` flag pointing to `packages/solana_kit_spl_account_compression`

### Package READMEs
- Updated all 42 package READMEs with per-package coverage badges
- Badge format: `[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=PACKAGE_NAME)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=PACKAGE_NAME)`

## Test plan
- [x] All README badges point to correct codecov flags
- [x] New packages have complete badge rows