### PR TITLE
feat: add Solana Config program package

### DIFF
--- a/.changeset/add-solana-config-program.md
+++ b/.changeset/add-solana-config-program.md
@@ -1,0 +1,5 @@
+---
+"solana_kit_config": minor
+---
+
+Add the Solana Config program package with generated codecs, account decoder, Store instruction builder, and typed store helper.

--- a/codecov.yml
+++ b/codecov.yml
@@ -43,6 +43,9 @@ flags:
   solana_kit_compute_budget:
     paths:
       - packages/solana_kit_compute_budget
+  solana_kit_config:
+    paths:
+      - packages/solana_kit_config
   solana_kit_errors:
     paths:
       - packages/solana_kit_errors

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -86,6 +86,7 @@ solana_kit_codecs_data_structures -> solana_kit_codecs_core, solana_kit_codecs_n
 solana_kit_codecs_numbers -> solana_kit_codecs_core, solana_kit_errors
 solana_kit_codecs_strings -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
 solana_kit_compute_budget -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
+solana_kit_config -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_errors -> (none)
 solana_kit_fast_stable_stringify -> (none)
 solana_kit_fixed_points -> (none)

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -6,7 +6,7 @@ This guide covers how to version, release, and publish the `solana_kit` Dart SDK
 
 <!-- workspace-summary:start -->
 
-This monorepo contains **50 packages** under `packages/`: **48 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
+This monorepo contains **51 packages** under `packages/`: **49 publishable** and **2 internal** (`solana_kit_lints`, `solana_kit_test_matchers`).
 
 <!-- workspace-summary:end -->
 

--- a/monochange.toml
+++ b/monochange.toml
@@ -54,6 +54,11 @@ path = "packages/solana_kit_compute_budget"
 tag = true
 release = false
 
+[package.solana_kit_config]
+path = "packages/solana_kit_config"
+tag = true
+release = false
+
 [package.solana_kit_errors]
 path = "packages/solana_kit_errors"
 
@@ -216,6 +221,7 @@ packages = [
   "solana_kit_codecs_strings",
   "solana_kit_fixed_points",
   "solana_kit_compute_budget",
+  "solana_kit_config",
   "solana_kit_errors",
   "solana_kit_fast_stable_stringify",
   "solana_kit_functional",

--- a/packages/solana_kit_config/CHANGELOG.md
+++ b/packages/solana_kit_config/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This changelog is managed by [monochange](https://github.com/monochange/monochange).

--- a/packages/solana_kit_config/CHANGELOG.md
+++ b/packages/solana_kit_config/CHANGELOG.md
@@ -3,3 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 This changelog is managed by [monochange](https://github.com/monochange/monochange).
+
+## 0.4.0
+
+- Initial release of the Solana Config program client with generated codecs, account decoders, Store instruction builders, and typed store helpers.

--- a/packages/solana_kit_config/LICENSE
+++ b/packages/solana_kit_config/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ifiok Jr.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/solana_kit_config/README.md
+++ b/packages/solana_kit_config/README.md
@@ -1,0 +1,53 @@
+# Solana Kit Config
+
+[![pub package](https://img.shields.io/pub/v/solana_kit_config.svg)](https://pub.dev/packages/solana_kit_config)
+[![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
+
+Config program client for the Solana Kit Dart SDK.
+
+This package provides generated codecs, account decoders, and instruction
+builders for Solana's native Config program, plus ergonomic helpers for storing
+configuration data.
+
+## Usage
+
+```dart
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_config/solana_kit_config.dart';
+
+void main() {
+  final configAccount = address('11111111111111111111111111111111');
+  final authority = address('Config1111111111111111111111111111111111111');
+
+  final instruction = getStoreConfigInstruction(
+    configAccount: configAccount,
+    keys: [ConfigKey(address: authority, isSigner: true)],
+    configData: Uint8List.fromList([1, 2, 3]),
+    configAccountIsSigner: true,
+  );
+
+  final parsed = parseStoreInstruction(instruction);
+  assert(parsed.data.length == 3);
+}
+```
+
+## Key APIs
+
+- `solanaConfigProgramAddress` — the native Config program address.
+- `identifySolanaConfigProgram` / `identifySolanaConfigInstruction` — helpers
+  for program and instruction identification.
+- `ConfigKey`, `ConfigKeys`, and related codecs — encode the Config key list
+  using Solana's short-vector format.
+- `ConfigAccount`, `getConfigAccountCodec`, and `decodeConfigAccount` — decode
+  Config account data into typed Dart objects.
+- `getStoreInstruction` / `parseStoreInstruction` — generated `Store`
+  instruction builder and parser.
+- `getStoreConfigInstruction` — helper wrapper that accepts config data and
+  derives signer accounts from typed config keys.
+
+## License
+
+MIT

--- a/packages/solana_kit_config/lib/solana_kit_config.dart
+++ b/packages/solana_kit_config/lib/solana_kit_config.dart
@@ -1,0 +1,5 @@
+/// Config program client for the Solana Kit Dart SDK.
+library;
+
+export 'src/generated/config.dart';
+export 'src/helpers/store_config.dart';

--- a/packages/solana_kit_config/lib/src/generated/accounts/accounts.dart
+++ b/packages/solana_kit_config/lib/src/generated/accounts/accounts.dart
@@ -1,0 +1,4 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'config_account.dart';

--- a/packages/solana_kit_config/lib/src/generated/accounts/config_account.dart
+++ b/packages/solana_kit_config/lib/src/generated/accounts/config_account.dart
@@ -1,0 +1,98 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_accounts/solana_kit_accounts.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_config/src/generated/types/config_keys.dart';
+
+/// Data stored in a Config program account.
+@immutable
+class ConfigAccount {
+  /// Creates [ConfigAccount].
+  const ConfigAccount({required this.keys, required this.data});
+
+  /// List of pubkeys stored in the config account.
+  final ConfigKeys keys;
+
+  /// Arbitrary data stored in the config account.
+  final Uint8List data;
+
+  @override
+  String toString() => 'ConfigAccount(keys: $keys, data: $data)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is ConfigAccount &&
+      _configKeysEqual(other.keys, keys) &&
+      _bytesEqual(other.data, data);
+
+  @override
+  int get hashCode => Object.hash(Object.hashAll(keys), Object.hashAll(data));
+}
+
+/// Returns the encoder for [ConfigAccount].
+Encoder<ConfigAccount> getConfigAccountEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('keys', getConfigKeysEncoder()),
+    ('data', getBytesEncoder()),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (ConfigAccount value) => <String, Object?>{
+      'keys': value.keys,
+      'data': value.data,
+    },
+  );
+}
+
+/// Returns the decoder for [ConfigAccount].
+Decoder<ConfigAccount> getConfigAccountDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('keys', getConfigKeysDecoder()),
+    ('data', getBytesDecoder()),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, bytes, offset) => ConfigAccount(
+      keys: map['keys']! as ConfigKeys,
+      data: map['data']! as Uint8List,
+    ),
+  );
+}
+
+/// Returns the codec for [ConfigAccount].
+Codec<ConfigAccount, ConfigAccount> getConfigAccountCodec() =>
+    combineCodec(getConfigAccountEncoder(), getConfigAccountDecoder());
+
+/// Decodes [encodedAccount] into a typed Config account.
+Account<ConfigAccount> decodeConfigAccount(EncodedAccount encodedAccount) =>
+    Account<ConfigAccount>(
+      address: encodedAccount.address,
+      data: getConfigAccountDecoder().decode(encodedAccount.data),
+      executable: encodedAccount.executable,
+      lamports: encodedAccount.lamports,
+      programAddress: encodedAccount.programAddress,
+      space: encodedAccount.space,
+    );
+
+bool _configKeysEqual(ConfigKeys left, ConfigKeys right) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}
+
+bool _bytesEqual(Uint8List left, Uint8List right) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}

--- a/packages/solana_kit_config/lib/src/generated/config.dart
+++ b/packages/solana_kit_config/lib/src/generated/config.dart
@@ -1,0 +1,7 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'accounts/accounts.dart';
+export 'instructions/instructions.dart';
+export 'programs/programs.dart';
+export 'types/types.dart';

--- a/packages/solana_kit_config/lib/src/generated/instructions/instructions.dart
+++ b/packages/solana_kit_config/lib/src/generated/instructions/instructions.dart
@@ -1,0 +1,4 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'store.dart';

--- a/packages/solana_kit_config/lib/src/generated/instructions/store.dart
+++ b/packages/solana_kit_config/lib/src/generated/instructions/store.dart
@@ -1,0 +1,124 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_config/src/generated/programs/solana_config.dart';
+import 'package:solana_kit_config/src/generated/types/config_keys.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+/// Data for the Store instruction.
+@immutable
+class StoreInstructionData {
+  /// Creates [StoreInstructionData].
+  const StoreInstructionData({required this.keys, required this.data});
+
+  /// List of pubkeys to store in the config account.
+  final ConfigKeys keys;
+
+  /// Arbitrary data to store in the config account.
+  final Uint8List data;
+
+  @override
+  String toString() => 'StoreInstructionData(keys: $keys, data: $data)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is StoreInstructionData &&
+      _configKeysEqual(other.keys, keys) &&
+      _bytesEqual(other.data, data);
+
+  @override
+  int get hashCode => Object.hash(Object.hashAll(keys), Object.hashAll(data));
+}
+
+/// Returns the encoder for [StoreInstructionData].
+Encoder<StoreInstructionData> getStoreInstructionDataEncoder() {
+  final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
+    ('keys', getConfigKeysEncoder()),
+    ('data', getBytesEncoder()),
+  ]);
+
+  return transformEncoder(
+    structEncoder,
+    (StoreInstructionData value) => <String, Object?>{
+      'keys': value.keys,
+      'data': value.data,
+    },
+  );
+}
+
+/// Returns the decoder for [StoreInstructionData].
+Decoder<StoreInstructionData> getStoreInstructionDataDecoder() {
+  final structDecoder = getStructDecoder(<(String, Decoder<Object?>)>[
+    ('keys', getConfigKeysDecoder()),
+    ('data', getBytesDecoder()),
+  ]);
+
+  return transformDecoder(
+    structDecoder,
+    (Map<String, Object?> map, bytes, offset) => StoreInstructionData(
+      keys: map['keys']! as ConfigKeys,
+      data: map['data']! as Uint8List,
+    ),
+  );
+}
+
+/// Returns the codec for [StoreInstructionData].
+Codec<StoreInstructionData, StoreInstructionData>
+getStoreInstructionDataCodec() => combineCodec(
+  getStoreInstructionDataEncoder(),
+  getStoreInstructionDataDecoder(),
+);
+
+/// Creates a Store instruction.
+Instruction getStoreInstruction({
+  required Address configAccount,
+  required ConfigKeys keys,
+  required Uint8List data,
+  List<Address> signers = const [],
+  bool configAccountIsSigner = false,
+  Address programAddress = solanaConfigProgramAddress,
+}) {
+  final instructionData = StoreInstructionData(keys: keys, data: data);
+  final accounts = <AccountMeta>[
+    AccountMeta(
+      address: configAccount,
+      role: configAccountIsSigner
+          ? AccountRole.writableSigner
+          : AccountRole.writable,
+    ),
+    for (final signer in signers)
+      AccountMeta(address: signer, role: AccountRole.readonlySigner),
+  ];
+
+  return Instruction(
+    programAddress: programAddress,
+    accounts: accounts,
+    data: getStoreInstructionDataEncoder().encode(instructionData),
+  );
+}
+
+/// Parses a Store instruction from [instruction].
+StoreInstructionData parseStoreInstruction(Instruction instruction) =>
+    getStoreInstructionDataDecoder().decode(instruction.data!);
+
+bool _configKeysEqual(ConfigKeys left, ConfigKeys right) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}
+
+bool _bytesEqual(Uint8List left, Uint8List right) {
+  if (left.length != right.length) return false;
+  for (var index = 0; index < left.length; index++) {
+    if (left[index] != right[index]) return false;
+  }
+  return true;
+}

--- a/packages/solana_kit_config/lib/src/generated/programs/programs.dart
+++ b/packages/solana_kit_config/lib/src/generated/programs/programs.dart
@@ -1,0 +1,4 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'solana_config.dart';

--- a/packages/solana_kit_config/lib/src/generated/programs/solana_config.dart
+++ b/packages/solana_kit_config/lib/src/generated/programs/solana_config.dart
@@ -1,0 +1,18 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+/// The address of the Solana Config program.
+const solanaConfigProgramAddress = Address(
+  'Config1111111111111111111111111111111111111',
+);
+
+/// Returns true when [programAddress] identifies the Solana Config program.
+bool identifySolanaConfigProgram(Address programAddress) =>
+    programAddress == solanaConfigProgramAddress;
+
+/// Returns true when [instruction] targets the Solana Config program.
+bool identifySolanaConfigInstruction(Instruction instruction) =>
+    identifySolanaConfigProgram(instruction.programAddress);

--- a/packages/solana_kit_config/lib/src/generated/types/config_keys.dart
+++ b/packages/solana_kit_config/lib/src/generated/types/config_keys.dart
@@ -1,0 +1,83 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'package:meta/meta.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+/// A key stored in Config account data.
+@immutable
+class ConfigKey {
+  /// Creates [ConfigKey].
+  const ConfigKey({required this.address, required this.isSigner});
+
+  /// The public key identifier.
+  final Address address;
+
+  /// Whether [address] must sign subsequent `store` calls.
+  final bool isSigner;
+
+  @override
+  String toString() => 'ConfigKey(address: $address, isSigner: $isSigner)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is ConfigKey &&
+      other.address == address &&
+      other.isSigner == isSigner;
+
+  @override
+  int get hashCode => Object.hash(address, isSigner);
+}
+
+/// A collection of keys to be stored in Config account data.
+typedef ConfigKeys = List<ConfigKey>;
+
+/// Returns the encoder for [ConfigKey].
+Encoder<ConfigKey> getConfigKeyEncoder() {
+  final tupleEncoder = getTupleEncoder(<Encoder<Object?>>[
+    getAddressEncoder(),
+    getBooleanEncoder(),
+  ]);
+
+  return transformEncoder(
+    tupleEncoder,
+    (ConfigKey value) => <Object?>[value.address, value.isSigner],
+  );
+}
+
+/// Returns the decoder for [ConfigKey].
+Decoder<ConfigKey> getConfigKeyDecoder() {
+  final tupleDecoder = getTupleDecoder(<Decoder<Object?>>[
+    getAddressDecoder(),
+    getBooleanDecoder(),
+  ]);
+
+  return transformDecoder(
+    tupleDecoder,
+    (List<Object?> tuple, bytes, offset) =>
+        ConfigKey(address: tuple[0]! as Address, isSigner: tuple[1]! as bool),
+  );
+}
+
+/// Returns the codec for [ConfigKey].
+Codec<ConfigKey, ConfigKey> getConfigKeyCodec() =>
+    combineCodec(getConfigKeyEncoder(), getConfigKeyDecoder());
+
+/// Returns the encoder for [ConfigKeys].
+Encoder<ConfigKeys> getConfigKeysEncoder() => getArrayEncoder(
+  getConfigKeyEncoder(),
+  size: PrefixedArraySize(getShortU16Encoder()),
+);
+
+/// Returns the decoder for [ConfigKeys].
+Decoder<ConfigKeys> getConfigKeysDecoder() => getArrayDecoder(
+  getConfigKeyDecoder(),
+  size: PrefixedArraySize(getShortU16Decoder()),
+);
+
+/// Returns the codec for [ConfigKeys].
+Codec<ConfigKeys, ConfigKeys> getConfigKeysCodec() =>
+    combineCodec(getConfigKeysEncoder(), getConfigKeysDecoder());

--- a/packages/solana_kit_config/lib/src/generated/types/types.dart
+++ b/packages/solana_kit_config/lib/src/generated/types/types.dart
@@ -1,0 +1,4 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'config_keys.dart';

--- a/packages/solana_kit_config/lib/src/helpers/store_config.dart
+++ b/packages/solana_kit_config/lib/src/helpers/store_config.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_config/src/generated/instructions/store.dart';
+import 'package:solana_kit_config/src/generated/programs/solana_config.dart';
+import 'package:solana_kit_config/src/generated/types/config_keys.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+
+/// Creates a typed Config program `Store` instruction.
+///
+/// The [configData] bytes are written to [configAccount]. The [keys] list is
+/// encoded into the config account and signer keys from that list must also be
+/// supplied as transaction accounts. If [signers] is omitted, it is derived from
+/// every [ConfigKey] where `isSigner` is true.
+Instruction getStoreConfigInstruction({
+  required Address configAccount,
+  required ConfigKeys keys,
+  required Uint8List configData,
+  List<Address>? signers,
+  bool configAccountIsSigner = false,
+  Address programAddress = solanaConfigProgramAddress,
+}) {
+  return getStoreInstruction(
+    configAccount: configAccount,
+    keys: keys,
+    data: configData,
+    signers: signers ?? _signerAddresses(keys),
+    configAccountIsSigner: configAccountIsSigner,
+    programAddress: programAddress,
+  );
+}
+
+List<Address> _signerAddresses(ConfigKeys keys) => [
+  for (final key in keys)
+    if (key.isSigner) key.address,
+];

--- a/packages/solana_kit_config/pubspec.yaml
+++ b/packages/solana_kit_config/pubspec.yaml
@@ -1,0 +1,23 @@
+name: solana_kit_config
+description: Config program client for the Solana Kit Dart SDK.
+version: 0.4.0
+repository: https://github.com/openbudgetfun/solana_kit
+homepage: https://openbudgetfun.github.io/solana_kit/
+
+environment:
+  sdk: ^3.10.1
+
+resolution: workspace
+
+dependencies:
+  meta: ^1.16.0
+  solana_kit_accounts: ^0.4.0
+  solana_kit_addresses: ^0.4.0
+  solana_kit_codecs_core: ^0.4.0
+  solana_kit_codecs_data_structures: ^0.4.0
+  solana_kit_codecs_numbers: ^0.4.0
+  solana_kit_instructions: ^0.4.0
+
+dev_dependencies:
+  solana_kit_lints: ^0.4.0
+  test: ^1.25.0

--- a/packages/solana_kit_config/test/barrel_test.dart
+++ b/packages/solana_kit_config/test/barrel_test.dart
@@ -1,0 +1,19 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_config/solana_kit_config.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('exports generated APIs and helpers', () {
+    const key = ConfigKey(address: solanaConfigProgramAddress, isSigner: true);
+    final instruction = getStoreConfigInstruction(
+      configAccount: address('11111111111111111111111111111111'),
+      keys: [key],
+      configData: Uint8List.fromList([1]),
+    );
+
+    expect(identifySolanaConfigInstruction(instruction), isTrue);
+    expect(parseStoreInstruction(instruction).keys, [key]);
+  });
+}

--- a/packages/solana_kit_config/test/config_codecs_test.dart
+++ b/packages/solana_kit_config/test/config_codecs_test.dart
@@ -1,0 +1,48 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_config/solana_kit_config.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const authority = solanaConfigProgramAddress;
+  const observer = Address('11111111111111111111111111111111');
+  const keys = [
+    ConfigKey(address: authority, isSigner: true),
+    ConfigKey(address: observer, isSigner: false),
+  ];
+
+  test('encodes config keys with a shortU16 length prefix', () {
+    final encoded = getConfigKeysEncoder().encode(keys);
+
+    expect(encoded.first, 2);
+    expect(encoded.length, 1 + (32 + 1) * 2);
+    expect(getConfigKeysDecoder().decode(encoded), keys);
+  });
+
+  test('round-trips ConfigAccount data', () {
+    final account = ConfigAccount(
+      keys: keys,
+      data: Uint8List.fromList([10, 20, 30, 40]),
+    );
+
+    final encoded = getConfigAccountEncoder().encode(account);
+    final decoded = getConfigAccountDecoder().decode(encoded);
+
+    expect(decoded, account);
+    expect(decoded.data, [10, 20, 30, 40]);
+  });
+
+  test('round-trips Store instruction data', () {
+    final data = StoreInstructionData(
+      keys: keys,
+      data: Uint8List.fromList([1, 1, 2, 3, 5, 8]),
+    );
+
+    final codec = getStoreInstructionDataCodec();
+    final decoded = codec.decode(codec.encode(data));
+
+    expect(decoded, data);
+    expect(decoded.data, [1, 1, 2, 3, 5, 8]);
+  });
+}

--- a/packages/solana_kit_config/test/instructions_test.dart
+++ b/packages/solana_kit_config/test/instructions_test.dart
@@ -1,0 +1,64 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_config/solana_kit_config.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const configAccount = Address('11111111111111111111111111111111');
+  const signer = solanaConfigProgramAddress;
+  const observer = Address('SysvarC1ock11111111111111111111111111111111');
+  const keys = [
+    ConfigKey(address: signer, isSigner: true),
+    ConfigKey(address: observer, isSigner: false),
+  ];
+
+  test('builds Store instruction accounts and data', () {
+    final instruction = getStoreInstruction(
+      configAccount: configAccount,
+      keys: keys,
+      data: Uint8List.fromList([9, 8, 7]),
+      signers: [signer],
+      configAccountIsSigner: true,
+    );
+
+    expect(instruction.programAddress, solanaConfigProgramAddress);
+    expect(instruction.accounts, [
+      const AccountMeta(
+        address: configAccount,
+        role: AccountRole.writableSigner,
+      ),
+      const AccountMeta(address: signer, role: AccountRole.readonlySigner),
+    ]);
+
+    final parsed = parseStoreInstruction(instruction);
+    expect(parsed.keys, keys);
+    expect(parsed.data, [9, 8, 7]);
+  });
+
+  test('helper derives signer accounts from typed config keys', () {
+    final instruction = getStoreConfigInstruction(
+      configAccount: configAccount,
+      keys: keys,
+      configData: Uint8List.fromList([42]),
+    );
+
+    expect(instruction.accounts, [
+      const AccountMeta(address: configAccount, role: AccountRole.writable),
+      const AccountMeta(address: signer, role: AccountRole.readonlySigner),
+    ]);
+    expect(parseStoreInstruction(instruction).data, [42]);
+  });
+
+  test('identifies Config program and instructions', () {
+    final instruction = getStoreConfigInstruction(
+      configAccount: configAccount,
+      keys: keys,
+      configData: Uint8List(0),
+    );
+
+    expect(identifySolanaConfigProgram(solanaConfigProgramAddress), isTrue);
+    expect(identifySolanaConfigInstruction(instruction), isTrue);
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ workspace:
   - packages/solana_kit_associated_token_account
   - packages/solana_kit_codecs
   - packages/solana_kit_compute_budget
+  - packages/solana_kit_config
   - packages/solana_kit_codecs_core
   - packages/solana_kit_codecs_data_structures
   - packages/solana_kit_codecs_numbers


### PR DESCRIPTION
## Summary
- add the solana_kit_config package with generated Config program codecs, account decoder, and Store instruction builder
- add getStoreConfigInstruction helper for typed config data and signer keys
- register the package in workspace metadata, monochange, codecov, docs, tests, and changeset

Closes #137

## Checks
- devenv shell -- dart analyze packages/solana_kit_config
- devenv shell -- flutter test packages/solana_kit_config