### PR TITLE
feat: add compute budget message helpers

### DIFF
--- a/.changeset/add-compute-budget-message-helpers.md
+++ b/.changeset/add-compute-budget-message-helpers.md
@@ -1,0 +1,7 @@
+---
+"solana_kit_compute_budget": minor
+---
+
+# Add Compute Budget message helpers
+
+Add transaction-message helper APIs for Compute Budget instructions, including introspection and update-or-append helpers for compute unit limits and prices.

--- a/docs/agents/upstream-api-gap-audit-2026-06-02.md
+++ b/docs/agents/upstream-api-gap-audit-2026-06-02.md
@@ -1,0 +1,69 @@
+# Upstream API gap audit — 2026-06-02
+
+Scope: all packages in this workspace compared with configured upstream references under `.repos/`, excluding `solana_kit_helius` because PR #183 is already covering that package.
+
+## Production TODO / unimplemented markers
+
+No production `lib/` APIs currently throw `UnimplementedError` or contain active `TODO` / `FIXME` implementation markers. Matches are limited to tests, docs describing previously fixed work, lint configuration, or defensive error handling.
+
+## High-priority gaps
+
+### Compute Budget helper layer
+
+Upstream `solana-program/compute-budget` includes non-generated helper APIs in `clients/js/src/introspect.ts`, `setComputeLimit.ts`, `setComputePrice.ts`, and estimation helpers.
+
+Implemented in this branch:
+
+- `findSetComputeUnitLimitInstructionIndexAndUnits`
+- `findSetComputeUnitPriceInstructionIndexAndMicroLamports`
+- `fillProvisorySetComputeUnitLimitInstruction`
+- `setTransactionMessageComputeUnitPrice`
+- `updateOrAppendSetComputeUnitLimitInstruction`
+- `updateOrAppendSetComputeUnitPriceInstruction`
+
+Remaining:
+
+- RPC-backed `estimateComputeUnitLimitFactory` equivalent.
+- RPC-backed `estimateAndSetComputeUnitLimit` equivalent.
+
+These require choosing or adding a stable simulation/RPC abstraction in Dart.
+
+### Core transaction/signing APIs
+
+Against `anza-xyz/kit`, notable missing or partial areas remain:
+
+- Transaction message v0/v1/legacy codec/decompile parity beyond the currently exposed Dart shape.
+- Resource/priority-fee helpers that compose compute-budget estimation with transaction messages.
+- Signer helpers: grinding keypair signers, off-chain-message signing, keypair persistence helpers.
+- Instruction plan error helpers analogous to upstream transaction-plan errors.
+
+### SPL Account Compression
+
+`solana_kit_spl_account_compression` is generated-instruction focused. Upstream/reference surfaces include higher-level account/type/event APIs such as concurrent Merkle tree account helpers, tree header/path/canopy types, and compression events.
+
+### Token / Token-2022 handwritten helpers
+
+Generated instruction parity is good. Remaining work is mostly handwritten helper/plugin parity such as higher-level token client extension APIs and verifying UI amount helpers.
+
+## Program package notes
+
+Generated program-package file parity is mostly complete for:
+
+- system
+- token
+- token-2022
+- address lookup table
+- memo
+- compute budget generated instructions
+- stake
+- config
+
+False positives from simple file matching include Dart renames/combined files (`loader_v3.dart`, `loader_v4.dart`, `stake_account.dart`, `config_account.dart`) and package-specific compatibility aliases.
+
+## Suggested implementation order
+
+1. Finish Compute Budget helpers that do not need RPC abstractions. ✅ started in this branch.
+2. Add RPC-backed compute estimation once the simulation abstraction is confirmed.
+3. Add signer helper gaps.
+4. Expand SPL Account Compression account/event helpers.
+5. Add higher-level token client helper parity.

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -96,7 +96,7 @@ solana_kit_codecs_core -> solana_kit_errors
 solana_kit_codecs_data_structures -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
 solana_kit_codecs_numbers -> solana_kit_codecs_core, solana_kit_errors
 solana_kit_codecs_strings -> solana_kit_codecs_core, solana_kit_codecs_numbers, solana_kit_errors
-solana_kit_compute_budget -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
+solana_kit_compute_budget -> solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions, solana_kit_transaction_messages
 solana_kit_config -> solana_kit_accounts, solana_kit_addresses, solana_kit_codecs_core, solana_kit_codecs_data_structures, solana_kit_codecs_numbers, solana_kit_instructions
 solana_kit_errors -> (none)
 solana_kit_fast_stable_stringify -> (none)

--- a/packages/solana_kit_compute_budget/lib/solana_kit_compute_budget.dart
+++ b/packages/solana_kit_compute_budget/lib/solana_kit_compute_budget.dart
@@ -20,3 +20,4 @@
 library;
 
 export 'src/generated/compute_budget.dart';
+export 'src/message_helpers.dart';

--- a/packages/solana_kit_compute_budget/lib/src/message_helpers.dart
+++ b/packages/solana_kit_compute_budget/lib/src/message_helpers.dart
@@ -1,0 +1,176 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_compute_budget/src/generated/instructions/set_compute_unit_limit.dart';
+import 'package:solana_kit_compute_budget/src/generated/instructions/set_compute_unit_price.dart';
+import 'package:solana_kit_compute_budget/src/generated/programs/compute_budget.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart';
+
+/// A provisional compute unit limit used before estimation.
+const provisoryComputeUnitLimit = 0;
+
+/// The maximum compute unit limit accepted by the Compute Budget program.
+const maxComputeUnitLimit = 1400000;
+
+/// The index and units for a `SetComputeUnitLimit` instruction.
+typedef SetComputeUnitLimitInstructionDetails = ({int index, int units});
+
+/// The index and micro-lamports for a `SetComputeUnitPrice` instruction.
+typedef SetComputeUnitPriceInstructionDetails = ({
+  int index,
+  BigInt microLamports,
+});
+
+/// A function that updates a compute unit limit from its previous value.
+typedef ComputeUnitLimitUpdater = int Function(int? previousUnits);
+
+/// A function that updates a compute unit price from its previous value.
+typedef ComputeUnitPriceUpdater =
+    BigInt Function(BigInt? previousMicroLamports);
+
+/// Finds the first `SetComputeUnitLimit` instruction and its units.
+SetComputeUnitLimitInstructionDetails?
+findSetComputeUnitLimitInstructionIndexAndUnits(
+  TransactionMessage transactionMessage,
+) {
+  final index = transactionMessage.instructions.indexWhere(
+    _isSetComputeUnitLimitInstruction,
+  );
+  if (index < 0) return null;
+
+  final data = transactionMessage.instructions[index].data!;
+  return (
+    index: index,
+    units: ByteData.sublistView(data).getUint32(1, Endian.little),
+  );
+}
+
+/// Finds the first `SetComputeUnitPrice` instruction and its micro-lamports.
+SetComputeUnitPriceInstructionDetails?
+findSetComputeUnitPriceInstructionIndexAndMicroLamports(
+  TransactionMessage transactionMessage,
+) {
+  final index = transactionMessage.instructions.indexWhere(
+    _isSetComputeUnitPriceInstruction,
+  );
+  if (index < 0) return null;
+
+  final data = transactionMessage.instructions[index].data!;
+  return (
+    index: index,
+    microLamports: BigInt.from(
+      ByteData.sublistView(data).getUint64(1, Endian.little),
+    ),
+  );
+}
+
+/// Appends a provisory `SetComputeUnitLimit` instruction when none exists.
+TransactionMessage fillProvisorySetComputeUnitLimitInstruction(
+  TransactionMessage transactionMessage,
+) {
+  return updateOrAppendSetComputeUnitLimitInstruction(
+    (int? previousUnits) => previousUnits ?? provisoryComputeUnitLimit,
+    transactionMessage,
+  );
+}
+
+/// Sets the compute unit price by appending a `SetComputeUnitPrice` instruction.
+TransactionMessage setTransactionMessageComputeUnitPrice(
+  BigInt microLamports,
+  TransactionMessage transactionMessage,
+) {
+  return appendTransactionMessageInstruction(
+    getSetComputeUnitPriceInstruction(microLamports: microLamports),
+    transactionMessage,
+  );
+}
+
+/// Updates the first `SetComputeUnitLimit` instruction, or appends one.
+TransactionMessage updateOrAppendSetComputeUnitLimitInstruction(
+  Object units,
+  TransactionMessage transactionMessage,
+) {
+  final details = findSetComputeUnitLimitInstructionIndexAndUnits(
+    transactionMessage,
+  );
+  final previousUnits = details?.units;
+  final newUnits = units is int
+      ? units
+      : (units as int Function(int?))(previousUnits);
+
+  if (details == null) {
+    return appendTransactionMessageInstruction(
+      getSetComputeUnitLimitInstruction(units: newUnits),
+      transactionMessage,
+    );
+  }
+
+  if (newUnits == previousUnits) return transactionMessage;
+  return transactionMessage.copyWith(
+    instructions: _replaceInstructionAt(
+      transactionMessage.instructions,
+      details.index,
+      getSetComputeUnitLimitInstruction(units: newUnits),
+    ),
+  );
+}
+
+/// Updates the first `SetComputeUnitPrice` instruction, or appends one.
+TransactionMessage updateOrAppendSetComputeUnitPriceInstruction(
+  Object microLamports,
+  TransactionMessage transactionMessage,
+) {
+  final details = findSetComputeUnitPriceInstructionIndexAndMicroLamports(
+    transactionMessage,
+  );
+  final previousMicroLamports = details?.microLamports;
+  final newMicroLamports = microLamports is BigInt
+      ? microLamports
+      : (microLamports as BigInt Function(BigInt?))(previousMicroLamports);
+
+  if (details == null) {
+    return appendTransactionMessageInstruction(
+      getSetComputeUnitPriceInstruction(microLamports: newMicroLamports),
+      transactionMessage,
+    );
+  }
+
+  if (newMicroLamports == previousMicroLamports) return transactionMessage;
+  return transactionMessage.copyWith(
+    instructions: _replaceInstructionAt(
+      transactionMessage.instructions,
+      details.index,
+      getSetComputeUnitPriceInstruction(microLamports: newMicroLamports),
+    ),
+  );
+}
+
+bool _isSetComputeUnitLimitInstruction(Instruction instruction) {
+  if (instruction.programAddress != computeBudgetProgramAddress) return false;
+  final data = instruction.data;
+  return data != null &&
+      data.length >= 5 &&
+      identifyComputeBudgetInstruction(data) ==
+          ComputeBudgetInstruction.setComputeUnitLimit;
+}
+
+bool _isSetComputeUnitPriceInstruction(Instruction instruction) {
+  if (instruction.programAddress != computeBudgetProgramAddress) return false;
+  final data = instruction.data;
+  return data != null &&
+      data.length >= 9 &&
+      identifyComputeBudgetInstruction(data) ==
+          ComputeBudgetInstruction.setComputeUnitPrice;
+}
+
+List<Instruction> _replaceInstructionAt(
+  List<Instruction> instructions,
+  int index,
+  Instruction instruction,
+) {
+  return List.unmodifiable([
+    ...instructions.take(index),
+    instruction,
+    ...instructions.skip(index + 1),
+  ]);
+}

--- a/packages/solana_kit_compute_budget/pubspec.yaml
+++ b/packages/solana_kit_compute_budget/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   solana_kit_codecs_data_structures: ^0.5.0
   solana_kit_codecs_numbers: ^0.5.0
   solana_kit_instructions: ^0.5.0
+  solana_kit_transaction_messages: ^0.5.0
 
 dev_dependencies:
   solana_kit_lints: ^0.5.0

--- a/packages/solana_kit_compute_budget/test/message_helpers_test.dart
+++ b/packages/solana_kit_compute_budget/test/message_helpers_test.dart
@@ -1,0 +1,135 @@
+import 'dart:typed_data';
+
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_compute_budget/solana_kit_compute_budget.dart';
+import 'package:solana_kit_instructions/solana_kit_instructions.dart';
+import 'package:solana_kit_transaction_messages/solana_kit_transaction_messages.dart'
+    hide provisoryComputeUnitLimit;
+import 'package:test/test.dart';
+
+void main() {
+  group('compute budget transaction message helpers', () {
+    test('finds and appends provisory compute unit limit', () {
+      final message = createTransactionMessage(version: TransactionVersion.v0);
+
+      final updated = fillProvisorySetComputeUnitLimitInstruction(message);
+      final details = findSetComputeUnitLimitInstructionIndexAndUnits(updated);
+
+      expect(details, isNotNull);
+      expect(details!.index, equals(0));
+      expect(details.units, equals(provisoryComputeUnitLimit));
+    });
+
+    test('returns null when compute budget instructions are absent', () {
+      final message = createTransactionMessage(version: TransactionVersion.v0)
+          .appendInstruction(
+            Instruction(
+              programAddress: systemProgramAddress,
+              accounts: const [],
+              data: Uint8List(0),
+            ),
+          )
+          .appendInstruction(
+            Instruction(
+              programAddress: computeBudgetProgramAddress,
+              accounts: const [],
+              data: Uint8List.fromList([setComputeUnitLimitDiscriminator]),
+            ),
+          );
+
+      expect(findSetComputeUnitLimitInstructionIndexAndUnits(message), isNull);
+      expect(
+        findSetComputeUnitPriceInstructionIndexAndMicroLamports(message),
+        isNull,
+      );
+    });
+
+    test('does not duplicate an existing provisory compute unit limit', () {
+      final message = updateOrAppendSetComputeUnitLimitInstruction(
+        provisoryComputeUnitLimit,
+        createTransactionMessage(version: TransactionVersion.v0),
+      );
+
+      final updated = fillProvisorySetComputeUnitLimitInstruction(message);
+
+      expect(identical(updated, message), isTrue);
+      expect(updated.instructions, hasLength(1));
+    });
+
+    test('updates existing compute unit limit without appending', () {
+      final message = updateOrAppendSetComputeUnitLimitInstruction(
+        100,
+        createTransactionMessage(version: TransactionVersion.v0),
+      );
+
+      final updated = updateOrAppendSetComputeUnitLimitInstruction(
+        (int? previousUnits) => previousUnits! * 2,
+        message,
+      );
+      final details = findSetComputeUnitLimitInstructionIndexAndUnits(updated);
+
+      expect(updated.instructions, hasLength(1));
+      expect(details!.units, equals(200));
+    });
+
+    test('returns original message when compute unit limit is unchanged', () {
+      final message = updateOrAppendSetComputeUnitLimitInstruction(
+        100,
+        createTransactionMessage(version: TransactionVersion.v0),
+      );
+
+      final updated = updateOrAppendSetComputeUnitLimitInstruction(
+        100,
+        message,
+      );
+
+      expect(identical(updated, message), isTrue);
+    });
+
+    test('appends compute unit price with update helper', () {
+      final updated = updateOrAppendSetComputeUnitPriceInstruction(
+        BigInt.from(700),
+        createTransactionMessage(version: TransactionVersion.v0),
+      );
+      final details = findSetComputeUnitPriceInstructionIndexAndMicroLamports(
+        updated,
+      );
+
+      expect(updated.instructions, hasLength(1));
+      expect(details!.microLamports, equals(BigInt.from(700)));
+    });
+
+    test('sets and updates compute unit price', () {
+      final message = setTransactionMessageComputeUnitPrice(
+        BigInt.from(500),
+        createTransactionMessage(version: TransactionVersion.v0),
+      );
+
+      final updated = updateOrAppendSetComputeUnitPriceInstruction(
+        (BigInt? previousMicroLamports) => previousMicroLamports! * BigInt.two,
+        message,
+      );
+      final details = findSetComputeUnitPriceInstructionIndexAndMicroLamports(
+        updated,
+      );
+
+      expect(updated.instructions, hasLength(1));
+      expect(details!.index, equals(0));
+      expect(details.microLamports, equals(BigInt.from(1000)));
+    });
+
+    test('returns original message when compute unit price is unchanged', () {
+      final message = setTransactionMessageComputeUnitPrice(
+        BigInt.from(500),
+        createTransactionMessage(version: TransactionVersion.v0),
+      );
+
+      final updated = updateOrAppendSetComputeUnitPriceInstruction(
+        BigInt.from(500),
+        message,
+      );
+
+      expect(identical(updated, message), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- audit upstream API gaps outside Helius and document the prioritized findings
- add Compute Budget transaction-message helper APIs for introspection and update-or-append flows
- add tests and a changeset for solana_kit_compute_budget

## Code reuse / package-size note
- keeps the new helper implementation in solana_kit_compute_budget
- adds only the focused solana_kit_transaction_messages dependency needed by these message-level helpers, rather than depending on the umbrella solana_kit package
- continues using smaller primitives packages for instructions/codecs instead of pulling broad packages into leaf packages

## Verification
- devenv shell -- bash -lc 'flutter test packages/solana_kit_compute_budget/test'
- devenv shell lint:all