### PR TITLE
test: speed up workspace test runner

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -424,56 +424,7 @@ in
     "test:all" = {
       exec = ''
         set -euo pipefail
-        failed=0
-        for pkg_dir in packages/*/; do
-          if [ ! -d "$pkg_dir/test" ]; then
-            continue
-          fi
-
-          if [ -z "$(find "$pkg_dir/test" -name '*_test.dart' -print -quit)" ]; then
-            continue
-          fi
-
-          # Skip Flutter plugin packages (covered by dedicated checks)
-          if grep -q "flutter:" "$pkg_dir/pubspec.yaml" 2>/dev/null; then
-            continue
-          fi
-
-          pkg_name="$(basename "$pkg_dir")"
-          echo "Testing $pkg_name..."
-          if ! (
-            cd "$pkg_dir"
-            fvm flutter test --exclude-tags integration
-          ); then
-            failed=1
-          fi
-        done
-
-        # Also test generated packages under codama renderers
-        for pkg_dir in packages/codama-renderers-dart/test-generated/; do
-          if [ -d "$pkg_dir/test" ]; then
-            pkg_name="$(basename "$(dirname "$pkg_dir")")/test-generated"
-            echo "Testing $pkg_name..."
-            if ! (
-              cd "$pkg_dir"
-              fvm flutter test
-            ); then
-              failed=1
-            fi
-          fi
-        done
-
-        if [ -d test ]; then
-          echo "Testing root workspace helpers..."
-          if ! fvm flutter test test; then
-            failed=1
-          fi
-        fi
-
-        if [ "$failed" -ne 0 ]; then
-          echo "Some tests failed."
-          exit 1
-        fi
+        dart "$DEVENV_ROOT/scripts/run_workspace_tests.dart" "$@"
       '';
       description = "Run all tests across workspace packages and root doc-comment checks.";
       binary = "bash";

--- a/scripts/run_workspace_tests.dart
+++ b/scripts/run_workspace_tests.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  final root = Directory.current;
+  final testDirectories = <String>[];
+
+  final packagesDirectory = Directory('packages');
+  if (packagesDirectory.existsSync()) {
+    final packageDirectories =
+        packagesDirectory
+            .listSync()
+            .whereType<Directory>()
+            .where(
+              (directory) =>
+                  File('${directory.path}/pubspec.yaml').existsSync(),
+            )
+            .toList()
+          ..sort((left, right) => left.path.compareTo(right.path));
+
+    for (final packageDirectory in packageDirectories) {
+      final testDirectory = Directory('${packageDirectory.path}/test');
+      if (!testDirectory.existsSync() || !_hasDartTests(testDirectory)) {
+        continue;
+      }
+
+      final pubspec = File(
+        '${packageDirectory.path}/pubspec.yaml',
+      ).readAsStringSync();
+      if (pubspec.contains(RegExp(r'^flutter:\s*$', multiLine: true))) {
+        continue;
+      }
+
+      testDirectories.add(testDirectory.path);
+    }
+  }
+
+  final generatedTestDirectory = Directory(
+    'packages/codama-renderers-dart/test-generated/test',
+  );
+  if (generatedTestDirectory.existsSync() &&
+      _hasDartTests(generatedTestDirectory) &&
+      !testDirectories.contains(generatedTestDirectory.path)) {
+    testDirectories.add(generatedTestDirectory.path);
+  }
+
+  final rootTestDirectory = Directory('test');
+  if (rootTestDirectory.existsSync() && _hasDartTests(rootTestDirectory)) {
+    testDirectories.add(rootTestDirectory.path);
+  }
+
+  if (testDirectories.isEmpty) {
+    stderr.writeln('No Dart test directories were found.');
+    exitCode = 1;
+    return;
+  }
+
+  stdout
+    ..writeln(
+      'Running ${testDirectories.length} test directories in one Dart test process.',
+    )
+    ..writeln(
+      'Skipping Flutter plugin packages; they are covered by dedicated checks.',
+    );
+
+  final stopwatch = Stopwatch()..start();
+  final result = await Process.start(
+    'fvm',
+    [
+      'dart',
+      'test',
+      '--exclude-tags',
+      'integration',
+      ...args,
+      ...testDirectories,
+    ],
+    workingDirectory: root.path,
+    mode: ProcessStartMode.inheritStdio,
+  );
+
+  final code = await result.exitCode;
+  stopwatch.stop();
+  stdout.writeln(
+    'Workspace tests finished in ${_formatDuration(stopwatch.elapsed)}.',
+  );
+  exitCode = code;
+}
+
+bool _hasDartTests(Directory directory) {
+  return directory
+      .listSync(recursive: true, followLinks: false)
+      .whereType<File>()
+      .any((file) => file.path.endsWith('_test.dart'));
+}
+
+String _formatDuration(Duration duration) {
+  final minutes = duration.inMinutes;
+  final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+  return '$minutes:${seconds}s';
+}


### PR DESCRIPTION
## Summary
- replace sequential per-package `fvm flutter test` calls with a single workspace-level `fvm dart test` invocation
- add a Dart test runner script that discovers package/root/generated test directories and preserves the integration tag exclusion
- keep Flutter plugin packages skipped, matching the existing dedicated-check behavior

## Results
- `test:all` now runs all 6,385 tests in ~22s locally, down from the reported ~7m baseline
- this is roughly a 95% runtime reduction and comfortably under 1 minute locally

## Validation
- `devenv shell -- bash -lc 'time test:all'` ✅ (~22s, all tests passed)
- `devenv shell -- bash -lc 'fvm dart analyze scripts/run_workspace_tests.dart && git diff --check'` ✅
- `devenv shell -- bash -lc 'docs:check'` ✅
- `devenv shell -- bash -lc 'mc step:validate && git diff --check'` ✅

Note: `sync:check` currently fails in this worktree because the generated command references a missing `scripts/sync-workspace-dependency-versions.sh`; this appears unrelated to these changes.