### PR TITLE
chore: harden security audit findings

### DIFF
--- a/.changeset/harden-security-audit-findings.md
+++ b/.changeset/harden-security-audit-findings.md
@@ -1,0 +1,8 @@
+---
+"solana_kit_helius": patch
+"solana_kit_mobile_wallet_adapter_protocol": patch
+---
+
+# Harden security audit findings
+
+Disable placeholder Helius auth signing, redact Helius API keys from JSON-RPC error context, validate malformed encrypted mobile-wallet messages before slicing, and reject negative mobile-wallet sequence numbers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   docs-site:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -35,9 +35,12 @@ jobs:
         uses: actions/configure-pages@v6
       - name: Resolve docs base path
         id: base
+        env:
+          INPUT_BASE_PATH: ${{ inputs.base_path }}
+          CONFIGURED_BASE_PATH: ${{ steps.pages.outputs.base_path }}
         run: |
-          input_base='${{ inputs.base_path }}'
-          configured_base='${{ steps.pages.outputs.base_path }}'
+          input_base="$INPUT_BASE_PATH"
+          configured_base="$CONFIGURED_BASE_PATH"
 
           if [[ -n "$input_base" ]]; then
             base_path="$input_base"

--- a/packages/solana_kit_helius/lib/src/auth/sign_auth_message.dart
+++ b/packages/solana_kit_helius/lib/src/auth/sign_auth_message.dart
@@ -1,20 +1,15 @@
-import 'dart:convert';
-import 'dart:typed_data';
-
 import 'package:solana_kit_helius/src/types/auth_types.dart';
 
 /// Signs an authentication message with the given secret key.
 ///
-/// In a full implementation, this would use Ed25519 signing with the secret
-/// key from [SignAuthMessageRequest.secretKey]. For now, returns a
-/// base64-encoded representation of the message bytes as a placeholder.
+/// This helper intentionally throws until a real Ed25519 implementation is
+/// wired in. Returning placeholder bytes would be forgeable and unsafe for
+/// downstream authentication flows.
 Future<SignAuthMessageResponse> authSignAuthMessage(
-  SignAuthMessageRequest request,
+  SignAuthMessageRequest _,
 ) async {
-  // In a full implementation, this would use Ed25519 signing.
-  // For now, return a base64 encoding of the message bytes as a placeholder.
-  final messageBytes = utf8.encode(request.message);
-  return SignAuthMessageResponse(
-    signature: base64Encode(Uint8List.fromList(messageBytes)),
+  throw UnsupportedError(
+    'authSignAuthMessage is not implemented; use wallet-based signing or '
+    'provide a verified Ed25519 implementation before using Helius auth.',
   );
 }

--- a/packages/solana_kit_helius/lib/src/internal/json_rpc_client.dart
+++ b/packages/solana_kit_helius/lib/src/internal/json_rpc_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_helius/src/internal/redact_url.dart';
 
 /// Internal JSON-RPC 2.0 caller for Helius RPC endpoints.
 ///
@@ -44,7 +45,7 @@ class JsonRpcClient {
           SolanaErrorContextKeys.methodName: method,
           SolanaErrorContextKeys.operation: 'heliusJsonRpc',
           SolanaErrorContextKeys.statusCode: response.statusCode,
-          SolanaErrorContextKeys.url: url,
+          SolanaErrorContextKeys.url: redactUrl(url),
           'message':
               'HTTP ${response.statusCode}: ${response.reasonPhrase ?? 'Unknown error'}',
         },
@@ -60,7 +61,7 @@ class JsonRpcClient {
         context: {
           SolanaErrorContextKeys.methodName: method,
           SolanaErrorContextKeys.operation: 'heliusJsonRpc',
-          SolanaErrorContextKeys.url: url,
+          SolanaErrorContextKeys.url: redactUrl(url),
           'message': error['message'] ?? 'Unknown RPC error',
         },
       );

--- a/packages/solana_kit_helius/lib/src/internal/redact_url.dart
+++ b/packages/solana_kit_helius/lib/src/internal/redact_url.dart
@@ -1,0 +1,15 @@
+/// Returns [url] with sensitive query parameter values redacted.
+String redactUrl(String url) {
+  final uri = Uri.tryParse(url);
+  if (uri == null || !uri.hasQuery) return url;
+
+  final redactedKeys = {'api-key', 'apikey', 'api_key', 'key', 'token'};
+  final query = <String, String>{};
+  for (final entry in uri.queryParameters.entries) {
+    query[entry.key] = redactedKeys.contains(entry.key.toLowerCase())
+        ? '[REDACTED]'
+        : entry.value;
+  }
+
+  return uri.replace(queryParameters: query).toString();
+}

--- a/packages/solana_kit_helius/test/auth/sign_auth_message_test.dart
+++ b/packages/solana_kit_helius/test/auth/sign_auth_message_test.dart
@@ -3,38 +3,21 @@ import 'package:test/test.dart';
 
 void main() {
   group('AuthClient.signAuthMessage', () {
-    test('returns a non-empty signature', () async {
-      final helius = createHelius(HeliusConfig(apiKey: 'test'));
-      final result = await helius.auth.signAuthMessage(
-        const SignAuthMessageRequest(
-          message: 'hello',
-          secretKey: 'secret-key-base64',
-        ),
-      );
-      expect(result.signature, isNotEmpty);
-    });
+    test(
+      'throws instead of returning a forgeable placeholder signature',
+      () async {
+        final helius = createHelius(HeliusConfig(apiKey: 'test'));
 
-    test('signature is a base64-encoded string', () async {
-      final helius = createHelius(HeliusConfig(apiKey: 'test'));
-      final result = await helius.auth.signAuthMessage(
-        const SignAuthMessageRequest(
-          message: 'test-message',
-          secretKey: 'secret-key',
-        ),
-      );
-      // Base64 strings contain only valid base64 characters.
-      expect(result.signature, matches(RegExp(r'^[A-Za-z0-9+/]+=*$')));
-    });
-
-    test('different messages produce different signatures', () async {
-      final helius = createHelius(HeliusConfig(apiKey: 'test'));
-      final result1 = await helius.auth.signAuthMessage(
-        const SignAuthMessageRequest(message: 'message-a', secretKey: 'key'),
-      );
-      final result2 = await helius.auth.signAuthMessage(
-        const SignAuthMessageRequest(message: 'message-b', secretKey: 'key'),
-      );
-      expect(result1.signature, isNot(result2.signature));
-    });
+        await expectLater(
+          helius.auth.signAuthMessage(
+            const SignAuthMessageRequest(
+              message: 'hello',
+              secretKey: 'secret-key-base64',
+            ),
+          ),
+          throwsA(isA<UnsupportedError>()),
+        );
+      },
+    );
   });
 }

--- a/packages/solana_kit_helius/test/internal/json_rpc_client_contract_test.dart
+++ b/packages/solana_kit_helius/test/internal/json_rpc_client_contract_test.dart
@@ -124,7 +124,7 @@ void main() {
               .having(
                 (error) => error.context[SolanaErrorContextKeys.url],
                 'url',
-                'https://mainnet.helius-rpc.com/?api-key=test-key',
+                'https://mainnet.helius-rpc.com/?api-key=%5BREDACTED%5D',
               )
               .having(
                 (error) => error.context['message'],

--- a/packages/solana_kit_helius/test/internal/redact_url_test.dart
+++ b/packages/solana_kit_helius/test/internal/redact_url_test.dart
@@ -1,0 +1,21 @@
+import 'package:solana_kit_helius/src/internal/redact_url.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('redactUrl', () {
+    test('redacts sensitive query parameters and keeps safe parameters', () {
+      expect(
+        redactUrl('https://example.com/rpc?api-key=secret&cluster=mainnet'),
+        'https://example.com/rpc?api-key=%5BREDACTED%5D&cluster=mainnet',
+      );
+    });
+
+    test('returns URLs without query parameters unchanged', () {
+      expect(redactUrl('https://example.com/rpc'), 'https://example.com/rpc');
+    });
+
+    test('returns unparsable strings unchanged', () {
+      expect(redactUrl('http://[::1'), 'http://[::1');
+    });
+  });
+}

--- a/packages/solana_kit_mobile_wallet_adapter_protocol/lib/src/encrypted_message.dart
+++ b/packages/solana_kit_mobile_wallet_adapter_protocol/lib/src/encrypted_message.dart
@@ -26,8 +26,9 @@ class DecryptedMessage {
 ///
 /// Wire format: `[4B seq big-endian][12B random IV][ciphertext + 16B GCM tag]`
 ///
-/// The sequence number is used as Additional Authenticated Data (AAD) to
-/// prevent replay attacks.
+/// The sequence number is used as Additional Authenticated Data (AAD) so it
+/// cannot be tampered with. Callers must still enforce monotonic sequence
+/// numbers per session to reject replayed ciphertexts.
 Uint8List encryptMessage(
   String plaintext,
   int sequenceNumber,
@@ -64,6 +65,12 @@ Uint8List encryptMessage(
 ///
 /// Returns the decrypted plaintext and the extracted sequence number.
 DecryptedMessage decryptMessage(Uint8List message, Uint8List sharedSecret) {
+  const minimumMessageLength =
+      mwaSequenceNumberBytes + mwaIvBytes + (mwaGcmTagBits ~/ 8);
+  if (message.length < minimumMessageLength) {
+    throw SolanaError(SolanaErrorCode.mwaDecryptionFailed);
+  }
+
   // Extract components from wire format.
   final sequenceNumberVector = message.sublist(0, mwaSequenceNumberBytes);
   final iv = message.sublist(

--- a/packages/solana_kit_mobile_wallet_adapter_protocol/lib/src/sequence_number.dart
+++ b/packages/solana_kit_mobile_wallet_adapter_protocol/lib/src/sequence_number.dart
@@ -8,9 +8,10 @@ import 'package:solana_kit_mobile_wallet_adapter_protocol/src/constants.dart';
 /// as additional authenticated data (AAD) in AES-GCM encryption.
 ///
 /// Throws a [SolanaError] with code
-/// [SolanaErrorCode.mwaSequenceNumberOverflow] if [sequenceNumber] is >= 2^32.
+/// [SolanaErrorCode.mwaSequenceNumberOverflow] if [sequenceNumber] is outside
+/// the unsigned 32-bit range.
 Uint8List createSequenceNumberVector(int sequenceNumber) {
-  if (sequenceNumber >= mwaMaxSequenceNumber) {
+  if (sequenceNumber < 0 || sequenceNumber >= mwaMaxSequenceNumber) {
     throw SolanaError(SolanaErrorCode.mwaSequenceNumberOverflow, {
       'sequenceNumber': sequenceNumber,
     });

--- a/packages/solana_kit_mobile_wallet_adapter_protocol/test/crypto_test.dart
+++ b/packages/solana_kit_mobile_wallet_adapter_protocol/test/crypto_test.dart
@@ -258,6 +258,19 @@ void main() {
       expect(encrypted1, isNot(equals(encrypted2)));
     });
 
+    test('malformed ciphertext fails decryption without range errors', () {
+      expect(
+        () => decryptMessage(Uint8List(3), sharedSecret),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.mwaDecryptionFailed,
+          ),
+        ),
+      );
+    });
+
     test('tampered ciphertext fails decryption', () {
       final encrypted = encryptMessage('test', 0, sharedSecret);
 

--- a/packages/solana_kit_mobile_wallet_adapter_protocol/test/validation_test.dart
+++ b/packages/solana_kit_mobile_wallet_adapter_protocol/test/validation_test.dart
@@ -115,6 +115,19 @@ void main() {
       expect(vector, [255, 255, 255, 255]);
     });
 
+    test('throws on negative sequence numbers', () {
+      expect(
+        () => createSequenceNumberVector(-1),
+        throwsA(
+          isA<SolanaError>().having(
+            (e) => e.code,
+            'code',
+            SolanaErrorCode.mwaSequenceNumberOverflow,
+          ),
+        ),
+      );
+    });
+
     test('throws on overflow at 2^32', () {
       expect(
         () => createSequenceNumberVector(4294967296),


### PR DESCRIPTION
## Summary
- restrict the Claude workflow trigger to repository collaborators and add default read-only CI permissions
- avoid direct workflow-command interpolation of the docs Pages base-path input
- disable placeholder Helius auth-message signing and redact Helius API keys from JSON-RPC error context
- harden Mobile Wallet Adapter encrypted-message and sequence-number validation

## Validation
- fvm dart analyze packages/solana_kit_helius packages/solana_kit_mobile_wallet_adapter_protocol
- fvm dart test packages/solana_kit_helius packages/solana_kit_mobile_wallet_adapter_protocol --exclude-tags integration --reporter compact
- test:all
- docs:check
- mc step:validate
- git diff --check

Note: sync:check still fails locally because the generated task references missing scripts/sync-workspace-dependency-versions.sh.