### PR TITLE
test: further optimize suite runners

### DIFF
--- a/.changeset/optimize-mpl-bubblegum-integration-test.md
+++ b/.changeset/optimize-mpl-bubblegum-integration-test.md
@@ -1,0 +1,7 @@
+---
+"solana_kit_mpl_bubblegum": test
+---
+
+# Optimize compressed NFT integration test polling
+
+Replaced a fixed local airdrop delay with short balance polling so integration tests complete faster while preserving the same assertion.

--- a/devenv.nix
+++ b/devenv.nix
@@ -373,50 +373,7 @@ in
     "test:integration" = {
       exec = ''
         set -euo pipefail
-
-        # Start SurfPool in daemon mode
-        echo "Starting SurfPool..."
-        surfpool start --daemon --ci
-
-        # Wait for SurfPool to be ready
-        echo "Waiting for SurfPool to be ready..."
-        for i in $(seq 1 30); do
-          if curl -s http://localhost:8899 > /dev/null 2>&1; then
-            echo "SurfPool is ready."
-            break
-          fi
-          if [ $i -eq 30 ]; then
-            echo "SurfPool failed to start within 30 seconds."
-            exit 1
-          fi
-          sleep 1
-        done
-
-        # Run integration tests
-        echo "Running integration tests..."
-        failed=0
-        for pkg_dir in packages/*/; do
-          if [ ! -d "$pkg_dir/test/integration" ]; then
-            continue
-          fi
-
-          pkg_name="$(basename "$pkg_dir")"
-          echo "Testing $pkg_name integration..."
-          if ! fvm flutter test --tags integration "$pkg_dir"; then
-            failed=1
-          fi
-        done
-
-        # Stop SurfPool
-        echo "Stopping SurfPool..."
-        surfpool stop 2>/dev/null || true
-
-        if [ "$failed" -ne 0 ]; then
-          echo "Some integration tests failed."
-          exit 1
-        fi
-
-        echo "All integration tests passed."
+        dart "$DEVENV_ROOT/scripts/run_integration_tests.dart" "$@"
       '';
       description = "Run all integration tests against SurfPool local validator.";
       binary = "bash";
@@ -440,21 +397,7 @@ in
     "test:coverage" = {
       exec = ''
         set -euo pipefail
-
-        mapfile -t test_dirs < <(
-          find packages -mindepth 2 -maxdepth 2 -type d -name test \
-            | grep -v '^packages/solana_kit_mobile_wallet_adapter/test$' \
-            | sort
-        )
-
-        if [ ''${#test_dirs[@]} -eq 0 ]; then
-          echo "No package test directories were found."
-          exit 1
-        fi
-
-        echo "Running coverage for ''${#test_dirs[@]} package test directories..."
-        echo "Skipping packages/solana_kit_mobile_wallet_adapter/test (requires flutter test)."
-        dart run coverage:test_with_coverage -- --exclude-tags integration "''${test_dirs[@]}"
+        dart "$DEVENV_ROOT/scripts/run_workspace_coverage.dart" "$@"
       '';
       description = "Generate merged LCOV coverage for all packages.";
       binary = "bash";

--- a/packages/solana_kit_mpl_bubblegum/test/integration/on_chain_compressed_nft_test.dart
+++ b/packages/solana_kit_mpl_bubblegum/test/integration/on_chain_compressed_nft_test.dart
@@ -59,12 +59,20 @@ void main() {
           )
           .send();
 
-      // Wait for airdrop
-      await Future<void>.delayed(const Duration(seconds: 5));
+      // SurfPool usually applies local airdrops immediately. Poll briefly
+      // instead of always sleeping for a fixed five seconds.
+      var balance = await rpc.getBalanceValue(payer!.address).send();
+      for (
+        var attempt = 0;
+        balance.value.value == BigInt.zero && attempt < 20;
+        attempt += 1
+      ) {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        balance = await rpc.getBalanceValue(payer!.address).send();
+      }
 
-      final balance = await rpc.getBalanceValue(payer!.address).send();
-      print('Balance: ${balance.value} lamports');
-      expect(balance.value, greaterThan(BigInt.zero));
+      print('Balance: ${balance.value.value} lamports');
+      expect(balance.value.value, greaterThan(BigInt.zero));
     });
 
     test('create tree instruction can be built', () {

--- a/scripts/run_integration_tests.dart
+++ b/scripts/run_integration_tests.dart
@@ -1,0 +1,193 @@
+import 'dart:async';
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  await _ensurePackageConfig();
+
+  final testDirectories = _discoverIntegrationTestDirectories();
+  if (testDirectories.isEmpty) {
+    stderr.writeln('No integration test directories were found.');
+    exitCode = 1;
+    return;
+  }
+
+  Process? surfpool;
+  var startedSurfpool = false;
+  final stopwatch = Stopwatch()..start();
+
+  try {
+    if (!await _isSurfpoolReady()) {
+      stdout.writeln('Starting SurfPool...');
+      surfpool = await _startSurfpool();
+      startedSurfpool = true;
+      await _waitForSurfpool();
+    } else {
+      stdout.writeln('Using existing SurfPool on localhost:8899.');
+    }
+
+    final testArgs = _withDefaultTestArgs(args);
+    stdout.writeln(
+      'Running ${testDirectories.length} integration test directories.',
+    );
+    final result = await Process.start(
+      'fvm',
+      [
+        'dart',
+        'test',
+        '--tags',
+        'integration',
+        ...testArgs,
+        ...testDirectories,
+      ],
+      mode: ProcessStartMode.inheritStdio,
+    );
+
+    exitCode = await result.exitCode;
+  } finally {
+    if (startedSurfpool) {
+      stdout.writeln('Stopping SurfPool...');
+      surfpool?.kill();
+      await surfpool?.exitCode.timeout(
+        const Duration(seconds: 5),
+        onTimeout: () {
+          surfpool?.kill(ProcessSignal.sigkill);
+          return -1;
+        },
+      );
+      await Process.run('surfpool', ['stop']);
+    }
+
+    stopwatch.stop();
+    stdout.writeln(
+      'Integration tests finished in ${_formatDuration(stopwatch.elapsed)}.',
+    );
+  }
+}
+
+List<String> _discoverIntegrationTestDirectories() {
+  final packagesDirectory = Directory('packages');
+  if (!packagesDirectory.existsSync()) {
+    return const [];
+  }
+
+  final testDirectories = <String>[];
+  final packageDirectories =
+      packagesDirectory
+          .listSync()
+          .whereType<Directory>()
+          .where(
+            (directory) => File('${directory.path}/pubspec.yaml').existsSync(),
+          )
+          .toList()
+        ..sort((left, right) => left.path.compareTo(right.path));
+
+  for (final packageDirectory in packageDirectories) {
+    final integrationDirectory = Directory(
+      '${packageDirectory.path}/test/integration',
+    );
+    if (!integrationDirectory.existsSync() ||
+        !_hasDartTests(integrationDirectory)) {
+      continue;
+    }
+    testDirectories.add(integrationDirectory.path);
+  }
+
+  return testDirectories;
+}
+
+List<String> _withDefaultTestArgs(List<String> args) {
+  return [
+    if (!_hasOption(args, 'reporter')) ...['--reporter', 'compact'],
+    if (!_hasConcurrencyOption(args)) ...['-j', '4'],
+    ...args,
+  ];
+}
+
+bool _hasOption(List<String> args, String option) {
+  return args.any((arg) => arg == '--$option' || arg.startsWith('--$option='));
+}
+
+bool _hasConcurrencyOption(List<String> args) {
+  return args.any(
+    (arg) =>
+        arg == '-j' ||
+        arg == '--concurrency' ||
+        arg.startsWith('--concurrency='),
+  );
+}
+
+bool _hasDartTests(Directory directory) {
+  return directory
+      .listSync(recursive: true, followLinks: false)
+      .whereType<File>()
+      .any((file) => file.path.endsWith('_test.dart'));
+}
+
+Future<Process> _startSurfpool() async {
+  final args = Platform.isLinux
+      ? ['start', '--daemon', '--ci']
+      : ['start', '--ci', '--no-tui'];
+
+  final process = await Process.start('surfpool', args);
+  if (!Platform.isLinux) {
+    process.stdout.listen(stdout.add);
+    process.stderr.listen(stderr.add);
+  } else {
+    unawaited(process.stdout.drain<void>());
+    unawaited(process.stderr.drain<void>());
+  }
+  return process;
+}
+
+Future<void> _waitForSurfpool() async {
+  for (var attempt = 1; attempt <= 30; attempt += 1) {
+    if (await _isSurfpoolReady()) {
+      stdout.writeln('SurfPool is ready.');
+      return;
+    }
+    await Future<void>.delayed(const Duration(seconds: 1));
+  }
+  throw StateError('SurfPool failed to start within 30 seconds.');
+}
+
+Future<bool> _isSurfpoolReady() async {
+  final client = HttpClient()..connectionTimeout = const Duration(seconds: 1);
+  try {
+    final request = await client.postUrl(Uri.parse('http://localhost:8899'));
+    request.headers.contentType = ContentType.json;
+    request.write('{"jsonrpc":"2.0","id":1,"method":"getHealth"}');
+    final response = await request.close().timeout(const Duration(seconds: 1));
+    await response.drain<void>();
+    return response.statusCode >= 200 && response.statusCode < 500;
+  } on Object {
+    return false;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<void> _ensurePackageConfig() async {
+  if (File('.dart_tool/package_config.json').existsSync()) {
+    return;
+  }
+
+  stdout.writeln(
+    'Resolving workspace dependencies with `fvm flutter pub get`...',
+  );
+  final result = await Process.start(
+    'fvm',
+    ['flutter', 'pub', 'get'],
+    mode: ProcessStartMode.inheritStdio,
+  );
+  final code = await result.exitCode;
+  if (code != 0) {
+    exitCode = code;
+    throw const ProcessException('fvm', ['flutter', 'pub', 'get']);
+  }
+}
+
+String _formatDuration(Duration duration) {
+  final minutes = duration.inMinutes;
+  final seconds = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+  return '$minutes:${seconds}s';
+}

--- a/scripts/run_workspace_coverage.dart
+++ b/scripts/run_workspace_coverage.dart
@@ -3,89 +3,77 @@ import 'dart:io';
 Future<void> main(List<String> args) async {
   await _ensurePackageConfig();
 
-  final root = Directory.current;
-  final testDirectories = <String>[];
-
-  final packagesDirectory = Directory('packages');
-  if (packagesDirectory.existsSync()) {
-    final packageDirectories =
-        packagesDirectory
-            .listSync()
-            .whereType<Directory>()
-            .where(
-              (directory) =>
-                  File('${directory.path}/pubspec.yaml').existsSync(),
-            )
-            .toList()
-          ..sort((left, right) => left.path.compareTo(right.path));
-
-    for (final packageDirectory in packageDirectories) {
-      final testDirectory = Directory('${packageDirectory.path}/test');
-      if (!testDirectory.existsSync() || !_hasDartTests(testDirectory)) {
-        continue;
-      }
-
-      final pubspec = File(
-        '${packageDirectory.path}/pubspec.yaml',
-      ).readAsStringSync();
-      if (pubspec.contains(RegExp(r'^flutter:\s*$', multiLine: true))) {
-        continue;
-      }
-
-      testDirectories.add(testDirectory.path);
-    }
-  }
-
-  final generatedTestDirectory = Directory(
-    'packages/codama-renderers-dart/test-generated/test',
-  );
-  if (generatedTestDirectory.existsSync() &&
-      _hasDartTests(generatedTestDirectory) &&
-      !testDirectories.contains(generatedTestDirectory.path)) {
-    testDirectories.add(generatedTestDirectory.path);
-  }
-
-  final rootTestDirectory = Directory('test');
-  if (rootTestDirectory.existsSync() && _hasDartTests(rootTestDirectory)) {
-    testDirectories.add(rootTestDirectory.path);
-  }
-
+  final testDirectories = _discoverPackageTestDirectories();
   if (testDirectories.isEmpty) {
-    stderr.writeln('No Dart test directories were found.');
+    stderr.writeln('No package test directories were found.');
     exitCode = 1;
     return;
   }
 
+  final testArgs = _withDefaultTestArgs(args);
+
   stdout
     ..writeln(
-      'Running ${testDirectories.length} test directories in one Dart test process.',
+      'Running coverage for ${testDirectories.length} package test directories.',
     )
     ..writeln(
       'Skipping Flutter plugin packages; they are covered by dedicated checks.',
     );
 
-  final testArgs = _withDefaultTestArgs(args);
   final stopwatch = Stopwatch()..start();
   final result = await Process.start(
-    'fvm',
+    'dart',
     [
-      'dart',
-      'test',
+      'run',
+      'coverage:test_with_coverage',
+      '--',
       '--exclude-tags',
       'integration',
       ...testArgs,
       ...testDirectories,
     ],
-    workingDirectory: root.path,
     mode: ProcessStartMode.inheritStdio,
   );
 
   final code = await result.exitCode;
   stopwatch.stop();
   stdout.writeln(
-    'Workspace tests finished in ${_formatDuration(stopwatch.elapsed)}.',
+    'Workspace coverage finished in ${_formatDuration(stopwatch.elapsed)}.',
   );
   exitCode = code;
+}
+
+List<String> _discoverPackageTestDirectories() {
+  final packagesDirectory = Directory('packages');
+  if (!packagesDirectory.existsSync()) {
+    return const [];
+  }
+
+  final testDirectories = <String>[];
+  final packageDirectories =
+      packagesDirectory
+          .listSync()
+          .whereType<Directory>()
+          .where(
+            (directory) => File('${directory.path}/pubspec.yaml').existsSync(),
+          )
+          .toList()
+        ..sort((left, right) => left.path.compareTo(right.path));
+
+  for (final packageDirectory in packageDirectories) {
+    final testDirectory = Directory('${packageDirectory.path}/test');
+    if (!testDirectory.existsSync() || !_hasDartTests(testDirectory)) {
+      continue;
+    }
+
+    if (_isFlutterPackage(packageDirectory)) {
+      continue;
+    }
+
+    testDirectories.add(testDirectory.path);
+  }
+
+  return testDirectories;
 }
 
 List<String> _withDefaultTestArgs(List<String> args) {
@@ -118,6 +106,13 @@ int _defaultConcurrency() {
     return 1;
   }
   return processors > 12 ? 12 : processors;
+}
+
+bool _isFlutterPackage(Directory packageDirectory) {
+  final pubspec = File(
+    '${packageDirectory.path}/pubspec.yaml',
+  ).readAsStringSync();
+  return pubspec.contains(RegExp(r'^flutter:\s*$', multiLine: true));
 }
 
 bool _hasDartTests(Directory directory) {


### PR DESCRIPTION
## Summary
- default `test:all` to compact reporting and capped high concurrency (`-j 12` on larger machines)
- move `test:coverage` discovery into a Dart runner and use the same compact/concurrency defaults
- move `test:integration` into a Dart runner that runs integration directories in one Dart test process and supports non-Linux foreground SurfPool startup
- replace the fixed 5s compressed NFT integration wait with short polling
- make Dart runners resolve workspace deps with `fvm flutter pub get` if `.dart_tool/package_config.json` is missing

## Findings
- `test:coverage` was already using a single `coverage:test_with_coverage` process, so it was mostly optimized already. The remaining win is better test-runner defaults and less log volume.
- The largest remaining integration win was eliminating fixed sleeps and avoiding per-package Flutter test startup.

## Local timings
- `test:all`: ~12s locally, down from the prior ~20-22s optimized runner
- `test:coverage`: ~18s locally; already single-process, little headroom left locally
- `test:integration`: ~4s locally, down from the prior script hanging on macOS and from CI’s previous ~2m48s job baseline

## Validation
- `fvm dart analyze packages/solana_kit_mpl_bubblegum/test/integration/on_chain_compressed_nft_test.dart scripts/run_workspace_tests.dart scripts/run_workspace_coverage.dart scripts/run_integration_tests.dart` ✅
- `test:all` ✅
- `test:coverage` ✅
- `test:integration` ✅
- `docs:check` ✅
- `mc step:validate` ✅
- `git diff --check` ✅

Note: `sync:check` still fails because the generated command references missing `scripts/sync-workspace-dependency-versions.sh`; this is unchanged and unrelated to these test runner changes.