### PR TITLE
feat: add SurfPool integration tests CI job

### DIFF
--- a/.changeset/add-integration-tests-ci.md
+++ b/.changeset/add-integration-tests-ci.md
@@ -1,0 +1,7 @@
+---
+"solana_kit": patch
+---
+
+# Add integration tests CI job
+
+Add SurfPool integration test CI job and devenv command for running integration tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,17 @@ jobs:
         run: test:all
         shell: devenv shell -- bash -e {0}
 
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Start SurfPool and run integration tests
+        run: test:integration
+        shell: devenv shell -- bash -e {0}
+
   android-plugin-compile:
     runs-on: ubuntu-latest
     steps:

--- a/devenv.nix
+++ b/devenv.nix
@@ -385,6 +385,57 @@ in
       description = "Run all local benchmark scripts across workspace packages.";
       binary = "bash";
     };
+    "test:integration" = {
+      exec = ''
+        set -e
+
+        # Start SurfPool in daemon mode
+        echo "Starting SurfPool..."
+        surfpool start --daemon --ci
+
+        # Wait for SurfPool to be ready
+        echo "Waiting for SurfPool to be ready..."
+        for i in $(seq 1 30); do
+          if curl -s http://localhost:8899 > /dev/null 2>&1; then
+            echo "SurfPool is ready."
+            break
+          fi
+          if [ $i -eq 30 ]; then
+            echo "SurfPool failed to start within 30 seconds."
+            exit 1
+          fi
+          sleep 1
+        done
+
+        # Run integration tests
+        echo "Running integration tests..."
+        failed=0
+        for pkg_dir in packages/*/; do
+          if [ ! -d "$pkg_dir/test/integration" ]; then
+            continue
+          fi
+
+          pkg_name="$(basename "$pkg_dir")"
+          echo "Testing $pkg_name integration..."
+          if ! fvm flutter test --tags integration "$pkg_dir"; then
+            failed=1
+          fi
+        done
+
+        # Stop SurfPool
+        echo "Stopping SurfPool..."
+        surfpool stop 2>/dev/null || true
+
+        if [ "$failed" -ne 0 ]; then
+          echo "Some integration tests failed."
+          exit 1
+        fi
+
+        echo "All integration tests passed."
+      '';
+      description = "Run all integration tests against SurfPool local validator.";
+      binary = "bash";
+    };
     "test:all" = {
       exec = ''
         set -e


### PR DESCRIPTION
## Summary

Add integration test infrastructure for running on-chain tests against SurfPool.

### Changes

**devenv.nix:**
- Add `test:integration` script that:
  1. Starts SurfPool in daemon mode (`surfpool start --daemon --ci`)
  2. Waits for SurfPool to be ready (polls localhost:8899)
  3. Runs integration tests for all packages with `test/integration/` directories
  4. Stops SurfPool after tests complete

**ci.yml:**
- Add `integration-tests` CI job that:
  1. Checks out code and sets up devenv
  2. Runs `test:integration` command
  3. SurfPool starts/stops automatically via the devenv script

### How it works

Integration tests are tagged with `@Tags(['integration'])` and run against `http://localhost:8899` (SurfPool). The `test:integration` script handles starting/stopping SurfPool automatically.

## Test plan
- [x] `test:integration` devenv script works locally
- [x] CI job runs successfully