### PR TITLE
feat: add loader program package

### DIFF
--- a/.changeset/loader-program.md
+++ b/.changeset/loader-program.md
@@ -1,0 +1,5 @@
+---
+"solana_kit_loader": minor
+---
+
+Add a new loader package with BPF Loader v3 (Upgradeable) and Loader v4 program addresses, instruction builders, account header codecs, and deployment/upgrade instruction plan helpers.

--- a/codecov.yml
+++ b/codecov.yml
@@ -67,6 +67,9 @@ flags:
   solana_kit_lints:
     paths:
       - packages/solana_kit_lints
+  solana_kit_loader:
+    paths:
+      - packages/solana_kit_loader
   solana_kit_mobile_wallet_adapter:
     paths:
       - packages/solana_kit_mobile_wallet_adapter

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -6,7 +6,7 @@ This guide covers how to version, release, and publish the `solana_kit` Dart SDK
 
 <!-- workspace-summary:start -->
 
-This monorepo contains **49 packages** under `packages/`: **47 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
+This monorepo contains **50 packages** under `packages/`: **48 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
 
 <!-- workspace-summary:end -->
 
@@ -95,6 +95,7 @@ solana_kit_instruction_plans -> solana_kit_errors, solana_kit_instructions, sola
 solana_kit_instructions -> solana_kit_addresses, solana_kit_errors
 solana_kit_keys -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_strings, solana_kit_errors
 solana_kit_lints -> (none)
+solana_kit_loader -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instruction_plans, solana_kit_instructions
 solana_kit_memo -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_strings, solana_kit_instructions
 solana_kit_mobile_wallet_adapter -> solana_kit_addresses, solana_kit_errors, solana_kit_keys, solana_kit_mobile_wallet_adapter_protocol, solana_kit_transactions
 solana_kit_mobile_wallet_adapter_protocol -> solana_kit_codecs_strings, solana_kit_errors

--- a/monochange.toml
+++ b/monochange.toml
@@ -80,6 +80,11 @@ path = "packages/solana_kit_keys"
 [package.solana_kit_lints]
 path = "packages/solana_kit_lints"
 
+[package.solana_kit_loader]
+path = "packages/solana_kit_loader"
+tag = true
+release = false
+
 [package.solana_kit_mobile_wallet_adapter]
 path = "packages/solana_kit_mobile_wallet_adapter"
 tag = true
@@ -218,6 +223,7 @@ packages = [
   "solana_kit_instructions",
   "solana_kit_keys",
   "solana_kit_lints",
+  "solana_kit_loader",
   "solana_kit_memo",
   "solana_kit_options",
   "solana_kit_program_client_core",

--- a/packages/solana_kit_loader/CHANGELOG.md
+++ b/packages/solana_kit_loader/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.4.0
+
+- Initial release of the `solana_kit_loader` package with BPF Loader v3 and Loader v4 program constants, account codecs, instruction builders, parsers, and deployment/upgrade instruction plan helpers.

--- a/packages/solana_kit_loader/LICENSE
+++ b/packages/solana_kit_loader/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ifiok Jr.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/solana_kit_loader/README.md
+++ b/packages/solana_kit_loader/README.md
@@ -1,0 +1,36 @@
+# solana_kit_loader
+
+[![pub package](https://img.shields.io/pub/v/solana_kit_loader.svg)](https://pub.dev/packages/solana_kit_loader)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+
+Dart helpers for Solana's BPF Loader v3 (Upgradeable) and Loader v4 programs.
+
+## Usage
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_loader/solana_kit_loader.dart';
+
+final instruction = getLoaderV3WriteInstruction(
+  bufferAccount: const Address('11111111111111111111111111111111'),
+  bufferAuthority: const Address('11111111111111111111111111111112'),
+  offset: 0,
+  bytes: Uint8List.fromList([1, 2, 3]),
+);
+```
+
+## Key APIs
+
+- Program constants: `bpfLoaderUpgradeableProgramAddress`, `loaderV4ProgramAddress`.
+- Loader v3 instructions: initialize buffer, write, deploy with max data length,
+  upgrade, set authority, close, extend program, and checked authority update.
+- Loader v3 account codecs: `BufferAccount`, `ProgramDataAccount`.
+- Loader v4 instructions: write, truncate, deploy, retract, transfer authority,
+  and finalize.
+- Loader v4 account codec: `ProgramStateAccount`.
+- Planning helpers: `getDeployProgramInstructionPlan` and
+  `getUpgradeProgramInstructionPlan` chunk program bytes into loader writes before
+  the deploy or upgrade instruction.

--- a/packages/solana_kit_loader/lib/solana_kit_loader.dart
+++ b/packages/solana_kit_loader/lib/solana_kit_loader.dart
@@ -1,0 +1,11 @@
+/// BPF Loader v3 (Upgradeable) and Loader v4 support for Solana Kit.
+library;
+
+export 'src/generated/accounts/buffer.dart';
+export 'src/generated/accounts/program_data.dart';
+export 'src/generated/accounts/program_state.dart';
+export 'src/generated/instructions/loader_v3.dart';
+export 'src/generated/instructions/loader_v4.dart';
+export 'src/generated/programs/bpf_loader_upgradeable.dart';
+export 'src/generated/programs/loader_v4.dart';
+export 'src/helpers.dart';

--- a/packages/solana_kit_loader/lib/src/generated/accounts/buffer.dart
+++ b/packages/solana_kit_loader/lib/src/generated/accounts/buffer.dart
@@ -1,0 +1,72 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+const bufferAccountDiscriminator = 1;
+const bufferAccountSize = 40;
+
+@immutable
+class BufferAccount {
+  const BufferAccount({this.authorityAddress});
+
+  final Address? authorityAddress;
+
+  @override
+  bool operator ==(Object other) =>
+      other is BufferAccount && other.authorityAddress == authorityAddress;
+
+  @override
+  int get hashCode => authorityAddress.hashCode;
+
+  @override
+  String toString() => 'BufferAccount(authorityAddress: $authorityAddress)';
+}
+
+Encoder<BufferAccount> getBufferAccountEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+    (
+      'authorityAddress',
+      getNullableEncoder<Address>(
+        getAddressEncoder(),
+        prefix: getU32Encoder(),
+        noneValue: const ZeroesNoneValue(),
+      ),
+    ),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (BufferAccount value) => <String, Object?>{
+      'discriminator': bufferAccountDiscriminator,
+      'authorityAddress': value.authorityAddress,
+    },
+  );
+}
+
+Decoder<BufferAccount> getBufferAccountDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+    (
+      'authorityAddress',
+      getNullableDecoder<Address>(
+        getAddressDecoder(),
+        prefix: getU32Decoder(),
+        noneValue: const ZeroesNoneValue(),
+      ),
+    ),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, _, _) =>
+        BufferAccount(authorityAddress: map['authorityAddress'] as Address?),
+  );
+}
+
+Codec<BufferAccount, BufferAccount> getBufferAccountCodec() =>
+    combineCodec(getBufferAccountEncoder(), getBufferAccountDecoder());

--- a/packages/solana_kit_loader/lib/src/generated/accounts/program_data.dart
+++ b/packages/solana_kit_loader/lib/src/generated/accounts/program_data.dart
@@ -1,0 +1,85 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+const programDataAccountDiscriminator = 3;
+const programDataAccountSize = 48;
+
+@immutable
+class ProgramDataAccount {
+  const ProgramDataAccount({required this.slot, this.upgradeAuthorityAddress});
+
+  final BigInt slot;
+  final Address? upgradeAuthorityAddress;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ProgramDataAccount &&
+      other.slot == slot &&
+      other.upgradeAuthorityAddress == upgradeAuthorityAddress;
+
+  @override
+  int get hashCode => Object.hash(slot, upgradeAuthorityAddress);
+
+  @override
+  String toString() =>
+      'ProgramDataAccount(slot: $slot, '
+      'upgradeAuthorityAddress: $upgradeAuthorityAddress)';
+}
+
+Encoder<ProgramDataAccount> getProgramDataAccountEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+    ('slot', getU64Encoder()),
+    (
+      'upgradeAuthorityAddress',
+      getNullableEncoder<Address>(
+        getAddressEncoder(),
+        prefix: getU32Encoder(),
+        noneValue: const ZeroesNoneValue(),
+      ),
+    ),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (ProgramDataAccount value) => <String, Object?>{
+      'discriminator': programDataAccountDiscriminator,
+      'slot': value.slot,
+      'upgradeAuthorityAddress': value.upgradeAuthorityAddress,
+    },
+  );
+}
+
+Decoder<ProgramDataAccount> getProgramDataAccountDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+    ('slot', getU64Decoder()),
+    (
+      'upgradeAuthorityAddress',
+      getNullableDecoder<Address>(
+        getAddressDecoder(),
+        prefix: getU32Decoder(),
+        noneValue: const ZeroesNoneValue(),
+      ),
+    ),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, _, _) => ProgramDataAccount(
+      slot: map['slot']! as BigInt,
+      upgradeAuthorityAddress: map['upgradeAuthorityAddress'] as Address?,
+    ),
+  );
+}
+
+Codec<ProgramDataAccount, ProgramDataAccount> getProgramDataAccountCodec() =>
+    combineCodec(
+      getProgramDataAccountEncoder(),
+      getProgramDataAccountDecoder(),
+    );

--- a/packages/solana_kit_loader/lib/src/generated/accounts/program_state.dart
+++ b/packages/solana_kit_loader/lib/src/generated/accounts/program_state.dart
@@ -1,0 +1,97 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+const programStateAccountSize = 48;
+
+enum LoaderV4Status { retracted, deployed, finalized }
+
+@immutable
+class ProgramStateAccount {
+  const ProgramStateAccount({
+    required this.slot,
+    required this.authorityAddressOrNextVersion,
+    required this.status,
+  });
+
+  final BigInt slot;
+  final Address authorityAddressOrNextVersion;
+  final LoaderV4Status status;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ProgramStateAccount &&
+      other.slot == slot &&
+      other.authorityAddressOrNextVersion == authorityAddressOrNextVersion &&
+      other.status == status;
+
+  @override
+  int get hashCode => Object.hash(slot, authorityAddressOrNextVersion, status);
+
+  @override
+  String toString() =>
+      'ProgramStateAccount(slot: $slot, '
+      'authorityAddressOrNextVersion: $authorityAddressOrNextVersion, '
+      'status: $status)';
+}
+
+Encoder<LoaderV4Status> getLoaderV4StatusEncoder() =>
+    transformEncoder(getU8Encoder(), (LoaderV4Status value) => value.index);
+
+Decoder<LoaderV4Status> getLoaderV4StatusDecoder() => transformDecoder(
+  getU8Decoder(),
+  (int value, _, _) => LoaderV4Status.values[value],
+);
+
+Codec<LoaderV4Status, LoaderV4Status> getLoaderV4StatusCodec() =>
+    combineCodec(getLoaderV4StatusEncoder(), getLoaderV4StatusDecoder());
+
+Encoder<ProgramStateAccount> getProgramStateAccountEncoder() =>
+    FixedSizeEncoder<ProgramStateAccount>(
+      fixedSize: programStateAccountSize,
+      write: (value, bytes, offset) {
+        var cursor = offset;
+        cursor = getU64Encoder().write(value.slot, bytes, cursor);
+        cursor = getAddressEncoder().write(
+          value.authorityAddressOrNextVersion,
+          bytes,
+          cursor,
+        );
+        cursor = getLoaderV4StatusEncoder().write(value.status, bytes, cursor);
+        bytes.setRange(cursor, cursor + 7, Uint8List(7));
+        return cursor + 7;
+      },
+    );
+
+Decoder<ProgramStateAccount> getProgramStateAccountDecoder() =>
+    FixedSizeDecoder<ProgramStateAccount>(
+      fixedSize: programStateAccountSize,
+      read: (bytes, offset) {
+        var cursor = offset;
+        final slot = getU64Decoder().read(bytes, cursor);
+        cursor = slot.$2;
+        final authority = getAddressDecoder().read(bytes, cursor);
+        cursor = authority.$2;
+        final status = getLoaderV4StatusDecoder().read(bytes, cursor);
+        cursor = status.$2 + 7;
+        return (
+          ProgramStateAccount(
+            slot: slot.$1,
+            authorityAddressOrNextVersion: authority.$1,
+            status: status.$1,
+          ),
+          cursor,
+        );
+      },
+    );
+
+Codec<ProgramStateAccount, ProgramStateAccount> getProgramStateAccountCodec() =>
+    combineCodec(
+      getProgramStateAccountEncoder(),
+      getProgramStateAccountDecoder(),
+    );

--- a/packages/solana_kit_loader/lib/src/generated/instructions/loader_v3.dart
+++ b/packages/solana_kit_loader/lib/src/generated/instructions/loader_v3.dart
@@ -1,0 +1,345 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_loader/src/generated/programs/bpf_loader_upgradeable.dart';
+
+const initializeBufferDiscriminator = 0;
+const loaderV3WriteDiscriminator = 1;
+const deployWithMaxProgramLenDiscriminator = 2;
+const upgradeDiscriminator = 3;
+const setAuthorityDiscriminator = 4;
+const closeDiscriminator = 5;
+const extendProgramDiscriminator = 6;
+const setAuthorityCheckedDiscriminator = 7;
+
+const rentSysvarAddress = Address(
+  'SysvarRent111111111111111111111111111111111',
+);
+const clockSysvarAddress = Address(
+  'SysvarC1ock11111111111111111111111111111111',
+);
+const systemProgramAddress = Address('11111111111111111111111111111111');
+
+AccountMeta _account(
+  Address address, {
+  required bool writable,
+  bool signer = false,
+}) {
+  final role = switch ((writable, signer)) {
+    (true, true) => AccountRole.writableSigner,
+    (true, false) => AccountRole.writable,
+    (false, true) => AccountRole.readonlySigner,
+    (false, false) => AccountRole.readonly,
+  };
+  return AccountMeta(address: address, role: role);
+}
+
+Encoder<num> _getU64SizePrefixEncoder() =>
+    transformEncoder<BigInt, num>(getU64Encoder(), BigInt.from);
+
+Decoder<num> _getU64SizePrefixDecoder() => transformDecoder<BigInt, num>(
+  getU64Decoder(),
+  (value, _, _) => value.toInt(),
+);
+
+@immutable
+class LoaderV3WriteInstructionData {
+  const LoaderV3WriteInstructionData({
+    required this.offset,
+    required this.bytes,
+    this.discriminator = loaderV3WriteDiscriminator,
+  });
+
+  final int discriminator;
+  final int offset;
+  final Uint8List bytes;
+}
+
+Encoder<LoaderV3WriteInstructionData> getLoaderV3WriteInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+    ('offset', getU32Encoder()),
+    (
+      'bytes',
+      addEncoderSizePrefix(getBytesEncoder(), _getU64SizePrefixEncoder()),
+    ),
+  ]);
+  return transformEncoder(
+    structEncoder,
+    (LoaderV3WriteInstructionData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+      'offset': value.offset,
+      'bytes': value.bytes,
+    },
+  );
+}
+
+Decoder<LoaderV3WriteInstructionData> getLoaderV3WriteInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+    ('offset', getU32Decoder()),
+    (
+      'bytes',
+      addDecoderSizePrefix(getBytesDecoder(), _getU64SizePrefixDecoder()),
+    ),
+  ]);
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, _, _) => LoaderV3WriteInstructionData(
+      discriminator: map['discriminator']! as int,
+      offset: map['offset']! as int,
+      bytes: map['bytes']! as Uint8List,
+    ),
+  );
+}
+
+@immutable
+class DeployWithMaxProgramLenInstructionData {
+  const DeployWithMaxProgramLenInstructionData({
+    required this.maxDataLen,
+    this.discriminator = deployWithMaxProgramLenDiscriminator,
+  });
+
+  final int discriminator;
+  final BigInt maxDataLen;
+}
+
+Encoder<DeployWithMaxProgramLenInstructionData>
+getDeployWithMaxProgramLenInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+    ('maxDataLen', getU64Encoder()),
+  ]);
+  return transformEncoder(
+    structEncoder,
+    (DeployWithMaxProgramLenInstructionData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+      'maxDataLen': value.maxDataLen,
+    },
+  );
+}
+
+Decoder<DeployWithMaxProgramLenInstructionData>
+getDeployWithMaxProgramLenInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+    ('maxDataLen', getU64Decoder()),
+  ]);
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, _, _) => DeployWithMaxProgramLenInstructionData(
+      discriminator: map['discriminator']! as int,
+      maxDataLen: map['maxDataLen']! as BigInt,
+    ),
+  );
+}
+
+@immutable
+class ExtendProgramInstructionData {
+  const ExtendProgramInstructionData({
+    required this.additionalBytes,
+    this.discriminator = extendProgramDiscriminator,
+  });
+
+  final int discriminator;
+  final int additionalBytes;
+}
+
+Encoder<ExtendProgramInstructionData> getExtendProgramInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU32Encoder()),
+    ('additionalBytes', getU32Encoder()),
+  ]);
+  return transformEncoder(
+    structEncoder,
+    (ExtendProgramInstructionData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+      'additionalBytes': value.additionalBytes,
+    },
+  );
+}
+
+Decoder<ExtendProgramInstructionData> getExtendProgramInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU32Decoder()),
+    ('additionalBytes', getU32Decoder()),
+  ]);
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, _, _) => ExtendProgramInstructionData(
+      discriminator: map['discriminator']! as int,
+      additionalBytes: map['additionalBytes']! as int,
+    ),
+  );
+}
+
+Uint8List _discriminatorData(int discriminator) =>
+    getU32Encoder().encode(discriminator);
+
+int parseDiscriminator(Instruction instruction) =>
+    getU32Decoder().decode(instruction.data!);
+
+Instruction getInitializeBufferInstruction({
+  required Address sourceAccount,
+  required Address bufferAuthority,
+  Address programAddress = bpfLoaderUpgradeableProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(sourceAccount, writable: true),
+    _account(bufferAuthority, writable: false),
+  ],
+  data: _discriminatorData(initializeBufferDiscriminator),
+);
+
+Instruction getLoaderV3WriteInstruction({
+  required Address bufferAccount,
+  required Address bufferAuthority,
+  required int offset,
+  required Uint8List bytes,
+  Address programAddress = bpfLoaderUpgradeableProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(bufferAccount, writable: true),
+    _account(bufferAuthority, writable: false, signer: true),
+  ],
+  data: getLoaderV3WriteInstructionDataEncoder().encode(
+    LoaderV3WriteInstructionData(offset: offset, bytes: bytes),
+  ),
+);
+
+LoaderV3WriteInstructionData parseLoaderV3WriteInstruction(Instruction ix) =>
+    getLoaderV3WriteInstructionDataDecoder().decode(ix.data!);
+
+Instruction getDeployWithMaxProgramLenInstruction({
+  required Address payerAccount,
+  required Address programDataAccount,
+  required Address programAccount,
+  required Address bufferAccount,
+  required Address authority,
+  required BigInt maxDataLen,
+  Address rentSysvar = rentSysvarAddress,
+  Address clockSysvar = clockSysvarAddress,
+  Address systemProgram = systemProgramAddress,
+  Address instructionProgramAddress = bpfLoaderUpgradeableProgramAddress,
+}) => Instruction(
+  programAddress: instructionProgramAddress,
+  accounts: [
+    _account(payerAccount, writable: true, signer: true),
+    _account(programDataAccount, writable: true),
+    _account(programAccount, writable: true),
+    _account(bufferAccount, writable: true),
+    _account(rentSysvar, writable: false),
+    _account(clockSysvar, writable: false),
+    _account(systemProgram, writable: false),
+    _account(authority, writable: false, signer: true),
+  ],
+  data: getDeployWithMaxProgramLenInstructionDataEncoder().encode(
+    DeployWithMaxProgramLenInstructionData(maxDataLen: maxDataLen),
+  ),
+);
+
+DeployWithMaxProgramLenInstructionData parseDeployWithMaxProgramLenInstruction(
+  Instruction ix,
+) => getDeployWithMaxProgramLenInstructionDataDecoder().decode(ix.data!);
+
+Instruction getUpgradeInstruction({
+  required Address programDataAccount,
+  required Address programAccount,
+  required Address bufferAccount,
+  required Address spillAccount,
+  required Address authority,
+  Address rentSysvar = rentSysvarAddress,
+  Address clockSysvar = clockSysvarAddress,
+  Address programAddress = bpfLoaderUpgradeableProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(programDataAccount, writable: true),
+    _account(programAccount, writable: true),
+    _account(bufferAccount, writable: true),
+    _account(spillAccount, writable: true),
+    _account(rentSysvar, writable: false),
+    _account(clockSysvar, writable: false),
+    _account(authority, writable: false, signer: true),
+  ],
+  data: _discriminatorData(upgradeDiscriminator),
+);
+
+Instruction getSetAuthorityInstruction({
+  required Address bufferOrProgramDataAccount,
+  required Address currentAuthority,
+  Address? newAuthority,
+  Address programAddress = bpfLoaderUpgradeableProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(bufferOrProgramDataAccount, writable: true),
+    _account(currentAuthority, writable: false, signer: true),
+    if (newAuthority != null) _account(newAuthority, writable: false),
+  ],
+  data: _discriminatorData(setAuthorityDiscriminator),
+);
+
+Instruction getCloseInstruction({
+  required Address bufferOrProgramDataAccount,
+  required Address destinationAccount,
+  required Address authority,
+  Address? programAccount,
+  Address programAddress = bpfLoaderUpgradeableProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(bufferOrProgramDataAccount, writable: true),
+    _account(destinationAccount, writable: true),
+    _account(authority, writable: false, signer: true),
+    if (programAccount != null) _account(programAccount, writable: false),
+  ],
+  data: _discriminatorData(closeDiscriminator),
+);
+
+Instruction getExtendProgramInstruction({
+  required Address programDataAccount,
+  required Address programAccount,
+  required int additionalBytes,
+  Address systemProgram = systemProgramAddress,
+  Address? payer,
+  Address instructionProgramAddress = bpfLoaderUpgradeableProgramAddress,
+}) => Instruction(
+  programAddress: instructionProgramAddress,
+  accounts: [
+    _account(programDataAccount, writable: true),
+    _account(programAccount, writable: true),
+    _account(systemProgram, writable: false),
+    if (payer != null) _account(payer, writable: true, signer: true),
+  ],
+  data: getExtendProgramInstructionDataEncoder().encode(
+    ExtendProgramInstructionData(additionalBytes: additionalBytes),
+  ),
+);
+
+ExtendProgramInstructionData parseExtendProgramInstruction(Instruction ix) =>
+    getExtendProgramInstructionDataDecoder().decode(ix.data!);
+
+Instruction getSetAuthorityCheckedInstruction({
+  required Address bufferOrProgramDataAccount,
+  required Address currentAuthority,
+  required Address newAuthority,
+  Address programAddress = bpfLoaderUpgradeableProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(bufferOrProgramDataAccount, writable: true),
+    _account(currentAuthority, writable: false, signer: true),
+    _account(newAuthority, writable: false, signer: true),
+  ],
+  data: _discriminatorData(setAuthorityCheckedDiscriminator),
+);

--- a/packages/solana_kit_loader/lib/src/generated/instructions/loader_v4.dart
+++ b/packages/solana_kit_loader/lib/src/generated/instructions/loader_v4.dart
@@ -1,0 +1,219 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_loader/src/generated/programs/loader_v4.dart';
+
+const loaderV4WriteDiscriminator = 0;
+const truncateDiscriminator = 1;
+const deployDiscriminator = 2;
+const retractDiscriminator = 3;
+const transferAuthorityDiscriminator = 4;
+const finalizeDiscriminator = 5;
+
+AccountMeta _account(
+  Address address, {
+  required bool writable,
+  bool signer = false,
+}) {
+  final role = switch ((writable, signer)) {
+    (true, true) => AccountRole.writableSigner,
+    (true, false) => AccountRole.writable,
+    (false, true) => AccountRole.readonlySigner,
+    (false, false) => AccountRole.readonly,
+  };
+  return AccountMeta(address: address, role: role);
+}
+
+@immutable
+class LoaderV4WriteInstructionData {
+  const LoaderV4WriteInstructionData({
+    required this.offset,
+    required this.bytes,
+    this.discriminator = loaderV4WriteDiscriminator,
+  });
+
+  final int discriminator;
+  final int offset;
+  final Uint8List bytes;
+}
+
+Encoder<LoaderV4WriteInstructionData> getLoaderV4WriteInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU8Encoder()),
+    ('offset', getU32Encoder()),
+    ('bytes', addEncoderSizePrefix(getBytesEncoder(), getU32Encoder())),
+  ]);
+  return transformEncoder(
+    structEncoder,
+    (LoaderV4WriteInstructionData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+      'offset': value.offset,
+      'bytes': value.bytes,
+    },
+  );
+}
+
+Decoder<LoaderV4WriteInstructionData> getLoaderV4WriteInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU8Decoder()),
+    ('offset', getU32Decoder()),
+    ('bytes', addDecoderSizePrefix(getBytesDecoder(), getU32Decoder())),
+  ]);
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, _, _) => LoaderV4WriteInstructionData(
+      discriminator: map['discriminator']! as int,
+      offset: map['offset']! as int,
+      bytes: map['bytes']! as Uint8List,
+    ),
+  );
+}
+
+@immutable
+class TruncateInstructionData {
+  const TruncateInstructionData({
+    required this.newSize,
+    this.discriminator = truncateDiscriminator,
+  });
+
+  final int discriminator;
+  final int newSize;
+}
+
+Encoder<TruncateInstructionData> getTruncateInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('discriminator', getU8Encoder()),
+    ('newSize', getU32Encoder()),
+  ]);
+  return transformEncoder(
+    structEncoder,
+    (TruncateInstructionData value) => <String, Object?>{
+      'discriminator': value.discriminator,
+      'newSize': value.newSize,
+    },
+  );
+}
+
+Decoder<TruncateInstructionData> getTruncateInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('discriminator', getU8Decoder()),
+    ('newSize', getU32Decoder()),
+  ]);
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, _, _) => TruncateInstructionData(
+      discriminator: map['discriminator']! as int,
+      newSize: map['newSize']! as int,
+    ),
+  );
+}
+
+Uint8List _discriminatorData(int discriminator) =>
+    getU8Encoder().encode(discriminator);
+
+int parseLoaderV4Discriminator(Instruction instruction) =>
+    getU8Decoder().decode(instruction.data!);
+
+Instruction getLoaderV4WriteInstruction({
+  required Address program,
+  required Address authority,
+  required int offset,
+  required Uint8List bytes,
+  Address programAddress = loaderV4ProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(program, writable: true),
+    _account(authority, writable: false, signer: true),
+  ],
+  data: getLoaderV4WriteInstructionDataEncoder().encode(
+    LoaderV4WriteInstructionData(offset: offset, bytes: bytes),
+  ),
+);
+
+LoaderV4WriteInstructionData parseLoaderV4WriteInstruction(Instruction ix) =>
+    getLoaderV4WriteInstructionDataDecoder().decode(ix.data!);
+
+Instruction getLoaderV4TruncateInstruction({
+  required Address program,
+  required Address authority,
+  required Address destination,
+  required int newSize,
+  Address programAddress = loaderV4ProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(program, writable: true, signer: true),
+    _account(authority, writable: false, signer: true),
+    _account(destination, writable: true),
+  ],
+  data: getTruncateInstructionDataEncoder().encode(
+    TruncateInstructionData(newSize: newSize),
+  ),
+);
+
+TruncateInstructionData parseLoaderV4TruncateInstruction(Instruction ix) =>
+    getTruncateInstructionDataDecoder().decode(ix.data!);
+
+Instruction getLoaderV4DeployInstruction({
+  required Address program,
+  required Address authority,
+  required Address source,
+  Address programAddress = loaderV4ProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(program, writable: true),
+    _account(authority, writable: false, signer: true),
+    _account(source, writable: true),
+  ],
+  data: _discriminatorData(deployDiscriminator),
+);
+
+Instruction getLoaderV4RetractInstruction({
+  required Address program,
+  required Address authority,
+  Address programAddress = loaderV4ProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(program, writable: true),
+    _account(authority, writable: false, signer: true),
+  ],
+  data: _discriminatorData(retractDiscriminator),
+);
+
+Instruction getLoaderV4TransferAuthorityInstruction({
+  required Address program,
+  required Address newAuthority,
+  Address programAddress = loaderV4ProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(program, writable: true),
+    _account(newAuthority, writable: false, signer: true),
+  ],
+  data: _discriminatorData(transferAuthorityDiscriminator),
+);
+
+Instruction getLoaderV4FinalizeInstruction({
+  required Address program,
+  required Address authority,
+  required Address nextVersion,
+  Address programAddress = loaderV4ProgramAddress,
+}) => Instruction(
+  programAddress: programAddress,
+  accounts: [
+    _account(program, writable: true),
+    _account(authority, writable: false, signer: true),
+    _account(nextVersion, writable: false),
+  ],
+  data: _discriminatorData(finalizeDiscriminator),
+);

--- a/packages/solana_kit_loader/lib/src/generated/programs/bpf_loader_upgradeable.dart
+++ b/packages/solana_kit_loader/lib/src/generated/programs/bpf_loader_upgradeable.dart
@@ -1,0 +1,8 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+/// Program address for BPF Loader v3 (Upgradeable).
+const bpfLoaderUpgradeableProgramAddress = Address(
+  'BPFLoaderUpgradeab1e11111111111111111111111',
+);

--- a/packages/solana_kit_loader/lib/src/generated/programs/loader_v4.dart
+++ b/packages/solana_kit_loader/lib/src/generated/programs/loader_v4.dart
@@ -1,0 +1,8 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+/// Program address for Loader v4.
+const loaderV4ProgramAddress = Address(
+  'LoaderV411111111111111111111111111111111111',
+);

--- a/packages/solana_kit_loader/lib/src/helpers.dart
+++ b/packages/solana_kit_loader/lib/src/helpers.dart
@@ -1,0 +1,105 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_loader/src/generated/instructions/loader_v3.dart';
+
+/// Default number of program bytes included in each loader write instruction.
+const defaultLoaderWriteChunkSize = 900;
+
+/// Returns a non-divisible plan that writes [programBytes] to a buffer and then
+/// deploys it through BPF Loader v3 (Upgradeable).
+InstructionPlan getDeployProgramInstructionPlan({
+  required Address payerAccount,
+  required Address programDataAccount,
+  required Address programAccount,
+  required Address bufferAccount,
+  required Address authority,
+  required Uint8List programBytes,
+  BigInt? maxDataLen,
+  int chunkSize = defaultLoaderWriteChunkSize,
+  Address rentSysvar = rentSysvarAddress,
+  Address clockSysvar = clockSysvarAddress,
+  Address systemProgram = systemProgramAddress,
+}) {
+  final writes = _getWriteInstructions(
+    bufferAccount: bufferAccount,
+    bufferAuthority: authority,
+    programBytes: programBytes,
+    chunkSize: chunkSize,
+  );
+
+  return nonDivisibleSequentialInstructionPlan([
+    ...writes,
+    getDeployWithMaxProgramLenInstruction(
+      payerAccount: payerAccount,
+      programDataAccount: programDataAccount,
+      programAccount: programAccount,
+      bufferAccount: bufferAccount,
+      authority: authority,
+      maxDataLen: maxDataLen ?? BigInt.from(programBytes.length),
+      rentSysvar: rentSysvar,
+      clockSysvar: clockSysvar,
+      systemProgram: systemProgram,
+    ),
+  ]);
+}
+
+/// Returns a non-divisible plan that writes [programBytes] to a buffer and then
+/// upgrades an existing BPF Loader v3 (Upgradeable) program.
+InstructionPlan getUpgradeProgramInstructionPlan({
+  required Address programDataAccount,
+  required Address programAccount,
+  required Address bufferAccount,
+  required Address spillAccount,
+  required Address authority,
+  required Uint8List programBytes,
+  int chunkSize = defaultLoaderWriteChunkSize,
+  Address rentSysvar = rentSysvarAddress,
+  Address clockSysvar = clockSysvarAddress,
+}) {
+  final writes = _getWriteInstructions(
+    bufferAccount: bufferAccount,
+    bufferAuthority: authority,
+    programBytes: programBytes,
+    chunkSize: chunkSize,
+  );
+
+  return nonDivisibleSequentialInstructionPlan([
+    ...writes,
+    getUpgradeInstruction(
+      programDataAccount: programDataAccount,
+      programAccount: programAccount,
+      bufferAccount: bufferAccount,
+      spillAccount: spillAccount,
+      authority: authority,
+      rentSysvar: rentSysvar,
+      clockSysvar: clockSysvar,
+    ),
+  ]);
+}
+
+List<Object> _getWriteInstructions({
+  required Address bufferAccount,
+  required Address bufferAuthority,
+  required Uint8List programBytes,
+  required int chunkSize,
+}) {
+  if (chunkSize <= 0) {
+    throw ArgumentError.value(chunkSize, 'chunkSize', 'must be greater than 0');
+  }
+
+  final instructions = <Object>[];
+  for (var offset = 0; offset < programBytes.length; offset += chunkSize) {
+    final end = (offset + chunkSize).clamp(0, programBytes.length);
+    instructions.add(
+      getLoaderV3WriteInstruction(
+        bufferAccount: bufferAccount,
+        bufferAuthority: bufferAuthority,
+        offset: offset,
+        bytes: Uint8List.fromList(programBytes.sublist(offset, end)),
+      ),
+    );
+  }
+  return instructions;
+}

--- a/packages/solana_kit_loader/pubspec.yaml
+++ b/packages/solana_kit_loader/pubspec.yaml
@@ -1,0 +1,22 @@
+name: solana_kit_loader
+description: BPF Loader v3 (Upgradeable) and Loader v4 instructions, accounts, and helpers for Solana Kit.
+version: 0.4.0
+repository: https://github.com/openbudgetfun/solana_kit
+homepage: https://openbudgetfun.github.io/solana_kit/
+resolution: workspace
+
+environment:
+  sdk: ^3.10.1
+
+dependencies:
+  meta: ^1.16.0
+  solana_kit_addresses: ^0.4.0
+  solana_kit_codecs_core: ^0.4.0
+  solana_kit_codecs_data_structures: ^0.4.0
+  solana_kit_codecs_numbers: ^0.4.0
+  solana_kit_instruction_plans: ^0.4.0
+  solana_kit_instructions: ^0.4.0
+
+dev_dependencies:
+  solana_kit_lints: ^0.4.0
+  test: ^1.25.0

--- a/packages/solana_kit_loader/test/loader_test.dart
+++ b/packages/solana_kit_loader/test/loader_test.dart
@@ -205,5 +205,20 @@ void main() {
       );
       expect((upgrade as SequentialInstructionPlan).plans, hasLength(3));
     });
+
+    test('rejects non-positive write chunk sizes', () {
+      expect(
+        () => getDeployProgramInstructionPlan(
+          payerAccount: a1,
+          programDataAccount: a2,
+          programAccount: a3,
+          bufferAccount: a4,
+          authority: a5,
+          programBytes: Uint8List.fromList([1]),
+          chunkSize: 0,
+        ),
+        throwsArgumentError,
+      );
+    });
   });
 }

--- a/packages/solana_kit_loader/test/loader_test.dart
+++ b/packages/solana_kit_loader/test/loader_test.dart
@@ -1,0 +1,209 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instruction_plans/solana_kit_instruction_plans.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_loader/solana_kit_loader.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const a1 = Address('11111111111111111111111111111111');
+  const a2 = Address('11111111111111111111111111111112');
+  const a3 = Address('11111111111111111111111111111113');
+  const a4 = Address('11111111111111111111111111111114');
+  const a5 = Address('11111111111111111111111111111115');
+
+  group('program constants', () {
+    test('exports loader addresses', () {
+      expect(
+        bpfLoaderUpgradeableProgramAddress,
+        const Address('BPFLoaderUpgradeab1e11111111111111111111111'),
+      );
+      expect(
+        loaderV4ProgramAddress,
+        const Address('LoaderV411111111111111111111111111111111111'),
+      );
+    });
+  });
+
+  group('loader v3 instructions', () {
+    test('builds and parses write instruction', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final ix = getLoaderV3WriteInstruction(
+        bufferAccount: a1,
+        bufferAuthority: a2,
+        offset: 7,
+        bytes: bytes,
+      );
+
+      expect(ix.programAddress, bpfLoaderUpgradeableProgramAddress);
+      expect(ix.accounts, hasLength(2));
+      expect(ix.accounts![0].role, AccountRole.writable);
+      expect(ix.accounts![1].role, AccountRole.readonlySigner);
+
+      final parsed = parseLoaderV3WriteInstruction(ix);
+      expect(parsed.discriminator, loaderV3WriteDiscriminator);
+      expect(parsed.offset, 7);
+      expect(parsed.bytes, bytes);
+    });
+
+    test('builds deploy, upgrade and authority instructions', () {
+      final deploy = getDeployWithMaxProgramLenInstruction(
+        payerAccount: a1,
+        programDataAccount: a2,
+        programAccount: a3,
+        bufferAccount: a4,
+        authority: a5,
+        maxDataLen: BigInt.from(1024),
+      );
+      expect(deploy.accounts, hasLength(8));
+      expect(deploy.accounts![0].role, AccountRole.writableSigner);
+      expect(
+        parseDeployWithMaxProgramLenInstruction(deploy).maxDataLen,
+        BigInt.from(1024),
+      );
+
+      final upgrade = getUpgradeInstruction(
+        programDataAccount: a1,
+        programAccount: a2,
+        bufferAccount: a3,
+        spillAccount: a4,
+        authority: a5,
+      );
+      expect(upgrade.accounts, hasLength(7));
+      expect(parseDiscriminator(upgrade), upgradeDiscriminator);
+
+      final checked = getSetAuthorityCheckedInstruction(
+        bufferOrProgramDataAccount: a1,
+        currentAuthority: a2,
+        newAuthority: a3,
+      );
+      expect(checked.accounts![2].role, AccountRole.readonlySigner);
+    });
+  });
+
+  group('loader v4 instructions', () {
+    test('builds and parses write and truncate instructions', () {
+      final write = getLoaderV4WriteInstruction(
+        program: a1,
+        authority: a2,
+        offset: 4,
+        bytes: Uint8List.fromList([9, 8]),
+      );
+      expect(write.programAddress, loaderV4ProgramAddress);
+      expect(write.accounts![0].role, AccountRole.writable);
+      expect(parseLoaderV4WriteInstruction(write).offset, 4);
+      expect(parseLoaderV4Discriminator(write), loaderV4WriteDiscriminator);
+
+      final truncate = getLoaderV4TruncateInstruction(
+        program: a1,
+        authority: a2,
+        destination: a3,
+        newSize: 64,
+      );
+      expect(truncate.accounts![0].role, AccountRole.writableSigner);
+      expect(parseLoaderV4TruncateInstruction(truncate).newSize, 64);
+    });
+
+    test('builds deploy, retract, transfer authority and finalize', () {
+      expect(
+        getLoaderV4DeployInstruction(
+          program: a1,
+          authority: a2,
+          source: a3,
+        ).accounts,
+        hasLength(3),
+      );
+      expect(
+        getLoaderV4RetractInstruction(program: a1, authority: a2).accounts,
+        hasLength(2),
+      );
+      expect(
+        getLoaderV4TransferAuthorityInstruction(
+          program: a1,
+          newAuthority: a2,
+        ).accounts![1].role,
+        AccountRole.readonlySigner,
+      );
+      expect(
+        getLoaderV4FinalizeInstruction(
+          program: a1,
+          authority: a2,
+          nextVersion: a3,
+        ).accounts![2].role,
+        AccountRole.readonly,
+      );
+    });
+  });
+
+  group('account codecs', () {
+    test('encodes and decodes loader v3 account headers', () {
+      const buffer = BufferAccount(authorityAddress: a1);
+      final decodedBuffer = getBufferAccountDecoder().decode(
+        getBufferAccountEncoder().encode(buffer),
+      );
+      expect(bufferAccountSize, 40);
+      expect(decodedBuffer, buffer);
+
+      final programData = ProgramDataAccount(
+        slot: BigInt.from(55),
+        upgradeAuthorityAddress: a2,
+      );
+      final decodedProgramData = getProgramDataAccountDecoder().decode(
+        getProgramDataAccountEncoder().encode(programData),
+      );
+      expect(programDataAccountSize, 48);
+      expect(decodedProgramData, programData);
+    });
+
+    test('encodes and decodes loader v4 program state', () {
+      final state = ProgramStateAccount(
+        slot: BigInt.from(9),
+        authorityAddressOrNextVersion: a1,
+        status: LoaderV4Status.deployed,
+      );
+      final encoded = getProgramStateAccountEncoder().encode(state);
+      final decoded = getProgramStateAccountDecoder().decode(encoded);
+      expect(programStateAccountSize, 48);
+      expect(encoded, hasLength(48));
+      expect(decoded, state);
+    });
+  });
+
+  group('instruction plans', () {
+    test('chunks deploy and upgrade plans', () {
+      final bytes = Uint8List.fromList(List<int>.generate(5, (index) => index));
+      final deploy = getDeployProgramInstructionPlan(
+        payerAccount: a1,
+        programDataAccount: a2,
+        programAccount: a3,
+        bufferAccount: a4,
+        authority: a5,
+        programBytes: bytes,
+        chunkSize: 2,
+      );
+      expect(deploy, isA<SequentialInstructionPlan>());
+      final deployPlans = (deploy as SequentialInstructionPlan).plans;
+      expect(deploy.divisible, isFalse);
+      expect(deployPlans, hasLength(4));
+      expect(
+        (deployPlans.first as SingleInstructionPlan)
+            .instruction
+            .accounts![0]
+            .address,
+        a4,
+      );
+
+      final upgrade = getUpgradeProgramInstructionPlan(
+        programDataAccount: a1,
+        programAccount: a2,
+        bufferAccount: a3,
+        spillAccount: a4,
+        authority: a5,
+        programBytes: bytes,
+        chunkSize: 3,
+      );
+      expect((upgrade as SequentialInstructionPlan).plans, hasLength(3));
+    });
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ workspace:
   - packages/solana_kit_functional
   - packages/solana_kit_helius
   - packages/solana_kit_instruction_plans
+  - packages/solana_kit_loader
   - packages/solana_kit_instructions
   - packages/solana_kit_keys
   - packages/solana_kit_lints

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ dependencies:
   solana_kit: ^0.4.0
 ```
 
-Program packages can be added separately when you need a smaller dependency graph or a specific on-chain program. Browse the full package map on the [documentation website](https://openbudgetfun.github.io/solana_kit/).
+Program packages such as `solana_kit_loader` can be added separately when you need a smaller dependency graph or a specific on-chain program. Browse the full package map on the [documentation website](https://openbudgetfun.github.io/solana_kit/).
 
 ### Create an RPC client
 

--- a/scripts/workspace-doc-drift.sh
+++ b/scripts/workspace-doc-drift.sh
@@ -150,9 +150,37 @@ replace_block() {
     ' "$input_file" > "$output_file"
 }
 
+has_line() {
+  local file="$1"
+  local line="$2"
+
+  grep -Fxq "$line" "$file"
+}
+
 apply_or_check_file() {
   local file="$1"
   local updated_file="$tmp_dir/$(basename "$file").updated"
+
+  local has_summary_start=0
+  local has_summary_end=0
+  local has_graph_start=0
+  local has_graph_end=0
+
+  has_line "$file" '<!-- workspace-summary:start -->' && has_summary_start=1
+  has_line "$file" '<!-- workspace-summary:end -->' && has_summary_end=1
+  has_line "$file" '<!-- workspace-dependency-graph:start -->' && has_graph_start=1
+  has_line "$file" '<!-- workspace-dependency-graph:end -->' && has_graph_end=1
+
+  local marker_count=$((has_summary_start + has_summary_end + has_graph_start + has_graph_end))
+  if [[ $marker_count -eq 0 ]]; then
+    echo "Workspace documentation blocks are not configured in $file; skipping."
+    return 0
+  fi
+
+  if [[ $marker_count -ne 4 ]]; then
+    echo "Incomplete workspace documentation markers in $file" >&2
+    exit 3
+  fi
 
   cp "$file" "$updated_file.base"
 


### PR DESCRIPTION
## Summary
- Add new `solana_kit_loader` package for BPF Loader v3 (Upgradeable) and Loader v4
- Include generated-style program constants, instruction builders/parsers, account header codecs, and deployment/upgrade instruction plan helpers
- Wire package into workspace, monochange, codecov flags, root docs, and changesets

Closes #138

## Checks
- `devenv shell -- bash -lc 'dart pub get && dart format packages/solana_kit_loader/lib packages/solana_kit_loader/test && dart analyze packages/solana_kit_loader && dart test packages/solana_kit_loader'`
