### PR TITLE
ci: add monochange release automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish (for example, v0.4.0)
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    environment: publisher
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+          registry-url: https://registry.npmjs.org
+      - name: install NPM dependencies
+        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: inspect release record
+        run: mc step:release-record --from HEAD --format json
+        shell: devenv shell -- bash -e {0}
+      - name: check publish readiness
+        run: mc step:publish-readiness --from HEAD --format json
+        shell: devenv shell -- bash -e {0}
+      - name: build NPM renderer package
+        run: pnpm --filter codama-renderers-dart build
+      - name: dry-run package publish
+        run: mc publish --dry-run
+        shell: devenv shell -- bash -e {0}
+      - name: publish packages
+        run: mc publish
+        shell: devenv shell -- bash -e {0}
+        env:
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: create or update release PR
+        run: dart run scripts/open_release_pr.dart
+        shell: devenv shell -- bash -e {0}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  tag-release:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/devenv
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: detect monochange release record
+        id: release-record
+        continue-on-error: true
+        run: mc step:release-record --from HEAD --format json
+        shell: devenv shell -- bash -e {0}
+      - name: tag release commit
+        if: steps.release-record.outcome == 'success'
+        run: mc step:tag-release --from HEAD --push=true --format json
+        shell: devenv shell -- bash -e {0}
+      - name: publish GitHub release notes
+        if: steps.release-record.outcome == 'success'
+        run: mc step:publish-release --from-ref HEAD --format json
+        shell: devenv shell -- bash -e {0}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/devenv.nix
+++ b/devenv.nix
@@ -24,7 +24,6 @@ in
       ripgrep
       shfmt
       taplo
-      extra.knope
       extra.mdt
       extra.monochange
       extra.pnpm

--- a/docs/agents/changesets-and-releases.md
+++ b/docs/agents/changesets-and-releases.md
@@ -4,26 +4,43 @@
 
 - Never delete files in `.changeset/`; they are release inputs.
 - Any PR that changes files under `packages/*` must include a `.changeset/*.md` file.
-- This workspace ships shared versions across published packages, so changesets must not use package-specific keys.
-- Every changeset frontmatter block must contain exactly one entry:
+- Use monochange package ids from `monochange.toml` in changeset frontmatter.
+- For changes that affect the lockstep Dart group, listing affected package ids is enough; monochange propagates the selected bump through `group.main`.
 
 ```md
 ---
-default: patch
+"solana_kit_rpc": minor
+"solana_kit_transactions": minor
 ---
+
+# Add new RPC and transaction helpers
+
+Describe the user-visible change.
 ```
 
-Valid values are `patch`, `minor`, or `major`.
+Valid release bump values are `patch`, `minor`, `major`, and `test`.
 
-If `knope document-change` generates package-specific keys, replace them with a single `default: patch|minor|major` entry before committing.
+Create changesets with the configured monochange workflow:
+
+```bash
+mc document
+```
 
 ## Release workflow
 
 Use dry runs before real release actions.
 
 ```bash
-knope document-change
-knope --dry-run release
+mc release --dry-run --diff
+mc release-pr --dry-run
 ```
 
-For the full release flow, see the publishing docs.
+`mc release-pr` prepares version bumps, changelogs, release metadata, and opens or updates the configured monochange release PR. After the release PR merges to `main`, GitHub Actions tags the release commit and publishes GitHub release notes from the embedded monochange release record.
+
+Publishing package artifacts is a separate trusted-publishing workflow:
+
+```bash
+mc step:publish-readiness --from HEAD --format json
+mc publish --dry-run
+mc publish
+```

--- a/docs/agents/workspace-commands.md
+++ b/docs/agents/workspace-commands.md
@@ -34,7 +34,7 @@ Use direct tools only when you specifically need them instead of a workspace tas
 - `flutter`
 - `melos`
 - `jaspr`
-- `knope`
+- `mc` (monochange)
 - `dprint`
 
 ## Renderer package

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -10,7 +10,7 @@ This monorepo contains **48 packages** under `packages/`: **46 publishable** and
 
 <!-- workspace-summary:end -->
 
-Versioning is managed by [knope](https://knope.tech/) using changesets stored in `.changeset/`. Publishing is executed via `knope` workflows that call `melos publish` (plus renderer npm publish), so Melos manages dependency-aware publish sequencing for Dart packages.
+Versioning is managed by [monochange](https://github.com/monochange/monochange) using changesets stored in `.changeset/`. Release PRs, release tags, GitHub release notes, and package publishing are executed through the configured `mc` workflows in `monochange.toml`.
 
 ## Package Inventory
 
@@ -135,22 +135,22 @@ solana_kit_transactions -> solana_kit_addresses, solana_kit_codecs_core, solana_
 When making changes to any package, create a changeset file:
 
 ```bash
-knope document-change
+mc document
 ```
 
 This is required for PRs that modify files under `packages/*` (CI enforces this with `Require changes to be documented`).
 
-This interactively creates a Markdown file in `.changeset/` with a release note description. Because this workspace shares one version across all published packages, each changeset file must use YAML frontmatter with a single `default:` entry instead of package names:
+This interactively creates a Markdown file in `.changeset/` with a release note description. Use YAML frontmatter keyed by monochange package ids:
 
 ```markdown
 ---
-default: minor
+"solana_kit_rpc": minor
 ---
 
 Add support for program derived addresses with custom seeds.
 ```
 
-If `knope document-change` generates package-specific keys, replace them with a single `default: patch|minor|major` entry before committing the changeset.
+Use monochange package ids from `monochange.toml` in changeset frontmatter. For lockstep Dart releases, listing the affected package ids is enough; `group.main` propagates the bump to the grouped packages.
 
 Bump types:
 
@@ -163,7 +163,7 @@ Bump types:
 When ready to release, run:
 
 ```bash
-knope release
+mc release --commit --push --tag --publish-release
 ```
 
 This workflow:
@@ -175,15 +175,13 @@ This workflow:
 5. Commits and pushes
 6. Creates a GitHub release
 
-### Publishing with Knope
+### Publishing with monochange
 
 Use a dry run before any real publish:
 
 ```bash
-knope --dry-run publish
-knope --dry-run publish-day-1
-knope --dry-run publish-day-2
-knope --dry-run publish-day-3
+mc step:publish-readiness --from HEAD --format json
+mc publish --dry-run
 ```
 
 Important requirements before running publish workflows:
@@ -194,25 +192,20 @@ Important requirements before running publish workflows:
 For the first release, publish in staged workflows to handle pub.dev limits:
 
 ```bash
-# Day 1
-knope publish-day-1
-
-# Day 2
-knope publish-day-2
-
-# Day 3
-knope publish-day-3
+mc step:plan-publish-rate-limits --from HEAD --format md
+mc publish --dry-run
+mc publish
 ```
 
-All day workflows call the same publish command sequence as `knope publish`. This is intentional so you can rerun on later days and let Melos continue publishing unpublished package versions.
+For large publish sets, use monochange publish-readiness output and registry rate-limit planning to decide whether to publish in batches. The configured `mc publish` workflow delegates Dart package ordering to Melos and publishes the renderer package with pnpm.
 
 If limits are not a concern, publish everything in one pass:
 
 ```bash
-knope publish
+mc publish
 ```
 
-After each day, verify published versions on pub.dev before moving to the next workflow.
+After any publish batch, verify published versions on pub.dev before continuing.
 
 ## Publishing to pub.dev
 
@@ -236,7 +229,7 @@ Before publishing, verify each package meets these requirements:
    - Basic usage example
    - Link to API docs
 
-3. **CHANGELOG.md** exists and is up to date (managed by knope)
+3. **CHANGELOG.md** exists and is up to date (managed by monochange)
 
 4. **LICENSE** file exists at the repo root (applies to all packages)
 
@@ -263,7 +256,7 @@ Before publishing, verify each package meets these requirements:
 
 ### Dependency-Order Publishing
 
-Packages must be published in dependency order (leaf packages first). The `knope publish` workflow handles this automatically through `melos publish`, which computes package ordering from the workspace dependency graph.
+Packages must be published in dependency order (leaf packages first). The configured `mc publish` workflow handles this automatically through `melos publish`, which computes package ordering from the workspace dependency graph.
 
 The correct publishing order follows the layer table above:
 
@@ -277,26 +270,21 @@ The correct publishing order follows the layer table above:
 ### Running the Publish Workflow
 
 ```bash
-knope publish
+mc publish
 ```
 
 This workflow currently runs:
 
 1. `melos publish`
-2. `pnpm -r publish`
+2. `pnpm --filter codama-renderers-dart publish --access public --no-git-checks`
 
 ### Dry Run
 
 To verify all packages are ready to publish without actually publishing:
 
 ```bash
-# Full workflow dry run
-knope --dry-run publish
-
-# Staged workflow dry runs
-knope --dry-run publish-day-1
-knope --dry-run publish-day-2
-knope --dry-run publish-day-3
+mc step:publish-readiness --from HEAD --format json
+mc publish --dry-run
 ```
 
 ## Known Issues and Considerations
@@ -305,7 +293,7 @@ knope --dry-run publish-day-3
 
 1. **Namespace reservation**: All packages use the `solana_kit_` prefix. Once the first package is published, the namespace is effectively reserved. Ensure the verified publisher account is set up before initial publish.
 
-2. **pub.dev rate limits**: Publishing many packages in quick succession may trigger limits. For the first release, use staged workflows (`knope publish-day-1`, `knope publish-day-2`, `knope publish-day-3`) and verify results between days.
+2. **pub.dev rate limits**: Publishing many packages in quick succession may trigger limits. For the first release, use `mc step:plan-publish-rate-limits --from HEAD --format md` and verify results between any manual batches.
 
 3. **Verified publisher**: Set up a [verified publisher](https://dart.dev/tools/pub/verified-publishers) on pub.dev before publishing. This displays a verified badge and prevents package name squatting. All packages should be published under the same verified publisher.
 
@@ -340,7 +328,7 @@ Before the very first publish of any package:
 2. Set up a [verified publisher](https://dart.dev/tools/pub/verified-publishers)
 3. Run `dart pub login` to authenticate
 4. Verify all packages pass `dart pub publish --dry-run`
-5. Publish packages in dependency order starting from `solana_kit_errors` (use staged knope workflows for first release)
+5. Publish packages in dependency order starting from `solana_kit_errors` (use monochange readiness and rate-limit planning for first release)
 6. Verify each package appears on pub.dev before running the next publish workflow
 7. After all packages are published, verify the umbrella `solana_kit` package correctly resolves all dependencies from pub.dev
 
@@ -349,12 +337,12 @@ Before the very first publish of any package:
 The recommended CI/CD workflow for publishing:
 
 1. **PR merged to main**: CI checks run (analyze, test, format, changeset enforcement, docs drift check)
-2. **Release preparation**: Trigger the `Release` GitHub Actions workflow (`workflow_dispatch`) to run `knope release`
-3. **Publishing**: Trigger the `Publish` GitHub Actions workflow (`workflow_dispatch`) to run `knope publish` or `knope publish-day-*`
+2. **Release preparation**: The `release` GitHub Actions workflow opens or updates a monochange release PR with `mc release-pr`
+3. **Publishing**: Trigger the `publish` GitHub Actions workflow (`workflow_dispatch`) for a release tag after publish-readiness passes
 4. **Verification**: Check pub.dev for all packages with correct versions
 
 The GitHub Actions workflow should include:
 
-- A manually triggered `Release` workflow that runs `knope release`
-- A manually triggered `Publish` workflow that runs `knope publish` or one of the staged publish-day workflows
-- The publish job needs pub.dev credentials (`PUB_TOKEN`) and npm credentials (`NPM_TOKEN`) because `knope publish` runs both Dart and renderer publish commands
+- A `release` workflow that opens/updates the monochange release PR and tags release commits after merge
+- A manually triggered `publish` workflow that checks publish readiness and runs `mc publish` from a release tag
+- The publish job uses GitHub Actions OIDC trusted publishing (`id-token: write`) for pub.dev and npm provenance; configure trusted publishers in pub.dev and npm before using it.

--- a/monochange.toml
+++ b/monochange.toml
@@ -294,6 +294,17 @@ steps = [
   { type = "Command", name = "format with dprint", command = "dprint fmt --config dprint.json" },
 ]
 
+[cli.release-pr]
+help_text = "Prepare release changes and open or update the monochange release PR"
+inputs = [
+  { name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "markdown" },
+  { name = "no_verify", type = "boolean", default = true },
+]
+steps = [
+  { type = "PrepareRelease", name = "plan release", allow_empty_changesets = true, inputs = ["format"] },
+  { type = "OpenReleaseRequest", name = "open release PR", when = "{{ number_of_changesets > 0 }}", inputs = { format = "markdown", no_verify = "{{ inputs.no_verify }}", stage_all = true } },
+]
+
 [cli.release]
 help_text = "Prepare a local release: plan bumps, sync files, format, optionally commit, tag, and publish the GitHub release"
 inputs = [
@@ -318,6 +329,6 @@ steps = [
 [cli.publish]
 help_text = "Publish packages to registries (Dart via melos, NPM via pnpm). Must be run from a tagged release commit."
 steps = [
-  { type = "Command", name = "publish Dart packages", command = "melos publish --no-dry-run --yes", dry_run_command = "melos publish" },
-  { type = "Command", name = "publish NPM renderer", command = "pnpm --filter codama-renderers-dart publish", dry_run_command = "pnpm --filter codama-renderers-dart publish --dry-run" },
+  { type = "Command", name = "publish Dart packages", command = "melos publish --no-dry-run --yes", dry_run_command = "melos publish --dry-run --yes" },
+  { type = "Command", name = "publish NPM renderer", command = "pnpm --filter codama-renderers-dart publish --access public --no-git-checks", dry_run_command = "pnpm --filter codama-renderers-dart publish --dry-run --access public --no-git-checks" },
 ]

--- a/scripts/open_release_pr.dart
+++ b/scripts/open_release_pr.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+const _noReleasablePackages =
+    'no releaseable packages were found in discovered changesets';
+
+Future<void> main(List<String> args) async {
+  final result = await Process.run('mc', ['release-pr', ...args]);
+  final stdoutText = result.stdout.toString();
+  final stderrText = result.stderr.toString();
+
+  stdout.write(stdoutText);
+  stderr.write(stderrText);
+
+  if (result.exitCode == 0) {
+    return;
+  }
+
+  final output = '$stdoutText\n$stderrText';
+  if (output.contains(_noReleasablePackages)) {
+    stderr.writeln(
+      'No releasable monochange entries were found; skipping release PR update.',
+    );
+    return;
+  }
+
+  exitCode = result.exitCode;
+}

--- a/scripts/workspace-doc-drift.sh
+++ b/scripts/workspace-doc-drift.sh
@@ -17,10 +17,9 @@ if [[ "$mode" != "--check" && "$mode" != "--write" ]]; then
 fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-readme_file="$repo_root/readme.md"
 publishing_guide_file="$repo_root/docs/publishing-guide.md"
 
-for file in "$readme_file" "$publishing_guide_file"; do
+for file in "$publishing_guide_file"; do
   if [[ ! -f "$file" ]]; then
     echo "Missing required file: $file" >&2
     exit 2
@@ -182,7 +181,6 @@ apply_or_check_file() {
   fi
 }
 
-apply_or_check_file "$readme_file"
 apply_or_check_file "$publishing_guide_file"
 
 if [[ "$mode" == "--write" ]]; then


### PR DESCRIPTION
## Summary

- Adds a monochange release workflow that opens/updates release PRs, then tags release commits and publishes GitHub release notes from the embedded monochange release record.
- Adds a trusted-publishing workflow for release tags with OIDC permissions, publish-readiness checks, dry-run publishing, and `mc publish`.
- Adds the repository-local `mc release-pr` workflow, hardens `mc publish` dry-run/npm publish flags, removes Knope from devenv tooling, and updates release docs to monochange.

Closes #150

## Audit notes

Already present on `main` before this branch:
- `monochange.toml` with Dart and npm packages, `group.main`, source provider config, affected changeset policy, and `mc release`/`mc publish` commands.
- Converted `.changeset/*.md` files (no `default:` Knope frontmatter remains).
- CI validation for `mc step:validate` and a separate changeset policy workflow.
- `knope.toml` was already removed.

Missing pieces implemented here:
- Release PR/tag/release-note GitHub Actions automation.
- Manual trusted-publishing GitHub Actions workflow for package publishing from a release tag.
- `mc release-pr` configured workflow and publish command flag fixes.
- Removal of `extra.knope` from devenv and stale Knope release docs.

## Checks run

- `devenv shell -- bash -lc 'dprint fmt --config dprint.json ...'`
- `devenv shell -- bash -lc 'dart format scripts/open_release_pr.dart'`
- `devenv shell -- bash -lc 'dart analyze scripts/open_release_pr.dart'`
- `devenv shell -- bash -lc 'mc step:validate'`
- `devenv shell -- bash -lc 'mc check'`
- `devenv shell -- bash -lc 'dart run scripts/open_release_pr.dart --dry-run --format json'`
- `devenv shell -- bash -lc 'mc help | grep -E "release-pr|publish"'`
- `devenv shell -- bash -lc 'git diff --check'`
- `devenv shell -- bash -lc 'ruby -e ... .github/workflows/release.yml .github/workflows/publish.yml'`
