### PR TITLE
fix(websocket): restrict allowInsecureWs to debug mode only

### DIFF
--- a/.changeset/sec-04-insecure-ws-debug-only.md
+++ b/.changeset/sec-04-insecure-ws-debug-only.md
@@ -1,0 +1,9 @@
+---
+"solana_kit_rpc_subscriptions_channel_websocket": patch
+---
+
+SEC-04: Restrict allowInsecureWs to debug mode only.
+
+- In release/profile mode, `ws://` URLs are now always rejected regardless of the `allowInsecureWs` flag
+- Prevents accidental use of insecure WebSocket connections in production
+- Updated documentation to reflect the debug-only behavior

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/lib/src/websocket_channel.dart
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/lib/src/websocket_channel.dart
@@ -297,6 +297,7 @@ void _validateWebSocketUrl(Uri url, {required bool allowInsecureWs}) {
     // the allowInsecureWs flag. This prevents accidental use of
     // insecure WebSocket connections in production.
     const isProduction = bool.fromEnvironment('dart.vm.product');
+    // coverage:ignore-start - unreachable in debug/test mode
     if (isProduction) {
       throw ArgumentError.value(
         url.toString(),
@@ -305,6 +306,7 @@ void _validateWebSocketUrl(Uri url, {required bool allowInsecureWs}) {
             'Use a wss:// URL instead.',
       );
     }
+    // coverage:ignore-end
     return;
   }
 

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/lib/src/websocket_channel.dart
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/lib/src/websocket_channel.dart
@@ -120,6 +120,9 @@ class WebSocketChannelConfig {
   /// Whether to allow insecure `ws://` URLs.
   ///
   /// Defaults to `false`, which enforces `wss://` URLs.
+  /// When set to `true`, insecure `ws://` URLs are only allowed in
+  /// debug mode. In release/profile mode, this flag is ignored and
+  /// `wss://` is always required.
   final bool allowInsecureWs;
 
   /// The number of bytes to admit into the send buffer before queueing
@@ -290,6 +293,18 @@ void _validateWebSocketUrl(Uri url, {required bool allowInsecureWs}) {
   }
 
   if (scheme == 'ws' && allowInsecureWs) {
+    // In release/profile mode, ws:// is never allowed regardless of
+    // the allowInsecureWs flag. This prevents accidental use of
+    // insecure WebSocket connections in production.
+    const isProduction = bool.fromEnvironment('dart.vm.product');
+    if (isProduction) {
+      throw ArgumentError.value(
+        url.toString(),
+        'url',
+        'Insecure WebSocket endpoints are not allowed in release mode. '  
+            'Use a wss:// URL instead.',
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
SEC-04: Prevent accidental use of insecure WebSocket in production. In release/profile mode, ws:// URLs are now always rejected regardless of the allowInsecureWs flag.