### PR TITLE
fix: resolve ambiguous export and lint ordering in barrel file

### DIFF
--- a/.changeset/fix-barrel-export-lint.md
+++ b/.changeset/fix-barrel-export-lint.md
@@ -1,0 +1,7 @@
+---
+"solana_kit_mpl_bubblegum": patch
+---
+
+# Fix barrel export ambiguity
+
+Fix ambiguous_export, directives_ordering, and eol_at_end_of_file lint issues in the barrel file.

--- a/.changeset/fix-monochange-ecosystem.md
+++ b/.changeset/fix-monochange-ecosystem.md
@@ -1,0 +1,7 @@
+---
+"solana_kit": patch
+---
+
+# Fix duplicate ecosystems.dart section in monochange.toml
+
+Merge duplicate `[ecosystem.dart]` and `[ecosystems.dart]` TOML sections into a single `[ecosystems.dart]` section.

--- a/monochange.toml
+++ b/monochange.toml
@@ -635,9 +635,6 @@ changelog = { path = "CHANGELOG.md" }
 #     placeholder.readme / placeholder.readme_file — default placeholder README
 #                      source inherited by packages during bootstrap publishing
 
-[ecosystem.dart]
-versioned_files = [{ path = "**/pubspec.yaml", type = "dart" }]
-
 # =============================================================================
 # [lints] — manifest lint configuration
 # =============================================================================
@@ -758,6 +755,7 @@ versioned_files = [{ path = "**/pubspec.yaml", type = "dart" }]
 # auto_merge = false
 
 [ecosystems.dart]
+versioned_files = [{ path = "**/pubspec.yaml", type = "dart" }]
 enabled = true
 publish.enabled = true
 publish.mode = "external"

--- a/packages/solana_kit_mpl_bubblegum/lib/solana_kit_mpl_bubblegum.dart
+++ b/packages/solana_kit_mpl_bubblegum/lib/solana_kit_mpl_bubblegum.dart
@@ -26,6 +26,12 @@
 /// [solana_kit_codecs_core] for the Keccak-256 hash function.
 library;
 
+// Generated (Codama-style).
+// Program addresses are exported directly from src/program_address.dart.
+// The generated file re-exports them; hide to avoid ambiguity.
+export 'package:solana_kit_mpl_bubblegum/src/generated/mpl_bubblegum.dart'
+    hide mplBubblegumProgramAddress, mplBubblegumProgramAddressObject;
+
 // Burn asset composite helper.
 export 'src/burn_asset.dart';
 
@@ -49,9 +55,6 @@ export 'src/delegate_asset.dart';
 
 // Flags.
 export 'src/flags/leaf_schema_flags.dart';
-
-// Generated (Codama-style).
-export 'src/generated/mpl_bubblegum.dart';
 
 // Hand-written hashing utilities.
 export 'src/hashing/hash.dart';
@@ -88,5 +91,3 @@ export 'src/transfer_asset.dart';
 
 // Byte utilities.
 export 'src/utils/bytes.dart';
-
-


### PR DESCRIPTION
## Summary

Fix 3 issues in `solana_kit_mpl_bubblegum` barrel file:

1. **ambiguous_export** — The generated file `mpl_bubblegum.dart` re-exports `mplBubblegumProgramAddress` and `mplBubblegumProgramAddressObject` from `program_address.dart`, which conflicts with the direct export. Fixed by hiding them in the barrel.

2. **directives_ordering** — Exports were not sorted alphabetically. Fixed by reordering all relative exports after the `package:` export.

3. **eol_at_end_of_file** — File was missing a trailing newline.

## Test plan
- [x] `dart analyze` passes with zero issues