### PR TITLE
✨ feat(memo): add memo program package

### DIFF
--- a/.changeset/add-memo-program.md
+++ b/.changeset/add-memo-program.md
@@ -1,0 +1,7 @@
+---
+"solana_kit_memo": minor
+---
+
+# Add Memo program package
+
+Added `solana_kit_memo` with generated AddMemo codecs, current and legacy program addresses, ergonomic memo instruction helper, documentation, and tests.

--- a/codecov.yml
+++ b/codecov.yml
@@ -73,6 +73,9 @@ flags:
   solana_kit_mobile_wallet_adapter_protocol:
     paths:
       - packages/solana_kit_mobile_wallet_adapter_protocol
+  solana_kit_memo:
+    paths:
+      - packages/solana_kit_memo
   solana_kit_offchain_messages:
     paths:
       - packages/solana_kit_offchain_messages

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -6,7 +6,7 @@ This guide covers how to version, release, and publish the `solana_kit` Dart SDK
 
 <!-- workspace-summary:start -->
 
-This monorepo contains **48 packages** under `packages/`: **46 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
+This monorepo contains **49 packages** under `packages/`: **47 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
 
 <!-- workspace-summary:end -->
 
@@ -95,6 +95,7 @@ solana_kit_instruction_plans -> solana_kit_errors, solana_kit_instructions, sola
 solana_kit_instructions -> solana_kit_addresses, solana_kit_errors
 solana_kit_keys -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
 solana_kit_lints -> (none)
+solana_kit_memo -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_strings, solana_kit_instructions
 solana_kit_mobile_wallet_adapter -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_mobile_wallet_adapter_protocol, solana_kit_transactions
 solana_kit_mobile_wallet_adapter_protocol -> solana_kit_codecs_strings, solana_kit_errors
 solana_kit_mpl_bubblegum -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_errors, solana_kit_instruction_plans, solana_kit_instructions, solana_kit_keys, solana_kit_spl_account_compression

--- a/monochange.toml
+++ b/monochange.toml
@@ -166,6 +166,11 @@ path = "packages/solana_kit_mpl_bubblegum"
 tag = true
 release = false
 
+[package.solana_kit_memo]
+path = "packages/solana_kit_memo"
+tag = true
+release = false
+
 [package.solana_kit_token]
 path = "packages/solana_kit_token"
 tag = true
@@ -213,6 +218,7 @@ packages = [
   "solana_kit_instructions",
   "solana_kit_keys",
   "solana_kit_lints",
+  "solana_kit_memo",
   "solana_kit_options",
   "solana_kit_program_client_core",
   "solana_kit_programs",

--- a/packages/solana_kit_memo/CHANGELOG.md
+++ b/packages/solana_kit_memo/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
+## 0.4.0 (2026-05-30)
+
+### 🚀 Feature
+
+#### New package available
+
+Memo program client for the Solana Kit Dart SDK. Provides AddMemo codecs,
+current and legacy program addresses, and a helper for building UTF-8 memo
+instructions.

--- a/packages/solana_kit_memo/LICENSE
+++ b/packages/solana_kit_memo/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ifiok Jr.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/solana_kit_memo/README.md
+++ b/packages/solana_kit_memo/README.md
@@ -1,0 +1,47 @@
+# solana_kit_memo
+
+[![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_memo)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_memo)
+Memo program client for the
+[Solana Kit](https://github.com/openbudgetfun/solana_kit) Dart SDK.
+
+Provides generated codecs and ergonomic helpers for the Memo program, which
+attaches arbitrary UTF-8 memo text to Solana transactions.
+
+## Installation
+
+```yaml
+dependencies:
+  solana_kit_memo: ^0.4.0
+```
+
+## Usage
+
+```dart
+import 'package:solana_kit_memo/solana_kit_memo.dart';
+
+final instruction = getAddMemoInstruction(memo: 'Hello from Solana Kit');
+```
+
+Use `memoLegacyProgramAddress` when you need to target the legacy Memo program:
+
+```dart
+final legacyInstruction = getAddMemoInstruction(
+  memo: 'legacy memo',
+  programAddress: memoLegacyProgramAddress,
+);
+```
+
+## Key APIs
+
+- `getAddMemoInstruction({required String memo})` — builds a Memo instruction from plain
+  Dart text.
+- `AddMemoInstructionData` — generated instruction data model.
+- `getAddMemoInstructionDataCodec()` — UTF-8 codec for AddMemo data.
+- `memoProgramAddress` — current Memo program address.
+- `memoLegacyProgramAddress` — legacy Memo program address.
+
+## Upstream reference
+
+Generated layer mirrors
+[solana-program/memo](https://github.com/solana-program/memo)
+at `js@v0.11.0`.

--- a/packages/solana_kit_memo/lib/solana_kit_memo.dart
+++ b/packages/solana_kit_memo/lib/solana_kit_memo.dart
@@ -1,0 +1,16 @@
+/// Memo program client for the Solana Kit Dart SDK.
+///
+/// Provides codecs and an ergonomic instruction builder for the Memo program,
+/// which attaches arbitrary UTF-8 memo text to transactions.
+///
+/// ## Quick start
+///
+/// ```dart
+/// import 'package:solana_kit_memo/solana_kit_memo.dart';
+///
+/// final instruction = getAddMemoInstruction(memo: 'Hello from Solana Kit');
+/// ```
+library;
+
+export 'src/add_memo.dart';
+export 'src/generated/memo.dart';

--- a/packages/solana_kit_memo/lib/src/add_memo.dart
+++ b/packages/solana_kit_memo/lib/src/add_memo.dart
@@ -1,0 +1,15 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_memo/src/generated/instructions/add_memo.dart';
+import 'package:solana_kit_memo/src/generated/programs/memo.dart';
+
+/// Creates a Memo program instruction from plain UTF-8 [memo] text.
+Instruction getAddMemoInstruction({
+  required String memo,
+  Address programAddress = memoProgramAddress,
+}) {
+  return getAddMemoInstructionFromData(
+    data: AddMemoInstructionData(memo: memo),
+    programAddress: programAddress,
+  );
+}

--- a/packages/solana_kit_memo/lib/src/generated/instructions/add_memo.dart
+++ b/packages/solana_kit_memo/lib/src/generated/instructions/add_memo.dart
@@ -1,0 +1,83 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_memo/src/generated/programs/memo.dart';
+
+/// Data for the AddMemo instruction.
+@immutable
+class AddMemoInstructionData {
+  /// Creates [AddMemoInstructionData].
+  const AddMemoInstructionData({required this.memo});
+
+  /// Memo text encoded as raw UTF-8 instruction data.
+  final String memo;
+
+  @override
+  String toString() => 'AddMemoInstructionData(memo: $memo)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is AddMemoInstructionData && other.memo == memo;
+
+  @override
+  int get hashCode => memo.hashCode;
+}
+
+/// Returns the encoder for [AddMemoInstructionData].
+Encoder<AddMemoInstructionData> getAddMemoInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('memo', getUtf8Encoder()),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (AddMemoInstructionData value) => <String, Object?>{'memo': value.memo},
+  );
+}
+
+/// Returns the decoder for [AddMemoInstructionData].
+Decoder<AddMemoInstructionData> getAddMemoInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('memo', getUtf8Decoder()),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, Uint8List bytes, int offset) =>
+        AddMemoInstructionData(memo: map['memo']! as String),
+  );
+}
+
+/// Returns the codec for [AddMemoInstructionData].
+Codec<AddMemoInstructionData, AddMemoInstructionData>
+getAddMemoInstructionDataCodec() {
+  return combineCodec(
+    getAddMemoInstructionDataEncoder(),
+    getAddMemoInstructionDataDecoder(),
+  );
+}
+
+/// Creates an AddMemo instruction from generated instruction data.
+Instruction getAddMemoInstructionFromData({
+  required AddMemoInstructionData data,
+  List<AccountMeta> accounts = const [],
+  Address programAddress = memoProgramAddress,
+}) {
+  return Instruction(
+    programAddress: programAddress,
+    accounts: accounts,
+    data: getAddMemoInstructionDataEncoder().encode(data),
+  );
+}
+
+/// Parses an AddMemo instruction from [instruction].
+AddMemoInstructionData parseAddMemoInstruction(Instruction instruction) {
+  return getAddMemoInstructionDataDecoder().decode(instruction.data!);
+}

--- a/packages/solana_kit_memo/lib/src/generated/instructions/instructions.dart
+++ b/packages/solana_kit_memo/lib/src/generated/instructions/instructions.dart
@@ -1,0 +1,3 @@
+// ignore_for_file: public_member_api_docs
+
+export 'add_memo.dart';

--- a/packages/solana_kit_memo/lib/src/generated/memo.dart
+++ b/packages/solana_kit_memo/lib/src/generated/memo.dart
@@ -1,0 +1,9 @@
+// ignore_for_file: public_member_api_docs
+
+/// Generated Memo program layer.
+///
+/// Mirrors the upstream Codama-generated TypeScript at `js@v0.11.0`.
+library;
+
+export 'instructions/instructions.dart';
+export 'programs/programs.dart';

--- a/packages/solana_kit_memo/lib/src/generated/programs/memo.dart
+++ b/packages/solana_kit_memo/lib/src/generated/programs/memo.dart
@@ -1,0 +1,13 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+/// Current Memo program address.
+const memoProgramAddress = Address(
+  'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr',
+);
+
+/// Legacy Memo program address.
+const memoLegacyProgramAddress = Address(
+  'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo',
+);

--- a/packages/solana_kit_memo/lib/src/generated/programs/programs.dart
+++ b/packages/solana_kit_memo/lib/src/generated/programs/programs.dart
@@ -1,0 +1,3 @@
+// ignore_for_file: public_member_api_docs
+
+export 'memo.dart';

--- a/packages/solana_kit_memo/pubspec.yaml
+++ b/packages/solana_kit_memo/pubspec.yaml
@@ -1,0 +1,22 @@
+name: solana_kit_memo
+description: Memo program client for the Solana Kit Dart SDK.
+version: 0.4.0
+repository: https://github.com/openbudgetfun/solana_kit
+homepage: https://openbudgetfun.github.io/solana_kit/
+
+environment:
+  sdk: ^3.10.1
+
+resolution: workspace
+
+dependencies:
+  meta: ^1.16.0
+  solana_kit_addresses: ^0.4.0
+  solana_kit_codecs_core: ^0.4.0
+  solana_kit_codecs_data_structures: ^0.4.0
+  solana_kit_codecs_strings: ^0.4.0
+  solana_kit_instructions: ^0.4.0
+
+dev_dependencies:
+  solana_kit_lints: ^0.4.0
+  test: ^1.25.0

--- a/packages/solana_kit_memo/test/add_memo_test.dart
+++ b/packages/solana_kit_memo/test/add_memo_test.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_memo/solana_kit_memo.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AddMemo', () {
+    test('known memo string produces UTF-8 encoded bytes', () {
+      final instruction = getAddMemoInstruction(memo: 'Hello, memo!');
+
+      expect(instruction.programAddress, equals(memoProgramAddress));
+      expect(instruction.accounts, isEmpty);
+      expect(
+        instruction.data,
+        equals(
+          Uint8List.fromList([
+            72,
+            101,
+            108,
+            108,
+            111,
+            44,
+            32,
+            109,
+            101,
+            109,
+            111,
+            33,
+          ]),
+        ),
+      );
+    });
+
+    test('non-ASCII memo string produces UTF-8 encoded bytes', () {
+      final instruction = getAddMemoInstruction(memo: 'memo 語');
+
+      expect(
+        instruction.data,
+        equals(Uint8List.fromList(utf8.encode('memo 語'))),
+      );
+    });
+
+    test('codec round-trips instruction data', () {
+      const original = AddMemoInstructionData(memo: 'Solana Kit memo');
+      final codec = getAddMemoInstructionDataCodec();
+      final encoded = codec.encode(original);
+      final decoded = codec.decode(encoded);
+
+      expect(decoded, equals(original));
+      expect(encoded, equals(Uint8List.fromList(utf8.encode(original.memo))));
+    });
+
+    test('parseAddMemoInstruction decodes instruction data', () {
+      final instruction = getAddMemoInstruction(memo: 'parsed memo');
+
+      expect(
+        parseAddMemoInstruction(instruction),
+        equals(const AddMemoInstructionData(memo: 'parsed memo')),
+      );
+    });
+
+    test('getAddMemoInstructionFromData preserves custom accounts', () {
+      const signer = AccountMeta(
+        address: Address('11111111111111111111111111111111'),
+        role: AccountRole.readonlySigner,
+      );
+      final instruction = getAddMemoInstructionFromData(
+        data: const AddMemoInstructionData(memo: 'signed memo'),
+        accounts: const [signer],
+      );
+
+      expect(instruction.accounts, equals(const [signer]));
+    });
+
+    test('supports legacy memo program address', () {
+      final instruction = getAddMemoInstruction(
+        memo: 'legacy memo',
+        programAddress: memoLegacyProgramAddress,
+      );
+
+      expect(instruction.programAddress, equals(memoLegacyProgramAddress));
+    });
+
+    test('value equality and toString', () {
+      const a = AddMemoInstructionData(memo: 'same');
+      const b = AddMemoInstructionData(memo: 'same');
+      const c = AddMemoInstructionData(memo: 'different');
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      expect(a.toString(), contains('same'));
+    });
+  });
+}

--- a/packages/solana_kit_memo/test/barrel_test.dart
+++ b/packages/solana_kit_memo/test/barrel_test.dart
@@ -1,0 +1,24 @@
+import 'package:solana_kit_memo/solana_kit_memo.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('barrel exports', () {
+    test('program addresses are accessible', () {
+      expect(
+        memoProgramAddress.value,
+        equals('MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr'),
+      );
+      expect(
+        memoLegacyProgramAddress.value,
+        equals('Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo'),
+      );
+    });
+
+    test('instruction helper is callable', () {
+      final instruction = getAddMemoInstruction(memo: 'barrel');
+
+      expect(instruction.programAddress, equals(memoProgramAddress));
+      expect(parseAddMemoInstruction(instruction).memo, equals('barrel'));
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ workspace:
   - packages/solana_kit_mobile_wallet_adapter
   - packages/solana_kit_mobile_wallet_adapter_protocol
   - packages/solana_kit_mpl_bubblegum
+  - packages/solana_kit_memo
   - packages/solana_kit_offchain_messages
   - packages/solana_kit_options
   - packages/solana_kit_program_client_core


### PR DESCRIPTION
## Summary
- Add `solana_kit_memo` with generated Memo program addresses and AddMemo codecs
- Add ergonomic `getAddMemoInstruction` helper plus README, changelog, and tests
- Register the package in workspace, monochange, and Codecov config

## Validation
- `dart analyze packages/solana_kit_memo`
- `dart test packages/solana_kit_memo`
- `dart pub publish --dry-run -C packages/solana_kit_memo`
- `monochange check`

Closes #135