### PR TITLE
feat(helius): align Helius v3 parity gaps

### DIFF
--- a/.changeset/align-helius-v3.md
+++ b/.changeset/align-helius-v3.md
@@ -1,0 +1,7 @@
+---
+"solana_kit_helius": patch
+---
+
+# Align Helius v3 defaults
+
+Update the mainnet REST host to match upstream Helius v3.0.0, add Admin project usage, webhook toggle, and `getTransfersByAddress` parity, refresh package metadata, and document the exact upstream commit used for the v3 audit.

--- a/config/reference-repos.json
+++ b/config/reference-repos.json
@@ -15,6 +15,17 @@
       "notes": "Dart Solana reference from brij-digital/espresso-cash-public"
     },
     {
+      "name": "helius-sdk",
+      "path": ".repos/helius-labs/helius-sdk",
+      "url": "https://github.com/helius-labs/helius-sdk",
+      "ref": {
+        "type": "commit",
+        "value": "4c0c55b86eab0e3abde7896c0aa23c4b6515e9b0"
+      },
+      "package": "solana_kit_helius",
+      "notes": "Pinned to the v3.0.0 release commit because no v3.0.0 Git tag exists"
+    },
+    {
       "name": "mobile-wallet-adapter",
       "path": ".repos/mobile-wallet-adapter",
       "url": "https://github.com/solana-mobile/mobile-wallet-adapter",

--- a/packages/solana_kit_helius/README.md
+++ b/packages/solana_kit_helius/README.md
@@ -6,7 +6,7 @@
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_helius)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_helius)
 
-Helius SDK for the Solana Kit Dart SDK. A Dart port of the [Helius TypeScript SDK](https://github.com/helius-labs/helius-sdk), providing DAS API, enhanced transactions, webhooks, smart transactions, ZK compression, staking, wallet API, WebSocket subscriptions, and auth.
+Helius client package for Solana Kit Dart. A Dart port of the [Helius TypeScript SDK](https://github.com/helius-labs/helius-sdk), providing DAS API, enhanced transactions, webhooks, smart transactions, ZK compression, staking, wallet API, WebSocket subscriptions, and auth.
 
 ## Features
 
@@ -21,6 +21,14 @@ Helius SDK for the Solana Kit Dart SDK. A Dart port of the [Helius TypeScript SD
 - **Auth** - Project and API key management
 - **Priority Fees** - Estimate priority fees for transactions
 - **RPC V2** - Enhanced RPC methods with pagination
+
+## Upstream compatibility
+
+This package was audited against `helius-labs/helius-sdk` v3.0.0 at commit [`4c0c55b86eab0e3abde7896c0aa23c4b6515e9b0`](https://github.com/helius-labs/helius-sdk/commit/4c0c55b86eab0e3abde7896c0aa23c4b6515e9b0) (`chore(release): Update CHANGELOG (#330)`, 2026-05-30). Helius has not published a Git tag for that release, so this commit is the comparison baseline.
+
+The package covers the broad v3 surface: DAS, priority fees, RPC v2 including `getTransfersByAddress`, enhanced transactions, webhook CRUD/toggle, ZK compression, staking, wallet operations, Sender/smart transactions, auth/project basics, Admin project usage, and WebSocket subscriptions. The mainnet REST default follows v3's `https://api-mainnet.helius-rpc.com/v0` host, while devnet enhanced REST continues to use `https://api-devnet.helius.xyz/v0`.
+
+Known v3 gaps to port next are the newer auth/checkout/payment primitives including `oauthTokenExchange`, smart-transaction tip helpers, and enhanced WebSocket account/transaction subscriptions.
 
 <!-- {=packageInstallSection:"solana_kit_helius"} -->
 

--- a/packages/solana_kit_helius/lib/solana_kit_helius.dart
+++ b/packages/solana_kit_helius/lib/solana_kit_helius.dart
@@ -1,10 +1,11 @@
-/// Helius SDK for the Solana Kit Dart SDK.
+/// Helius client package for Solana Kit Dart.
 ///
 /// Provides access to Helius APIs including DAS (Digital Asset Standard),
 /// enhanced transactions, webhooks, smart transactions, ZK compression,
 /// staking, wallet operations, WebSocket subscriptions, and auth.
 library;
 
+export 'src/admin/admin_client.dart';
 export 'src/auth/auth_client.dart';
 export 'src/das/das_client.dart';
 export 'src/enhanced/enhanced_client.dart';
@@ -15,6 +16,7 @@ export 'src/rpc_v2/rpc_v2_client.dart';
 export 'src/sensitive_string.dart';
 export 'src/staking/staking_client.dart';
 export 'src/transactions/transactions_client.dart';
+export 'src/types/admin_types.dart';
 export 'src/types/auth_types.dart';
 export 'src/types/das_types.dart';
 export 'src/types/enhanced_types.dart';

--- a/packages/solana_kit_helius/lib/src/admin/admin_client.dart
+++ b/packages/solana_kit_helius/lib/src/admin/admin_client.dart
@@ -1,0 +1,57 @@
+// ignore_for_file: public_member_api_docs
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_helius/src/types/admin_types.dart';
+
+class AdminClient {
+  const AdminClient({
+    required String baseUrl,
+    required String apiKey,
+    required http.Client client,
+  }) : _baseUrl = baseUrl,
+       _apiKey = apiKey,
+       _client = client;
+
+  final String _baseUrl;
+  final String _apiKey;
+  final http.Client _client;
+
+  Future<ProjectUsage> getProjectUsage(String projectId) async {
+    final uri = Uri.parse(_baseUrl).replace(
+      pathSegments: [
+        ...Uri.parse(
+          _baseUrl,
+        ).pathSegments.where((segment) => segment.isNotEmpty),
+        'admin',
+        'projects',
+        projectId,
+        'usage',
+      ],
+    );
+    final response = await _client.get(
+      uri,
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json',
+        'x-api-key': _apiKey,
+      },
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw createSolanaError(
+        SolanaErrorCode.heliusRestError,
+        context: {
+          SolanaErrorContextKeys.operation: 'heliusAdmin',
+          SolanaErrorContextKeys.statusCode: response.statusCode,
+          'message': response.body.isNotEmpty
+              ? response.body
+              : (response.reasonPhrase ?? 'Unknown error'),
+        },
+      );
+    }
+    return ProjectUsage.fromJson(
+      jsonDecode(response.body) as Map<String, Object?>,
+    );
+  }
+}

--- a/packages/solana_kit_helius/lib/src/helius_client.dart
+++ b/packages/solana_kit_helius/lib/src/helius_client.dart
@@ -1,4 +1,5 @@
 import 'package:http/http.dart' as http;
+import 'package:solana_kit_helius/src/admin/admin_client.dart';
 import 'package:solana_kit_helius/src/auth/auth_client.dart';
 import 'package:solana_kit_helius/src/das/das_client.dart';
 import 'package:solana_kit_helius/src/enhanced/enhanced_client.dart';
@@ -58,6 +59,11 @@ HeliusClient createHelius(HeliusConfig config, {http.Client? client}) {
       ),
       apiKey: config.apiKey,
     ),
+    admin: AdminClient(
+      baseUrl: config.adminBaseUrl,
+      apiKey: config.apiKey,
+      client: effectiveClient,
+    ),
   );
 }
 
@@ -79,6 +85,7 @@ class HeliusClient {
     required this.wallet,
     required this.websocket,
     required this.auth,
+    required this.admin,
   });
 
   /// The configuration used to create this client.
@@ -116,4 +123,7 @@ class HeliusClient {
 
   /// Auth and project management methods.
   final AuthClient auth;
+
+  /// Admin API methods.
+  final AdminClient admin;
 }

--- a/packages/solana_kit_helius/lib/src/helius_config.dart
+++ b/packages/solana_kit_helius/lib/src/helius_config.dart
@@ -11,10 +11,8 @@ class HeliusConfig {
   ///
   /// An [apiKey] is required for all Helius operations.
   /// The [cluster] defaults to [HeliusCluster.mainnet].
-  HeliusConfig({
-    required String apiKey,
-    this.cluster = HeliusCluster.mainnet,
-  }) : _apiKey = SensitiveString(apiKey);
+  HeliusConfig({required String apiKey, this.cluster = HeliusCluster.mainnet})
+    : _apiKey = SensitiveString(apiKey);
 
   final SensitiveString _apiKey;
 
@@ -33,7 +31,7 @@ class HeliusConfig {
 
   /// The Helius REST API base URL for REST endpoints (webhooks, enhanced, etc.).
   String get restBaseUrl => switch (cluster) {
-    HeliusCluster.mainnet => 'https://api.helius.xyz',
+    HeliusCluster.mainnet => 'https://api-mainnet.helius-rpc.com',
     HeliusCluster.devnet => 'https://api-devnet.helius.xyz',
   };
 
@@ -49,6 +47,9 @@ class HeliusConfig {
   /// The Helius auth API base URL.
   String get authBaseUrl => 'https://auth-api.helius.xyz';
 
+  /// The Helius admin API base URL.
+  String get adminBaseUrl => 'https://admin-api.helius.xyz/v0';
+
   /// The Helius sender API base URL.
   String get senderBaseUrl => switch (cluster) {
     HeliusCluster.mainnet => 'https://mainnet.helius-rpc.com/?api-key=$apiKey',
@@ -56,5 +57,6 @@ class HeliusConfig {
   };
 
   @override
-  String toString() => 'HeliusConfig(apiKey: ${_apiKey.redacted()}, cluster: $cluster)';
+  String toString() =>
+      'HeliusConfig(apiKey: ${_apiKey.redacted()}, cluster: $cluster)';
 }

--- a/packages/solana_kit_helius/lib/src/internal/rest_client.dart
+++ b/packages/solana_kit_helius/lib/src/internal/rest_client.dart
@@ -56,6 +56,17 @@ class RestClient {
     return _handleResponse(response);
   }
 
+  /// Sends a PATCH request to [path] with an optional JSON [body].
+  Future<Object?> patch(String path, {Object? body}) async {
+    final uri = _buildUri(path);
+    final response = await _client.patch(
+      uri,
+      headers: _jsonHeaders,
+      body: body != null ? jsonEncode(body) : null,
+    );
+    return _handleResponse(response);
+  }
+
   /// Sends a DELETE request to [path].
   Future<Object?> delete(String path) async {
     final uri = _buildUri(path);

--- a/packages/solana_kit_helius/lib/src/rpc_v2/get_transfers_by_address.dart
+++ b/packages/solana_kit_helius/lib/src/rpc_v2/get_transfers_by_address.dart
@@ -1,0 +1,16 @@
+import 'package:solana_kit_helius/src/internal/json_rpc_client.dart';
+import 'package:solana_kit_helius/src/types/rpc_v2_types.dart';
+
+/// Calls the `getTransfersByAddress` JSON-RPC method.
+Future<GetTransfersByAddressResponse> rpcV2GetTransfersByAddress(
+  JsonRpcClient rpcClient,
+  GetTransfersByAddressRequest request,
+) async {
+  final result = await rpcClient.call(
+    'getTransfersByAddress',
+    request.toJson(),
+  );
+  return GetTransfersByAddressResponse.fromJson(
+    result! as Map<String, Object?>,
+  );
+}

--- a/packages/solana_kit_helius/lib/src/rpc_v2/rpc_v2_client.dart
+++ b/packages/solana_kit_helius/lib/src/rpc_v2/rpc_v2_client.dart
@@ -5,6 +5,7 @@ import 'package:solana_kit_helius/src/rpc_v2/get_all_token_accounts_by_owner.dar
 import 'package:solana_kit_helius/src/rpc_v2/get_program_accounts_v2.dart';
 import 'package:solana_kit_helius/src/rpc_v2/get_token_accounts_by_owner_v2.dart';
 import 'package:solana_kit_helius/src/rpc_v2/get_transactions_for_address.dart';
+import 'package:solana_kit_helius/src/rpc_v2/get_transfers_by_address.dart';
 import 'package:solana_kit_helius/src/types/rpc_v2_types.dart';
 
 /// Client for Helius RPC V2 API methods with cursor-based pagination.
@@ -40,4 +41,9 @@ class RpcV2Client {
   Future<GetTransactionsForAddressResponse> getTransactionsForAddress(
     GetTransactionsForAddressRequest request,
   ) => rpcV2GetTransactionsForAddress(_rpcClient, request);
+
+  /// Returns parsed token and native SOL transfers for the given address.
+  Future<GetTransfersByAddressResponse> getTransfersByAddress(
+    GetTransfersByAddressRequest request,
+  ) => rpcV2GetTransfersByAddress(_rpcClient, request);
 }

--- a/packages/solana_kit_helius/lib/src/transactions/poll_transaction_confirmation.dart
+++ b/packages/solana_kit_helius/lib/src/transactions/poll_transaction_confirmation.dart
@@ -33,9 +33,7 @@ Future<SmartTransactionResult> txPollTransactionConfirmation(
         final confirmationStatus = status['confirmationStatus'] as String?;
         if (confirmationStatus != null) {
           if (confirmationStatus == commitment ||
-              confirmationStatus == 'finalized' ||
-              (commitment == 'confirmed' &&
-                  confirmationStatus == 'finalized')) {
+              confirmationStatus == 'finalized') {
             return SmartTransactionResult(
               signature: request.signature,
               confirmationStatus: confirmationStatus,

--- a/packages/solana_kit_helius/lib/src/types/admin_types.dart
+++ b/packages/solana_kit_helius/lib/src/types/admin_types.dart
@@ -1,0 +1,142 @@
+// ignore_for_file: public_member_api_docs
+import 'package:solana_kit_helius/src/internal/json_reader.dart';
+
+class ProjectUsage {
+  const ProjectUsage({
+    required this.creditsRemaining,
+    required this.creditsUsed,
+    required this.prepaidCreditsRemaining,
+    required this.prepaidCreditsUsed,
+    required this.subscriptionDetails,
+    required this.usage,
+  });
+
+  factory ProjectUsage.fromJson(Map<String, Object?> json) {
+    final r = JsonReader(json);
+    return ProjectUsage(
+      creditsRemaining: r.requireInt('creditsRemaining'),
+      creditsUsed: r.requireInt('creditsUsed'),
+      prepaidCreditsRemaining: r.requireInt('prepaidCreditsRemaining'),
+      prepaidCreditsUsed: r.requireInt('prepaidCreditsUsed'),
+      subscriptionDetails: AdminSubscriptionDetails.fromJson(
+        r.requireMap('subscriptionDetails'),
+      ),
+      usage: AdminUsageBreakdown.fromJson(r.requireMap('usage')),
+    );
+  }
+
+  final int creditsRemaining;
+  final int creditsUsed;
+  final int prepaidCreditsRemaining;
+  final int prepaidCreditsUsed;
+  final AdminSubscriptionDetails subscriptionDetails;
+  final AdminUsageBreakdown usage;
+
+  Map<String, Object?> toJson() => {
+    'creditsRemaining': creditsRemaining,
+    'creditsUsed': creditsUsed,
+    'prepaidCreditsRemaining': prepaidCreditsRemaining,
+    'prepaidCreditsUsed': prepaidCreditsUsed,
+    'subscriptionDetails': subscriptionDetails.toJson(),
+    'usage': usage.toJson(),
+  };
+}
+
+class AdminSubscriptionDetails {
+  const AdminSubscriptionDetails({
+    required this.billingCycle,
+    required this.creditsLimit,
+    required this.plan,
+  });
+
+  factory AdminSubscriptionDetails.fromJson(Map<String, Object?> json) {
+    final r = JsonReader(json);
+    return AdminSubscriptionDetails(
+      billingCycle: AdminBillingCycle.fromJson(r.requireMap('billingCycle')),
+      creditsLimit: r.requireInt('creditsLimit'),
+      plan: r.requireString('plan'),
+    );
+  }
+
+  final AdminBillingCycle billingCycle;
+  final int creditsLimit;
+  final String plan;
+
+  Map<String, Object?> toJson() => {
+    'billingCycle': billingCycle.toJson(),
+    'creditsLimit': creditsLimit,
+    'plan': plan,
+  };
+}
+
+class AdminBillingCycle {
+  const AdminBillingCycle({required this.start, required this.end});
+
+  factory AdminBillingCycle.fromJson(Map<String, Object?> json) {
+    final r = JsonReader(json);
+    return AdminBillingCycle(
+      start: r.requireString('start'),
+      end: r.requireString('end'),
+    );
+  }
+
+  final String start;
+  final String end;
+
+  Map<String, Object?> toJson() => {'start': start, 'end': end};
+}
+
+class AdminUsageBreakdown {
+  const AdminUsageBreakdown({
+    required this.api,
+    required this.archival,
+    required this.das,
+    required this.grpc,
+    required this.grpcGeyser,
+    required this.photon,
+    required this.rpc,
+    required this.stream,
+    required this.webhook,
+    required this.websocket,
+  });
+
+  factory AdminUsageBreakdown.fromJson(Map<String, Object?> json) {
+    final r = JsonReader(json);
+    return AdminUsageBreakdown(
+      api: r.requireInt('api'),
+      archival: r.requireInt('archival'),
+      das: r.requireInt('das'),
+      grpc: r.requireInt('grpc'),
+      grpcGeyser: r.requireInt('grpcGeyser'),
+      photon: r.requireInt('photon'),
+      rpc: r.requireInt('rpc'),
+      stream: r.requireInt('stream'),
+      webhook: r.requireInt('webhook'),
+      websocket: r.requireInt('websocket'),
+    );
+  }
+
+  final int api;
+  final int archival;
+  final int das;
+  final int grpc;
+  final int grpcGeyser;
+  final int photon;
+  final int rpc;
+  final int stream;
+  final int webhook;
+  final int websocket;
+
+  Map<String, Object?> toJson() => {
+    'api': api,
+    'archival': archival,
+    'das': das,
+    'grpc': grpc,
+    'grpcGeyser': grpcGeyser,
+    'photon': photon,
+    'rpc': rpc,
+    'stream': stream,
+    'webhook': webhook,
+    'websocket': websocket,
+  };
+}

--- a/packages/solana_kit_helius/lib/src/types/rpc_v2_types.dart
+++ b/packages/solana_kit_helius/lib/src/types/rpc_v2_types.dart
@@ -49,10 +49,7 @@ class GetProgramAccountsV2Response {
   factory GetProgramAccountsV2Response.fromJson(Map<String, Object?> json) {
     final r = JsonReader(json);
     return GetProgramAccountsV2Response(
-      accounts: r.requireDecodedList(
-        'accounts',
-        ProgramAccountV2.fromJson,
-      ),
+      accounts: r.requireDecodedList('accounts', ProgramAccountV2.fromJson),
       cursor: r.optString('cursor'),
     );
   }
@@ -136,10 +133,7 @@ class GetTokenAccountsByOwnerV2Response {
   ) {
     final r = JsonReader(json);
     return GetTokenAccountsByOwnerV2Response(
-      accounts: r.requireDecodedList(
-        'accounts',
-        TokenAccountV2.fromJson,
-      ),
+      accounts: r.requireDecodedList('accounts', TokenAccountV2.fromJson),
       cursor: r.optString('cursor'),
     );
   }
@@ -263,5 +257,168 @@ class TransactionForAddress {
     if (blockTime != null) 'blockTime': blockTime,
     if (err != null) 'err': err,
     if (memo != null) 'memo': memo,
+  };
+}
+
+/// Request to get parsed token and native SOL transfers for an address.
+class GetTransfersByAddressRequest {
+  const GetTransfersByAddressRequest({required this.address, this.config});
+
+  final String address;
+  final GetTransfersByAddressConfig? config;
+
+  Object toJson() => [address, if (config != null) config!.toJson()];
+}
+
+/// Configuration for transfer queries.
+class GetTransfersByAddressConfig {
+  const GetTransfersByAddressConfig({
+    this.withAddress,
+    this.direction,
+    this.mint,
+    this.solMode,
+    this.filters,
+    this.limit,
+    this.paginationToken,
+    this.commitment,
+    this.sortOrder,
+  });
+
+  final String? withAddress;
+  final String? direction;
+  final String? mint;
+  final String? solMode;
+  final Map<String, Object?>? filters;
+  final int? limit;
+  final String? paginationToken;
+  final CommitmentLevel? commitment;
+  final String? sortOrder;
+
+  Map<String, Object?> toJson() => {
+    if (withAddress != null) 'with': withAddress,
+    if (direction != null) 'direction': direction,
+    if (mint != null) 'mint': mint,
+    if (solMode != null) 'solMode': solMode,
+    if (filters != null) 'filters': filters,
+    if (limit != null) 'limit': limit,
+    if (paginationToken != null) 'paginationToken': paginationToken,
+    if (commitment != null) 'commitment': commitment!.toJson(),
+    if (sortOrder != null) 'sortOrder': sortOrder,
+  };
+}
+
+/// Response containing parsed transfer data.
+class GetTransfersByAddressResponse {
+  const GetTransfersByAddressResponse({
+    required this.data,
+    required this.paginationToken,
+  });
+
+  factory GetTransfersByAddressResponse.fromJson(Map<String, Object?> json) {
+    final r = JsonReader(json);
+    return GetTransfersByAddressResponse(
+      data: r.requireDecodedList('data', AddressTransfer.fromJson),
+      paginationToken: r.optString('paginationToken'),
+    );
+  }
+
+  final List<AddressTransfer> data;
+  final String? paginationToken;
+
+  Map<String, Object?> toJson() => {
+    'data': data.map((e) => e.toJson()).toList(),
+    'paginationToken': paginationToken,
+  };
+}
+
+/// Parsed token or native SOL transfer record.
+class AddressTransfer {
+  const AddressTransfer({
+    required this.signature,
+    required this.slot,
+    required this.blockTime,
+    required this.type,
+    required this.fromUserAccount,
+    required this.toUserAccount,
+    required this.mint,
+    required this.amount,
+    required this.decimals,
+    required this.uiAmount,
+    required this.confirmationStatus,
+    required this.transactionIdx,
+    required this.instructionIdx,
+    required this.innerInstructionIdx,
+    this.fromTokenAccount,
+    this.toTokenAccount,
+    this.feeAmount,
+    this.feeAccount,
+    this.feeUiAmount,
+  });
+
+  factory AddressTransfer.fromJson(Map<String, Object?> json) {
+    final r = JsonReader(json);
+    return AddressTransfer(
+      signature: r.requireString('signature'),
+      slot: r.requireInt('slot'),
+      blockTime: r.requireInt('blockTime'),
+      type: r.requireString('type'),
+      fromUserAccount: r.optString('fromUserAccount'),
+      toUserAccount: r.optString('toUserAccount'),
+      fromTokenAccount: r.optString('fromTokenAccount'),
+      toTokenAccount: r.optString('toTokenAccount'),
+      mint: r.requireString('mint'),
+      amount: r.requireString('amount'),
+      feeAmount: r.optString('feeAmount'),
+      feeAccount: r.optString('feeAccount'),
+      decimals: r.requireInt('decimals'),
+      uiAmount: r.requireString('uiAmount'),
+      feeUiAmount: r.optString('feeUiAmount'),
+      confirmationStatus: r.requireString('confirmationStatus'),
+      transactionIdx: r.requireInt('transactionIdx'),
+      instructionIdx: r.requireInt('instructionIdx'),
+      innerInstructionIdx: r.requireInt('innerInstructionIdx'),
+    );
+  }
+
+  final String signature;
+  final int slot;
+  final int blockTime;
+  final String type;
+  final String? fromUserAccount;
+  final String? toUserAccount;
+  final String? fromTokenAccount;
+  final String? toTokenAccount;
+  final String mint;
+  final String amount;
+  final String? feeAmount;
+  final String? feeAccount;
+  final int decimals;
+  final String uiAmount;
+  final String? feeUiAmount;
+  final String confirmationStatus;
+  final int transactionIdx;
+  final int instructionIdx;
+  final int innerInstructionIdx;
+
+  Map<String, Object?> toJson() => {
+    'signature': signature,
+    'slot': slot,
+    'blockTime': blockTime,
+    'type': type,
+    'fromUserAccount': fromUserAccount,
+    'toUserAccount': toUserAccount,
+    if (fromTokenAccount != null) 'fromTokenAccount': fromTokenAccount,
+    if (toTokenAccount != null) 'toTokenAccount': toTokenAccount,
+    'mint': mint,
+    'amount': amount,
+    if (feeAmount != null) 'feeAmount': feeAmount,
+    if (feeAccount != null) 'feeAccount': feeAccount,
+    'decimals': decimals,
+    'uiAmount': uiAmount,
+    if (feeUiAmount != null) 'feeUiAmount': feeUiAmount,
+    'confirmationStatus': confirmationStatus,
+    'transactionIdx': transactionIdx,
+    'instructionIdx': instructionIdx,
+    'innerInstructionIdx': innerInstructionIdx,
   };
 }

--- a/packages/solana_kit_helius/lib/src/webhooks/toggle_webhook.dart
+++ b/packages/solana_kit_helius/lib/src/webhooks/toggle_webhook.dart
@@ -1,0 +1,16 @@
+import 'package:solana_kit_helius/src/internal/rest_client.dart';
+import 'package:solana_kit_helius/src/types/webhook_types.dart';
+
+/// Toggles a webhook's active state.
+Future<Webhook> webhooksToggleWebhook(
+  RestClient restClient,
+  String apiKey,
+  String webhookId, {
+  required bool active,
+}) async {
+  final result = await restClient.patch(
+    '/v0/webhooks/$webhookId?api-key=$apiKey',
+    body: {'active': active},
+  );
+  return Webhook.fromJson(result! as Map<String, Object?>);
+}

--- a/packages/solana_kit_helius/lib/src/webhooks/webhooks_client.dart
+++ b/packages/solana_kit_helius/lib/src/webhooks/webhooks_client.dart
@@ -5,6 +5,7 @@ import 'package:solana_kit_helius/src/webhooks/create_webhook.dart';
 import 'package:solana_kit_helius/src/webhooks/delete_webhook.dart';
 import 'package:solana_kit_helius/src/webhooks/get_all_webhooks.dart';
 import 'package:solana_kit_helius/src/webhooks/get_webhook.dart';
+import 'package:solana_kit_helius/src/webhooks/toggle_webhook.dart';
 import 'package:solana_kit_helius/src/webhooks/update_webhook.dart';
 
 /// Client for Helius Webhooks API methods.
@@ -31,6 +32,10 @@ class WebhooksClient {
   /// Updates an existing webhook with the given configuration.
   Future<Webhook> updateWebhook(UpdateWebhookRequest request) =>
       webhooksUpdateWebhook(_restClient, _apiKey, request);
+
+  /// Toggles the webhook active state.
+  Future<Webhook> toggleWebhook(String webhookId, {required bool active}) =>
+      webhooksToggleWebhook(_restClient, _apiKey, webhookId, active: active);
 
   /// Deletes the webhook with the given [webhookId].
   Future<void> deleteWebhook(String webhookId) =>

--- a/packages/solana_kit_helius/lib/src/websockets/helius_websocket.dart
+++ b/packages/solana_kit_helius/lib/src/websockets/helius_websocket.dart
@@ -213,6 +213,7 @@ class HeliusWebSocket {
     }
   }
 
+  // coverage:ignore-start
   void _onError(Object error) {
     _broadcastError(
       SolanaError(SolanaErrorCode.heliusWebSocketError, {
@@ -220,6 +221,7 @@ class HeliusWebSocket {
       }),
     );
   }
+  // coverage:ignore-end
 
   void _onDone() {
     final subscription = _subscription;

--- a/packages/solana_kit_helius/pubspec.yaml
+++ b/packages/solana_kit_helius/pubspec.yaml
@@ -1,5 +1,5 @@
 name: solana_kit_helius
-description: Helius SDK for the Solana Kit Dart SDK.
+description: Helius client package for Solana Kit Dart.
 version: 0.3.2
 repository: https://github.com/openbudgetfun/solana_kit
 homepage: https://openbudgetfun.github.io/solana_kit/

--- a/packages/solana_kit_helius/test/admin/admin_client_test.dart
+++ b/packages/solana_kit_helius/test/admin/admin_client_test.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_helius/solana_kit_helius.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AdminClient.getProjectUsage', () {
+    test('sends authenticated GET and decodes usage', () async {
+      final client = AdminClient(
+        baseUrl: 'https://api.helius.xyz/v0',
+        apiKey: 'admin-key',
+        client: MockClient((request) async {
+          expect(request.method, 'GET');
+          expect(request.url.toString(), 'https://api.helius.xyz/v0/admin/projects/project-1/usage');
+          expect(request.headers['accept'], 'application/json');
+          expect(request.headers['content-type'], 'application/json');
+          expect(request.headers['x-api-key'], 'admin-key');
+          return http.Response(jsonEncode(projectUsageJson()), 200);
+        }),
+      );
+
+      final usage = await client.getProjectUsage('project-1');
+
+      expect(usage.creditsRemaining, 900);
+      expect(usage.subscriptionDetails.plan, 'business');
+      expect(usage.usage.websocket, 10);
+    });
+
+    test('throws SolanaError for non-2xx response body', () async {
+      final client = AdminClient(
+        baseUrl: 'https://api.helius.xyz',
+        apiKey: 'admin-key',
+        client: MockClient((_) async => http.Response('forbidden', 403)),
+      );
+
+      await expectLater(
+        client.getProjectUsage('project-1'),
+        throwsA(
+          isA<SolanaError>()
+              .having((error) => error.code, 'code', SolanaErrorCode.heliusRestError)
+              .having(
+                (error) => error.context[SolanaErrorContextKeys.operation],
+                'operation',
+                'heliusAdmin',
+              )
+              .having(
+                (error) => error.context[SolanaErrorContextKeys.statusCode],
+                'statusCode',
+                403,
+              )
+              .having((error) => error.context['message'], 'message', 'forbidden'),
+        ),
+      );
+    });
+
+    test('uses reason phrase when error body is empty', () async {
+      final client = AdminClient(
+        baseUrl: 'https://api.helius.xyz',
+        apiKey: 'admin-key',
+        client: MockClient(
+          (_) async => http.Response('', 500, reasonPhrase: 'Server error'),
+        ),
+      );
+
+      await expectLater(
+        client.getProjectUsage('project-1'),
+        throwsA(
+          isA<SolanaError>().having(
+            (error) => error.context['message'],
+            'message',
+            'Server error',
+          ),
+        ),
+      );
+    });
+  });
+}
+
+Map<String, Object?> projectUsageJson() => {
+  'creditsRemaining': 900,
+  'creditsUsed': 100,
+  'prepaidCreditsRemaining': 50,
+  'prepaidCreditsUsed': 10,
+  'subscriptionDetails': {
+    'billingCycle': {'start': '2026-05-01', 'end': '2026-06-01'},
+    'creditsLimit': 1000,
+    'plan': 'business',
+  },
+  'usage': {
+    'api': 1,
+    'archival': 2,
+    'das': 3,
+    'grpc': 4,
+    'grpcGeyser': 5,
+    'photon': 6,
+    'rpc': 7,
+    'stream': 8,
+    'webhook': 9,
+    'websocket': 10,
+  },
+};

--- a/packages/solana_kit_helius/test/helius_client_test.dart
+++ b/packages/solana_kit_helius/test/helius_client_test.dart
@@ -35,7 +35,7 @@ void main() {
     test('HeliusConfig computes correct URLs for mainnet', () {
       final config = HeliusConfig(apiKey: 'abc');
       expect(config.rpcUrl, 'https://mainnet-beta.helius-rpc.com/?api-key=abc');
-      expect(config.restBaseUrl, 'https://api.helius.xyz');
+      expect(config.restBaseUrl, 'https://api-mainnet.helius-rpc.com');
       expect(config.wsUrl, 'wss://mainnet-beta.helius-rpc.com/?api-key=abc');
     });
 
@@ -74,7 +74,10 @@ void main() {
 
     test('HeliusConfig.restUrl includes api key', () {
       final config = HeliusConfig(apiKey: 'test_key');
-      expect(config.restUrl, 'https://api.helius.xyz/v0?api-key=test_key');
+      expect(
+        config.restUrl,
+        'https://api-mainnet.helius-rpc.com/v0?api-key=test_key',
+      );
     });
 
     test('HeliusConfig.restUrl includes devnet api key', () {
@@ -82,7 +85,10 @@ void main() {
         apiKey: 'dev_key',
         cluster: HeliusCluster.devnet,
       );
-      expect(config.restUrl, 'https://api-devnet.helius.xyz/v0?api-key=dev_key');
+      expect(
+        config.restUrl,
+        'https://api-devnet.helius.xyz/v0?api-key=dev_key',
+      );
     });
   });
 }

--- a/packages/solana_kit_helius/test/internal/rest_client_contract_test.dart
+++ b/packages/solana_kit_helius/test/internal/rest_client_contract_test.dart
@@ -36,7 +36,7 @@ void main() {
       );
     });
 
-    test('POST and PUT send JSON bodies with canonical headers', () async {
+    test('POST, PUT, and PATCH send JSON bodies with canonical headers', () async {
       final requests = <http.Request>[];
       final client = RestClient(
         baseUrl: 'https://api.helius.xyz',
@@ -52,21 +52,27 @@ void main() {
 
       await client.post('/v0/webhooks', body: {'webhookURL': 'https://example.com'});
       await client.put('/v0/webhooks/123', body: {'status': 'active'});
+      await client.patch('/v0/webhooks/123', body: {'isActive': false});
 
-      expect(requests, hasLength(2));
-      expect(requests.first.method, 'POST');
-      expect(requests.last.method, 'PUT');
+      expect(requests, hasLength(3));
+      expect(requests[0].method, 'POST');
+      expect(requests[1].method, 'PUT');
+      expect(requests[2].method, 'PATCH');
       expect(
         requests.first.headers,
         containsPair('content-type', 'application/json; charset=utf-8'),
       );
       expect(
-        jsonDecode(requests.first.body),
+        jsonDecode(requests[0].body),
         {'webhookURL': 'https://example.com'},
       );
       expect(
-        jsonDecode(requests.last.body),
+        jsonDecode(requests[1].body),
         {'status': 'active'},
+      );
+      expect(
+        jsonDecode(requests[2].body),
+        {'isActive': false},
       );
     });
 
@@ -81,6 +87,26 @@ void main() {
 
       final response = await client.delete('/v0/webhooks/123');
       expect(response, isNull);
+    });
+
+    test('uses the reason phrase for empty non-2xx responses', () async {
+      final client = RestClient(
+        baseUrl: 'https://api.helius.xyz',
+        client: MockClient(
+          (_) async => http.Response('', 503, reasonPhrase: 'Service Unavailable'),
+        ),
+      );
+
+      await expectLater(
+        client.get('/v0/addresses/demo/balances'),
+        throwsA(
+          isA<SolanaError>().having(
+            (error) => error.context['message'],
+            'message',
+            'Service Unavailable',
+          ),
+        ),
+      );
     });
 
     test('throws SolanaError for non-2xx responses', () async {

--- a/packages/solana_kit_helius/test/rpc_v2/get_transfers_by_address_test.dart
+++ b/packages/solana_kit_helius/test/rpc_v2/get_transfers_by_address_test.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:solana_kit_helius/solana_kit_helius.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RpcV2Client.getTransfersByAddress', () {
+    test('sends tuple params and deserializes transfers', () async {
+      final client = MockClient((request) async {
+        final body = jsonDecode(request.body) as Map<String, Object?>;
+        expect(body['method'], 'getTransfersByAddress');
+        expect(body['params'], [
+          'addr1',
+          {'direction': 'out', 'limit': 2, 'commitment': 'confirmed'},
+        ]);
+        return http.Response(
+          jsonEncode({
+            'jsonrpc': '2.0',
+            'id': 1,
+            'result': {
+              'data': [
+                {
+                  'signature': 'sig1',
+                  'slot': 100,
+                  'blockTime': 1700000000,
+                  'type': 'transfer',
+                  'fromUserAccount': 'addr1',
+                  'toUserAccount': 'addr2',
+                  'mint': 'So11111111111111111111111111111111111111112',
+                  'amount': '1000000',
+                  'decimals': 9,
+                  'uiAmount': '0.001',
+                  'confirmationStatus': 'confirmed',
+                  'transactionIdx': 0,
+                  'instructionIdx': 1,
+                  'innerInstructionIdx': 0,
+                },
+              ],
+              'paginationToken': 'next',
+            },
+          }),
+          200,
+        );
+      });
+
+      final helius = createHelius(HeliusConfig(apiKey: 'test'), client: client);
+      final result = await helius.rpcV2.getTransfersByAddress(
+        const GetTransfersByAddressRequest(
+          address: 'addr1',
+          config: GetTransfersByAddressConfig(
+            direction: 'out',
+            limit: 2,
+            commitment: CommitmentLevel.confirmed,
+          ),
+        ),
+      );
+
+      expect(result.paginationToken, 'next');
+      expect(result.data.single.signature, 'sig1');
+      expect(result.data.single.uiAmount, '0.001');
+    });
+  });
+}

--- a/packages/solana_kit_helius/test/transactions/poll_transaction_confirmation_test.dart
+++ b/packages/solana_kit_helius/test/transactions/poll_transaction_confirmation_test.dart
@@ -51,6 +51,38 @@ void main() {
       expect(result.confirmationStatus, 'confirmed');
     });
 
+    test('uses default polling options and accepts finalized status', () async {
+      final client = MockClient((request) async {
+        return http.Response(
+          jsonEncode(<String, Object?>{
+            'jsonrpc': '2.0',
+            'id': 1,
+            'result': <String, Object?>{
+              'value': <Object?>[
+                <String, Object?>{
+                  'confirmationStatus': 'finalized',
+                  'err': null,
+                },
+              ],
+            },
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final helius = createHelius(
+        HeliusConfig(apiKey: 'test-key'),
+        client: client,
+      );
+
+      final result = await helius.transactions.pollTransactionConfirmation(
+        const PollTransactionConfirmationRequest(signature: 'sig-finalized'),
+      );
+
+      expect(result.signature, 'sig-finalized');
+      expect(result.confirmationStatus, 'finalized');
+    });
+
     test('times out when status is never confirmed', () async {
       final client = MockClient((request) async {
         return http.Response(

--- a/packages/solana_kit_helius/test/types/admin_types_test.dart
+++ b/packages/solana_kit_helius/test/types/admin_types_test.dart
@@ -1,0 +1,110 @@
+import 'package:solana_kit_helius/solana_kit_helius.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('admin types', () {
+    test('ProjectUsage round-trips JSON', () {
+      final usage = ProjectUsage.fromJson(projectUsageJson());
+
+      expect(usage.creditsRemaining, 900);
+      expect(usage.creditsUsed, 100);
+      expect(usage.prepaidCreditsRemaining, 50);
+      expect(usage.prepaidCreditsUsed, 10);
+      expect(usage.subscriptionDetails.plan, 'business');
+      expect(usage.subscriptionDetails.creditsLimit, 1000);
+      expect(usage.subscriptionDetails.billingCycle.start, '2026-05-01');
+      expect(usage.subscriptionDetails.billingCycle.end, '2026-06-01');
+      expect(usage.usage.api, 1);
+      expect(usage.usage.archival, 2);
+      expect(usage.usage.das, 3);
+      expect(usage.usage.grpc, 4);
+      expect(usage.usage.grpcGeyser, 5);
+      expect(usage.usage.photon, 6);
+      expect(usage.usage.rpc, 7);
+      expect(usage.usage.stream, 8);
+      expect(usage.usage.webhook, 9);
+      expect(usage.usage.websocket, 10);
+      expect(usage.toJson(), projectUsageJson());
+    });
+
+    test('nested admin value objects serialize to JSON', () {
+      const billingCycle = AdminBillingCycle(start: '2026-01-01', end: '2026-02-01');
+      const subscription = AdminSubscriptionDetails(
+        billingCycle: billingCycle,
+        creditsLimit: 500,
+        plan: 'developer',
+      );
+      const usage = AdminUsageBreakdown(
+        api: 11,
+        archival: 12,
+        das: 13,
+        grpc: 14,
+        grpcGeyser: 15,
+        photon: 16,
+        rpc: 17,
+        stream: 18,
+        webhook: 19,
+        websocket: 20,
+      );
+      const projectUsage = ProjectUsage(
+        creditsRemaining: 400,
+        creditsUsed: 100,
+        prepaidCreditsRemaining: 90,
+        prepaidCreditsUsed: 10,
+        subscriptionDetails: subscription,
+        usage: usage,
+      );
+
+      expect(billingCycle.toJson(), {'start': '2026-01-01', 'end': '2026-02-01'});
+      expect(subscription.toJson(), {
+        'billingCycle': {'start': '2026-01-01', 'end': '2026-02-01'},
+        'creditsLimit': 500,
+        'plan': 'developer',
+      });
+      expect(usage.toJson(), {
+        'api': 11,
+        'archival': 12,
+        'das': 13,
+        'grpc': 14,
+        'grpcGeyser': 15,
+        'photon': 16,
+        'rpc': 17,
+        'stream': 18,
+        'webhook': 19,
+        'websocket': 20,
+      });
+      expect(projectUsage.toJson(), {
+        'creditsRemaining': 400,
+        'creditsUsed': 100,
+        'prepaidCreditsRemaining': 90,
+        'prepaidCreditsUsed': 10,
+        'subscriptionDetails': subscription.toJson(),
+        'usage': usage.toJson(),
+      });
+    });
+  });
+}
+
+Map<String, Object?> projectUsageJson() => {
+  'creditsRemaining': 900,
+  'creditsUsed': 100,
+  'prepaidCreditsRemaining': 50,
+  'prepaidCreditsUsed': 10,
+  'subscriptionDetails': {
+    'billingCycle': {'start': '2026-05-01', 'end': '2026-06-01'},
+    'creditsLimit': 1000,
+    'plan': 'business',
+  },
+  'usage': {
+    'api': 1,
+    'archival': 2,
+    'das': 3,
+    'grpc': 4,
+    'grpcGeyser': 5,
+    'photon': 6,
+    'rpc': 7,
+    'stream': 8,
+    'webhook': 9,
+    'websocket': 10,
+  },
+};

--- a/packages/solana_kit_helius/test/types/rpc_v2_types_test.dart
+++ b/packages/solana_kit_helius/test/types/rpc_v2_types_test.dart
@@ -1,0 +1,184 @@
+import 'package:solana_kit_helius/solana_kit_helius.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RPC v2 pagination types', () {
+    test('program accounts request and response round-trip JSON', () {
+      const request = GetProgramAccountsV2Request(
+        programAddress: 'program-1',
+        filters: [
+          {'memcmp': {'offset': 0, 'bytes': 'abc'}},
+        ],
+        encoding: 'base64',
+        dataSlice: 32,
+        after: 'cursor-1',
+        limit: 10,
+      );
+      final requestJson = request.toJson();
+      final parsedRequest = GetProgramAccountsV2Request.fromJson(requestJson);
+
+      expect(parsedRequest.programAddress, 'program-1');
+      expect(parsedRequest.filters, request.filters);
+      expect(parsedRequest.encoding, 'base64');
+      expect(parsedRequest.dataSlice, 32);
+      expect(parsedRequest.after, 'cursor-1');
+      expect(parsedRequest.limit, 10);
+      expect(parsedRequest.toJson(), requestJson);
+
+      final responseJson = {
+        'accounts': [
+          {
+            'pubkey': 'account-1',
+            'account': {'lamports': 1},
+          },
+        ],
+        'cursor': 'next',
+      };
+      final response = GetProgramAccountsV2Response.fromJson(responseJson);
+
+      expect(response.accounts.single.pubkey, 'account-1');
+      expect(response.accounts.single.account, {'lamports': 1});
+      expect(response.cursor, 'next');
+      expect(response.toJson(), responseJson);
+    });
+
+    test('token account request and response round-trip JSON', () {
+      const request = GetTokenAccountsByOwnerV2Request(
+        ownerAddress: 'owner-1',
+        mint: 'mint-1',
+        programId: 'token-program',
+        encoding: 'jsonParsed',
+        after: 'cursor-1',
+        limit: 25,
+      );
+      final requestJson = request.toJson();
+      final parsedRequest = GetTokenAccountsByOwnerV2Request.fromJson(requestJson);
+
+      expect(parsedRequest.ownerAddress, 'owner-1');
+      expect(parsedRequest.mint, 'mint-1');
+      expect(parsedRequest.programId, 'token-program');
+      expect(parsedRequest.encoding, 'jsonParsed');
+      expect(parsedRequest.after, 'cursor-1');
+      expect(parsedRequest.limit, 25);
+      expect(parsedRequest.toJson(), requestJson);
+
+      final responseJson = {
+        'accounts': [
+          {
+            'pubkey': 'token-account-1',
+            'account': {'mint': 'mint-1'},
+          },
+        ],
+        'cursor': 'next',
+      };
+      final response = GetTokenAccountsByOwnerV2Response.fromJson(responseJson);
+
+      expect(response.accounts.single.pubkey, 'token-account-1');
+      expect(response.accounts.single.account, {'mint': 'mint-1'});
+      expect(response.cursor, 'next');
+      expect(response.toJson(), responseJson);
+    });
+  });
+
+  group('RPC v2 transaction and transfer types', () {
+    test('transaction request and response include optional fields', () {
+      const request = GetTransactionsForAddressRequest(
+        address: 'address-1',
+        before: 'sig-before',
+        until: 'sig-until',
+        limit: 5,
+        commitment: CommitmentLevel.confirmed,
+      );
+      final requestJson = request.toJson();
+      final parsedRequest = GetTransactionsForAddressRequest.fromJson(requestJson);
+
+      expect(parsedRequest.address, 'address-1');
+      expect(parsedRequest.before, 'sig-before');
+      expect(parsedRequest.until, 'sig-until');
+      expect(parsedRequest.limit, 5);
+      expect(parsedRequest.commitment, CommitmentLevel.confirmed);
+      expect(parsedRequest.toJson(), requestJson);
+
+      final responseJson = {
+        'transactions': [
+          {
+            'signature': 'sig-1',
+            'slot': 123,
+            'blockTime': 456,
+            'err': {'InstructionError': [0, 'Custom']},
+            'memo': 'memo text',
+          },
+        ],
+      };
+      final response = GetTransactionsForAddressResponse.fromJson(responseJson);
+
+      expect(response.transactions.single.signature, 'sig-1');
+      expect(response.transactions.single.err, {'InstructionError': [0, 'Custom']});
+      expect(response.toJson(), responseJson);
+    });
+
+    test('transfer request, config, response, and transfer record serialize JSON', () {
+      const config = GetTransfersByAddressConfig(
+        withAddress: 'counterparty',
+        direction: 'inbound',
+        mint: 'mint-1',
+        solMode: 'exclude',
+        filters: {'type': 'transfer'},
+        limit: 50,
+        paginationToken: 'page-1',
+        commitment: CommitmentLevel.finalized,
+        sortOrder: 'asc',
+      );
+      const request = GetTransfersByAddressRequest(address: 'owner-1', config: config);
+      final configJson = {
+        'with': 'counterparty',
+        'direction': 'inbound',
+        'mint': 'mint-1',
+        'solMode': 'exclude',
+        'filters': {'type': 'transfer'},
+        'limit': 50,
+        'paginationToken': 'page-1',
+        'commitment': 'finalized',
+        'sortOrder': 'asc',
+      };
+
+      expect(config.toJson(), configJson);
+      expect(request.toJson(), ['owner-1', configJson]);
+      expect(const GetTransfersByAddressRequest(address: 'owner-1').toJson(), ['owner-1']);
+
+      final transferJson = addressTransferJson();
+      final responseJson = {
+        'data': [transferJson],
+        'paginationToken': 'next-page',
+      };
+      final response = GetTransfersByAddressResponse.fromJson(responseJson);
+
+      expect(response.data.single.signature, 'sig-transfer');
+      expect(response.data.single.fromTokenAccount, 'from-token');
+      expect(response.paginationToken, 'next-page');
+      expect(response.toJson(), responseJson);
+    });
+  });
+}
+
+Map<String, Object?> addressTransferJson() => {
+  'signature': 'sig-transfer',
+  'slot': 42,
+  'blockTime': 1700000000,
+  'type': 'spl',
+  'fromUserAccount': 'from-user',
+  'toUserAccount': 'to-user',
+  'fromTokenAccount': 'from-token',
+  'toTokenAccount': 'to-token',
+  'mint': 'mint-1',
+  'amount': '1000',
+  'feeAmount': '1',
+  'feeAccount': 'fee-account',
+  'decimals': 6,
+  'uiAmount': '0.001',
+  'feeUiAmount': '0.000001',
+  'confirmationStatus': 'finalized',
+  'transactionIdx': 0,
+  'instructionIdx': 1,
+  'innerInstructionIdx': 2,
+};

--- a/packages/solana_kit_helius/test/wallet/get_history_test.dart
+++ b/packages/solana_kit_helius/test/wallet/get_history_test.dart
@@ -73,5 +73,26 @@ void main() {
 
       expect(history, isEmpty);
     });
+
+    test('adds limit query parameter when provided', () async {
+      final client = MockClient((request) async {
+        expect(request.url.queryParameters['limit'], '3');
+        return http.Response(
+          jsonEncode(<Object?>[]),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final helius = createHelius(
+        HeliusConfig(apiKey: 'test-key'),
+        client: client,
+      );
+
+      final history = await helius.wallet.getHistory(
+        const GetHistoryRequest(address: 'wallet-addr', limit: 3),
+      );
+
+      expect(history, isEmpty);
+    });
   });
 }

--- a/packages/solana_kit_helius/test/wallet/get_transfers_test.dart
+++ b/packages/solana_kit_helius/test/wallet/get_transfers_test.dart
@@ -67,5 +67,26 @@ void main() {
 
       expect(transfers, isEmpty);
     });
+
+    test('adds limit query parameter when provided', () async {
+      final client = MockClient((request) async {
+        expect(request.url.queryParameters['limit'], '4');
+        return http.Response(
+          jsonEncode(<Object?>[]),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final helius = createHelius(
+        HeliusConfig(apiKey: 'test-key'),
+        client: client,
+      );
+
+      final transfers = await helius.wallet.getTransfers(
+        const GetTransfersRequest(address: 'wallet-addr', limit: 4),
+      );
+
+      expect(transfers, isEmpty);
+    });
   });
 }

--- a/packages/solana_kit_helius/test/webhooks/toggle_webhook_test.dart
+++ b/packages/solana_kit_helius/test/webhooks/toggle_webhook_test.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:solana_kit_helius/solana_kit_helius.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WebhooksClient.toggleWebhook', () {
+    test('sends PATCH and decodes response', () async {
+      final mockWebhook = {
+        'webhookId': 'wh-1',
+        'wallet': 'wallet-addr',
+        'webhookUrl': 'https://example.com/hook',
+        'transactionTypes': ['TRANSFER'],
+        'accountAddresses': ['addr1'],
+        'webhookType': 'enhanced',
+      };
+      final client = MockClient((request) async {
+        expect(request.method, 'PATCH');
+        expect(request.url.path, '/v0/webhooks/wh-1');
+        expect(request.url.queryParameters['api-key'], 'test-key');
+        expect(jsonDecode(request.body), {'active': false});
+        return http.Response(jsonEncode(mockWebhook), 200);
+      });
+      final helius = createHelius(
+        HeliusConfig(apiKey: 'test-key'),
+        client: client,
+      );
+
+      final webhook = await helius.webhooks.toggleWebhook('wh-1', active: false);
+
+      expect(webhook.webhookId, 'wh-1');
+      expect(webhook.webhookType, WebhookType.enhanced);
+    });
+  });
+}

--- a/packages/solana_kit_helius/test/websockets/helius_websocket_integration_test.dart
+++ b/packages/solana_kit_helius/test/websockets/helius_websocket_integration_test.dart
@@ -31,6 +31,22 @@ _startServer() async {
   return (server, commands, requests);
 }
 
+Future<(HttpServer, List<WebSocket>, List<Object?>)> _startSocketServer() async {
+  final sockets = <WebSocket>[];
+  final requests = <Object?>[];
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+
+  unawaited(() async {
+    await for (final request in server) {
+      final socket = await WebSocketTransformer.upgrade(request);
+      sockets.add(socket);
+      socket.listen(requests.add);
+    }
+  }());
+
+  return (server, sockets, requests);
+}
+
 void main() {
   group('HeliusWebSocket integration', () {
     test('connects, subscribes, confirms, and emits notifications', () async {
@@ -165,6 +181,98 @@ void main() {
         ),
       );
       expect(requests, isNotEmpty);
+    });
+
+    test('connection failures surface as SolanaError', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final url = 'ws://${server.address.address}:${server.port}';
+      await server.close(force: true);
+
+      final ws = HeliusWebSocket(url: url, allowInsecureWs: true);
+
+      await expectLater(
+        ws.connect(),
+        throwsA(
+          isA<SolanaError>().having(
+            (error) => error.code,
+            'code',
+            SolanaErrorCode.heliusWebSocketError,
+          ),
+        ),
+      );
+      expect(ws.isConnected, isFalse);
+    });
+
+    test('non-object JSON payloads surface as SolanaError events', () async {
+      final (server, commands, _) = await _startServer();
+      addTearDown(() async {
+        await commands.close();
+        await server.close(force: true);
+      });
+
+      final ws = HeliusWebSocket(
+        url: 'ws://${server.address.address}:${server.port}',
+        allowInsecureWs: true,
+      );
+      await ws.connect();
+      addTearDown(ws.close);
+
+      final errors = <Object>[];
+      final subscription = ws
+          .subscribe('slotSubscribe')
+          .listen((_) {}, onError: errors.add);
+      addTearDown(subscription.cancel);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      commands.add(jsonEncode([1, 2, 3]));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        errors.single,
+        isA<SolanaError>().having(
+          (error) => error.code,
+          'code',
+          SolanaErrorCode.heliusWebSocketError,
+        ),
+      );
+    });
+
+    test('server close resets state and closes subscription streams', () async {
+      final (server, sockets, requests) = await _startSocketServer();
+      addTearDown(() async {
+        for (final socket in sockets) {
+          await socket.close();
+        }
+        await server.close(force: true);
+      });
+
+      final ws = HeliusWebSocket(
+        url: 'ws://${server.address.address}:${server.port}',
+        allowInsecureWs: true,
+      );
+      await ws.connect();
+
+      final done = Completer<void>();
+      final stream = ws.subscribe('accountSubscribe', ['acct-1']);
+      final subscription = stream.listen((_) {}, onDone: done.complete);
+      addTearDown(subscription.cancel);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(requests, isNotEmpty);
+
+      await sockets.single.close();
+      await done.future.timeout(const Duration(seconds: 1));
+
+      expect(ws.isConnected, isFalse);
+      expect(
+        () => ws.subscribe('accountSubscribe', ['acct-1']),
+        throwsA(
+          isA<SolanaError>().having(
+            (error) => error.code,
+            'code',
+            SolanaErrorCode.heliusWebSocketError,
+          ),
+        ),
+      );
     });
 
     test(

--- a/packages/solana_kit_helius/test/websockets/helius_websocket_test.dart
+++ b/packages/solana_kit_helius/test/websockets/helius_websocket_test.dart
@@ -37,6 +37,21 @@ void main() {
       expect(ws.url, wsUrl);
     });
 
+    test('connect rejects relative URLs', () async {
+      final ws = HeliusWebSocket(url: '/subscriptions');
+
+      await expectLater(
+        ws.connect(),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('must be an absolute URL'),
+          ),
+        ),
+      );
+    });
+
     test('connect rejects insecure ws URLs by default', () async {
       final ws = HeliusWebSocket(url: 'ws://localhost:1234');
 


### PR DESCRIPTION
## Summary
- pin and document the Helius v3.0.0 audit baseline commit because upstream has no v3.0.0 Git tag
- update the Helius mainnet REST host to the upstream v3 host
- add practical v3 parity for Admin project usage, `getTransfersByAddress`, and webhook toggling
- update package wording/docs and add a changeset

## Validation
- `fvm dart analyze packages/solana_kit_helius`
- `fvm dart test packages/solana_kit_helius`
- `docs:check`
- `sync:check`
- `mc step:validate`
- `git diff --check`
