### PR TITLE
docs: add new program client examples

### DIFF
--- a/examples/28_program_clients.dart
+++ b/examples/28_program_clients.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:solana_kit_address_lookup_table/solana_kit_address_lookup_table.dart';
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_config/solana_kit_config.dart';
+import 'package:solana_kit_loader/solana_kit_loader.dart';
+import 'package:solana_kit_memo/solana_kit_memo.dart';
+import 'package:solana_kit_stake/solana_kit_stake.dart';
+
+const payer = Address('11111111111111111111111111111111');
+const authority = Address('11111111111111111111111111111112');
+const account = Address('11111111111111111111111111111113');
+const secondAccount = Address('11111111111111111111111111111114');
+const thirdAccount = Address('11111111111111111111111111111115');
+
+void main() {
+  buildMemoInstruction();
+  buildConfigInstruction();
+  buildAddressLookupTableInstructions();
+  buildLoaderInstructions();
+  buildStakeInstructions();
+}
+
+void buildMemoInstruction() {
+  final instruction = getAddMemoInstruction(memo: 'hello from solana_kit');
+
+  print('memo program: ${instruction.programAddress}');
+  print('memo bytes: ${utf8.decode(instruction.data ?? Uint8List(0))}');
+}
+
+void buildConfigInstruction() {
+  final instruction = getStoreConfigInstruction(
+    configAccount: account,
+    keys: const [ConfigKey(address: authority, isSigner: true)],
+    configData: Uint8List.fromList(utf8.encode('validator.example')),
+  );
+
+  print('config program: ${instruction.programAddress}');
+  print('config account metas: ${instruction.accounts?.length ?? 0}');
+}
+
+void buildAddressLookupTableInstructions() {
+  final create = getCreateLookupTableInstruction(
+    address: account,
+    authority: authority,
+    payer: payer,
+    recentSlot: BigInt.from(42),
+    bump: 255,
+  );
+  final extend = getExtendLookupTableInstruction(
+    address: account,
+    authority: authority,
+    payer: payer,
+    addresses: const [secondAccount, thirdAccount],
+  );
+
+  print('lookup table program: ${create.programAddress}');
+  print('lookup table extend bytes: ${extend.data?.length ?? 0}');
+}
+
+void buildLoaderInstructions() {
+  final write = getLoaderV3WriteInstruction(
+    bufferAccount: account,
+    bufferAuthority: authority,
+    offset: 0,
+    bytes: Uint8List.fromList([1, 2, 3, 4]),
+  );
+  final truncate = getLoaderV4TruncateInstruction(
+    program: account,
+    authority: authority,
+    destination: payer,
+    newSize: 64,
+  );
+
+  print('loader v3 program: ${write.programAddress}');
+  print('loader v4 program: ${truncate.programAddress}');
+}
+
+void buildStakeInstructions() {
+  final delegate = getDelegateStakeInstructionPlan(
+    stake: account,
+    vote: secondAccount,
+    stakeAuthority: authority,
+  );
+  final create = getCreateStakeAccountInstructionPlan(
+    payer: payer,
+    stake: account,
+    authorized: const Authorized(staker: authority, withdrawer: authority),
+    lamports: BigInt.from(1_000_000_000),
+  );
+
+  print('stake delegate plan: ${delegate.kind}');
+  print('stake create plan: ${create.kind}');
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,6 +43,8 @@ dart examples/<file>.dart
 | 24 | [24_fetch_encoded_account.dart](24_fetch_encoded_account.dart)               | `fetchEncodedAccount`, `fetchEncodedAccounts`, `ExistingAccount` / `NonExistingAccount` (devnet)   |
 | 25 | [25_union_codec.dart](25_union_codec.dart)                                   | `Union2` typed variants and `getDiscriminatedUnionEncoder/Decoder` for Anchor-style discriminators |
 | 26 | [26_transaction_serialization.dart](26_transaction_serialization.dart)       | Base64 wire format, `getTransactionSize`, `isFullySignedTransaction`, raw message bytes            |
+| 27 | [27_compressed_nft.dart](27_compressed_nft.dart)                             | Compressed NFT tree sizing, Bubblegum PDAs, metadata hashing, and DAS client setup                 |
+| 28 | [28_program_clients.dart](28_program_clients.dart)                           | Offline builders for Memo, Config, Address Lookup Table, Loader, and Stake program instructions    |
 
 ---
 
@@ -98,6 +100,8 @@ Get a free API key at <https://helius.dev> and replace the placeholder.
 | RPC subscriptions            | `solana_kit_rpc_subscriptions`, `solana_kit_rpc_subscriptions_channel_websocket`                                                             |
 | Transaction confirmation     | `solana_kit_transaction_confirmation`                                                                                                        |
 | Accounts                     | `solana_kit_accounts`                                                                                                                        |
+| Program clients              | `solana_kit_memo`, `solana_kit_config`, `solana_kit_address_lookup_table`, `solana_kit_loader`, `solana_kit_stake`                           |
+| Compressed NFTs              | `solana_kit_mpl_bubblegum`, `solana_kit_spl_account_compression`                                                                             |
 | Offchain messages            | `solana_kit_offchain_messages`                                                                                                               |
 | Helius                       | `solana_kit_helius`                                                                                                                          |
 | Functional (deprecated shim) | `solana_kit_functional`                                                                                                                      |

--- a/examples/pubspec.yaml
+++ b/examples/pubspec.yaml
@@ -10,17 +10,21 @@ resolution: workspace
 dependencies:
   solana_kit: ^0.4.0
   solana_kit_accounts: ^0.4.0
+  solana_kit_address_lookup_table: ^0.3.1
   solana_kit_addresses: ^0.4.0
   solana_kit_codecs: ^0.4.0
   solana_kit_codecs_core: ^0.4.0
   solana_kit_codecs_data_structures: ^0.4.0
   solana_kit_codecs_numbers: ^0.4.0
   solana_kit_codecs_strings: ^0.4.0
+  solana_kit_config: ^0.4.0
   solana_kit_errors: ^0.4.0
   solana_kit_fast_stable_stringify: ^0.4.0
   solana_kit_helius: ^0.3.2
   solana_kit_instructions: ^0.4.0
   solana_kit_keys: ^0.4.0
+  solana_kit_loader: ^0.4.0
+  solana_kit_memo: ^0.4.0
   solana_kit_mpl_bubblegum: ^0.2.0
   solana_kit_offchain_messages: ^0.3.2
   solana_kit_options: ^0.4.0
@@ -31,6 +35,7 @@ dependencies:
   solana_kit_rpc_types: ^0.4.0
   solana_kit_signers: ^0.4.0
   solana_kit_spl_account_compression: ^0.2.0
+  solana_kit_stake: ^0.1.0
   solana_kit_sysvars: ^0.3.2
   solana_kit_transaction_confirmation: ^0.4.0
   solana_kit_transaction_messages: ^0.4.0


### PR DESCRIPTION
## Summary
- add an offline examples/28_program_clients.dart covering Memo, Config, Address Lookup Table, Loader, and Stake instruction builders
- register the new program packages in the examples workspace dependencies
- update the examples index and package map

## Validation
- devenv shell -- bash -lc 'fvm dart analyze examples; fvm dart run examples/28_program_clients.dart; docs:check; sync:check'

Note: FlakeHub cache returned a non-blocking 401 warning during devenv startup.