### PR TITLE
ci: add zizmor workflow linting

### DIFF
--- a/.changeset/zizmor-workflow-lint.md
+++ b/.changeset/zizmor-workflow-lint.md
@@ -1,0 +1,10 @@
+---
+solana_kit_address_lookup_table: none
+solana_kit_associated_token_account: none
+solana_kit_system: none
+solana_kit_token_2022: none
+---
+
+# Format workflow lint follow-up files
+
+Apply formatting-only changes discovered while adding the GitHub Actions workflow lint gate.

--- a/.github/actions/devenv/action.yml
+++ b/.github/actions/devenv/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: cache pnpm node
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ~/.local/share/pnpm
         key: ${{ runner.os }}-pnpm-node-${{ inputs.cache-version }}-${{ hashFiles('pnpm-workspace.yaml') }}
@@ -21,7 +21,7 @@ runs:
           ${{ runner.os }}-pnpm-node-${{ inputs.cache-version }}-
 
     - name: install nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@b97f05dcb019ddea06450a50ef6203d2fdc19fee # v31
       with:
         github_access_token: ${{ inputs.github-token }}
 
@@ -34,10 +34,15 @@ runs:
 
     - name: install flutter sdk via fvm
       run: |
+        devenv shell -- bash -e <<'EOF'
         fvm install
         fvm use --force
-      shell: devenv shell -- bash -e {0}
+        EOF
+      shell: bash
 
     - name: install dependencies
-      run: install:all
-      shell: devenv shell -- bash -e {0}
+      run: |
+        devenv shell -- bash -e <<'EOF'
+        install:all
+        EOF
+      shell: bash

--- a/.github/workflows/changeset-policy.yml
+++ b/.github/workflows/changeset-policy.yml
@@ -17,9 +17,10 @@ jobs:
       pull-requests: read
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: ./.github/actions/devenv
         with:
@@ -27,7 +28,7 @@ jobs:
 
       - name: collect changed files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
 
       - name: reject group-targeted changesets
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,24 @@ permissions:
   contents: read
 
 jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - name: run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          inputs: ".github/workflows/ .github/actions/"
+          advanced-security: true
+
   docs-site:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +38,9 @@ jobs:
   upstream-compatibility:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -35,11 +51,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: lint all (includes ktlint)
+      - name: lint all (includes ktlint and zizmor)
         run: lint:all
         shell: devenv shell -- bash -e {0}
 
@@ -50,7 +68,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +81,9 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,17 +94,19 @@ jobs:
   android-plugin-compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin
           java-version: "17"
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: stable
           cache: true
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
         with:
           sdk-version: 34
           ndk-version: "26.0.10792818"
@@ -99,9 +123,11 @@ jobs:
       run:
         working-directory: packages/codama-renderers-dart
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -116,9 +142,11 @@ jobs:
   publish-dry-run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -144,11 +172,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+          persist-credentials: false
+      - uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: pnpm
@@ -169,7 +198,7 @@ jobs:
         shell: devenv shell -- bash -e {0}
       - name: upload Codecov flag reports artifact
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: codecov-flag-reports
           path: coverage/flags/*.lcov
@@ -177,7 +206,7 @@ jobs:
           retention-days: 7
       - name: upload coverage
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./coverage/lcov.info,./packages/codama-renderers-dart/coverage/lcov.info
           disable_search: true
@@ -199,14 +228,16 @@ jobs:
       matrix:
         flag: ${{ fromJson(needs.coverage.outputs.codecov-flags) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: download Codecov flag reports artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: codecov-flag-reports
           path: coverage/flags
       - name: upload package coverage flag to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: ./coverage/flags/${{ matrix.flag }}.lcov
           disable_search: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,14 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6f5c0a628403f455e9376beb45a2ad81f71f1b2f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -14,7 +14,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.5
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
     with:
       # PR diff scanning is limited to tracked lockfiles committed to the repo.
       scan-args: |-
@@ -31,7 +31,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
     with:
       # Scheduled/manual scanning is limited to tracked lockfiles committed to the repo.
       scan-args: |-

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -16,8 +16,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: docs-pages
@@ -27,12 +25,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/devenv
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - id: pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Resolve docs base path
         id: base
         env:
@@ -60,14 +60,20 @@ jobs:
           echo "base_path=$base_path" >> "$GITHUB_OUTPUT"
           echo "Using DOCS_BASE_PATH=$base_path"
       - name: Build docs site
-        run: docs:site:build --dart-define=DOCS_BASE_PATH=${{ steps.base.outputs.base_path }}
+        env:
+          DOCS_BASE_PATH: ${{ steps.base.outputs.base_path }}
+        run: docs:site:build --dart-define=DOCS_BASE_PATH="$DOCS_BASE_PATH"
         shell: devenv shell -- bash -e {0}
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: docs/site/build/jaspr
 
   deploy:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -76,4 +82,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/devenv.nix
+++ b/devenv.nix
@@ -25,6 +25,7 @@ in
       ripgrep
       shfmt
       taplo
+      zizmor
       extra.mdt
       extra.monochange
       extra.pnpm
@@ -185,6 +186,7 @@ in
         set -euo pipefail
         docs:update
         fix:lint
+        fix:workflows
         mc check --fix
         fix:format
       '';
@@ -215,6 +217,7 @@ in
         lint:format
         lint:kotlin
         lint:analyze
+        lint:workflows
         mc check
       '';
       description = "Run all lint checks.";
@@ -228,6 +231,7 @@ in
         ${currentDir}/.devenv/profile/bin/lint:format
         ${currentDir}/.devenv/profile/bin/lint:kotlin
         ${currentDir}/.devenv/profile/bin/lint:analyze
+        ${currentDir}/.devenv/profile/bin/lint:workflows
         ${extra.monochange}/bin/mc check
       '';
       description = "Run all lint checks before `git push`.";
@@ -253,6 +257,22 @@ in
         ktlint
       '';
       description = "Lint tracked Kotlin files with ktlint.";
+      binary = "bash";
+    };
+    "lint:workflows" = {
+      exec = ''
+        set -euo pipefail
+        zizmor .github/workflows/ .github/actions/
+      '';
+      description = "Scan GitHub Actions workflows and actions for security vulnerabilities with zizmor.";
+      binary = "bash";
+    };
+    "fix:workflows" = {
+      exec = ''
+        set -euo pipefail
+        zizmor --fix .github/workflows/ .github/actions/
+      '';
+      description = "Auto-fix zizmor findings in GitHub Actions workflows where possible.";
       binary = "bash";
     };
     "mdt:info" = {

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/close_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/close_lookup_table.dart
@@ -41,9 +41,7 @@ getCloseLookupTableInstructionDataEncoder() {
 
   return transformEncoder(
     structEncoder,
-    (value) => <String, Object?>{
-      'discriminator': value.discriminator,
-    },
+    (value) => <String, Object?>{'discriminator': value.discriminator},
   );
 }
 

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/deactivate_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/deactivate_lookup_table.dart
@@ -41,9 +41,7 @@ getDeactivateLookupTableInstructionDataEncoder() {
 
   return transformEncoder(
     structEncoder,
-    (value) => <String, Object?>{
-      'discriminator': value.discriminator,
-    },
+    (value) => <String, Object?>{'discriminator': value.discriminator},
   );
 }
 

--- a/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/freeze_lookup_table.dart
+++ b/packages/solana_kit_address_lookup_table/lib/src/generated/instructions/freeze_lookup_table.dart
@@ -41,9 +41,7 @@ getFreezeLookupTableInstructionDataEncoder() {
 
   return transformEncoder(
     structEncoder,
-    (value) => <String, Object?>{
-      'discriminator': value.discriminator,
-    },
+    (value) => <String, Object?>{'discriminator': value.discriminator},
   );
 }
 

--- a/packages/solana_kit_associated_token_account/lib/src/instructions/create_associated_token.dart
+++ b/packages/solana_kit_associated_token_account/lib/src/instructions/create_associated_token.dart
@@ -39,9 +39,7 @@ getCreateAssociatedTokenInstructionDataEncoder() {
 
   return transformEncoder(
     structEncoder,
-    (value) => <String, Object?>{
-      'discriminator': value.discriminator,
-    },
+    (value) => <String, Object?>{'discriminator': value.discriminator},
   );
 }
 

--- a/packages/solana_kit_associated_token_account/lib/src/instructions/create_associated_token_idempotent.dart
+++ b/packages/solana_kit_associated_token_account/lib/src/instructions/create_associated_token_idempotent.dart
@@ -41,9 +41,7 @@ getCreateAssociatedTokenIdempotentInstructionDataEncoder() {
 
   return transformEncoder(
     structEncoder,
-    (value) => <String, Object?>{
-      'discriminator': value.discriminator,
-    },
+    (value) => <String, Object?>{'discriminator': value.discriminator},
   );
 }
 

--- a/packages/solana_kit_associated_token_account/lib/src/instructions/recover_nested_associated_token.dart
+++ b/packages/solana_kit_associated_token_account/lib/src/instructions/recover_nested_associated_token.dart
@@ -39,9 +39,7 @@ getRecoverNestedAssociatedTokenInstructionDataEncoder() {
 
   return transformEncoder(
     structEncoder,
-    (value) => <String, Object?>{
-      'discriminator': value.discriminator,
-    },
+    (value) => <String, Object?>{'discriminator': value.discriminator},
   );
 }
 

--- a/packages/solana_kit_system/lib/src/generated/instructions/create_account_allow_prefund.dart
+++ b/packages/solana_kit_system/lib/src/generated/instructions/create_account_allow_prefund.dart
@@ -107,9 +107,7 @@ Instruction getCreateAccountAllowPrefundInstruction({
 
 /// Parses a System Program `CreateAccountAllowPrefund` instruction.
 CreateAccountAllowPrefundInstructionData
-parseCreateAccountAllowPrefundInstruction(
-  Instruction instruction,
-) {
+parseCreateAccountAllowPrefundInstruction(Instruction instruction) {
   return getCreateAccountAllowPrefundInstructionDataDecoder().decode(
     instruction.data!,
   );

--- a/packages/solana_kit_token_2022/lib/src/get_initialize_instructions_for_extensions.dart
+++ b/packages/solana_kit_token_2022/lib/src/get_initialize_instructions_for_extensions.dart
@@ -63,42 +63,30 @@ List<Instruction> getPreInitializeInstructionsForMintExtensions({
                 maximumFee: newerTransferFee.maximumFee,
               ),
             ],
-          MetadataPointer(
-            :final authority,
-            :final metadataAddress,
-          ) =>
-            [
-              getInitializeMetadataPointerInstruction(
-                programAddress: programAddress,
-                mint: mint,
-                authority: authority,
-                metadataAddress: metadataAddress,
-              ),
-            ],
-          InterestBearingConfig(
-            :final rateAuthority,
-            :final currentRate,
-          ) =>
-            [
-              getInitializeInterestBearingMintInstruction(
-                programAddress: programAddress,
-                mint: mint,
-                rateAuthority: rateAuthority,
-                rate: currentRate,
-              ),
-            ],
-          ScaledUiAmountConfig(
-            :final authority,
-            :final multiplier,
-          ) =>
-            [
-              getInitializeScaledUiAmountMintInstruction(
-                programAddress: programAddress,
-                mint: mint,
-                authority: authority,
-                multiplier: multiplier,
-              ),
-            ],
+          MetadataPointer(:final authority, :final metadataAddress) => [
+            getInitializeMetadataPointerInstruction(
+              programAddress: programAddress,
+              mint: mint,
+              authority: authority,
+              metadataAddress: metadataAddress,
+            ),
+          ],
+          InterestBearingConfig(:final rateAuthority, :final currentRate) => [
+            getInitializeInterestBearingMintInstruction(
+              programAddress: programAddress,
+              mint: mint,
+              rateAuthority: rateAuthority,
+              rate: currentRate,
+            ),
+          ],
+          ScaledUiAmountConfig(:final authority, :final multiplier) => [
+            getInitializeScaledUiAmountMintInstruction(
+              programAddress: programAddress,
+              mint: mint,
+              authority: authority,
+              multiplier: multiplier,
+            ),
+          ],
           PausableConfig(:final authority) => [
             getInitializePausableConfigInstruction(
               programAddress: programAddress,
@@ -119,48 +107,36 @@ List<Instruction> getPreInitializeInstructionsForMintExtensions({
                   )),
             ),
           ],
-          GroupPointer(
-            :final authority,
-            :final groupAddress,
-          ) =>
-            [
-              getInitializeGroupPointerInstruction(
-                programAddress: programAddress,
-                mint: mint,
-                authority: authority,
-                groupAddress: groupAddress,
-              ),
-            ],
-          GroupMemberPointer(
-            :final authority,
-            :final memberAddress,
-          ) =>
-            [
-              getInitializeGroupMemberPointerInstruction(
-                programAddress: programAddress,
-                mint: mint,
-                authority: authority,
-                memberAddress: memberAddress,
-              ),
-            ],
+          GroupPointer(:final authority, :final groupAddress) => [
+            getInitializeGroupPointerInstruction(
+              programAddress: programAddress,
+              mint: mint,
+              authority: authority,
+              groupAddress: groupAddress,
+            ),
+          ],
+          GroupMemberPointer(:final authority, :final memberAddress) => [
+            getInitializeGroupMemberPointerInstruction(
+              programAddress: programAddress,
+              mint: mint,
+              authority: authority,
+              memberAddress: memberAddress,
+            ),
+          ],
           NonTransferable() => [
             getInitializeNonTransferableMintInstruction(
               programAddress: programAddress,
               mint: mint,
             ),
           ],
-          TransferHook(
-            :final authority,
-            :final programId,
-          ) =>
-            [
-              getInitializeTransferHookInstruction(
-                programAddress: programAddress,
-                mint: mint,
-                authority: authority,
-                programId: programId,
-              ),
-            ],
+          TransferHook(:final authority, :final programId) => [
+            getInitializeTransferHookInstruction(
+              programAddress: programAddress,
+              mint: mint,
+              authority: authority,
+              programId: programId,
+            ),
+          ],
           PermanentDelegate(:final delegate) => [
             getInitializePermanentDelegateInstruction(
               programAddress: programAddress,
@@ -168,18 +144,14 @@ List<Instruction> getPreInitializeInstructionsForMintExtensions({
               delegate: delegate,
             ),
           ],
-          ConfidentialTransferFee(
-            :final authority,
-            :final elgamalPubkey,
-          ) =>
-            [
-              getInitializeConfidentialTransferFeeInstruction(
-                programAddress: programAddress,
-                mint: mint,
-                authority: authority,
-                withdrawWithheldAuthorityElGamalPubkey: elgamalPubkey,
-              ),
-            ],
+          ConfidentialTransferFee(:final authority, :final elgamalPubkey) => [
+            getInitializeConfidentialTransferFeeInstruction(
+              programAddress: programAddress,
+              mint: mint,
+              authority: authority,
+              withdrawWithheldAuthorityElGamalPubkey: elgamalPubkey,
+            ),
+          ],
           MintCloseAuthority(:final closeAuthority) => [
             getInitializeMintCloseAuthorityInstruction(
               programAddress: programAddress,

--- a/scripts/run_integration_tests.dart
+++ b/scripts/run_integration_tests.dart
@@ -29,18 +29,14 @@ Future<void> main(List<String> args) async {
     stdout.writeln(
       'Running ${testDirectories.length} integration test directories.',
     );
-    final result = await Process.start(
-      'fvm',
-      [
-        'dart',
-        'test',
-        '--tags',
-        'integration',
-        ...testArgs,
-        ...testDirectories,
-      ],
-      mode: ProcessStartMode.inheritStdio,
-    );
+    final result = await Process.start('fvm', [
+      'dart',
+      'test',
+      '--tags',
+      'integration',
+      ...testArgs,
+      ...testDirectories,
+    ], mode: ProcessStartMode.inheritStdio);
 
     exitCode = await result.exitCode;
   } finally {
@@ -174,11 +170,11 @@ Future<void> _ensurePackageConfig() async {
   stdout.writeln(
     'Resolving workspace dependencies with `fvm flutter pub get`...',
   );
-  final result = await Process.start(
-    'fvm',
-    ['flutter', 'pub', 'get'],
-    mode: ProcessStartMode.inheritStdio,
-  );
+  final result = await Process.start('fvm', [
+    'flutter',
+    'pub',
+    'get',
+  ], mode: ProcessStartMode.inheritStdio);
   final code = await result.exitCode;
   if (code != 0) {
     exitCode = code;

--- a/scripts/run_workspace_coverage.dart
+++ b/scripts/run_workspace_coverage.dart
@@ -21,19 +21,15 @@ Future<void> main(List<String> args) async {
     );
 
   final stopwatch = Stopwatch()..start();
-  final result = await Process.start(
-    'dart',
-    [
-      'run',
-      'coverage:test_with_coverage',
-      '--',
-      '--exclude-tags',
-      'integration',
-      ...testArgs,
-      ...testDirectories,
-    ],
-    mode: ProcessStartMode.inheritStdio,
-  );
+  final result = await Process.start('dart', [
+    'run',
+    'coverage:test_with_coverage',
+    '--',
+    '--exclude-tags',
+    'integration',
+    ...testArgs,
+    ...testDirectories,
+  ], mode: ProcessStartMode.inheritStdio);
 
   final code = await result.exitCode;
   stopwatch.stop();
@@ -130,11 +126,11 @@ Future<void> _ensurePackageConfig() async {
   stdout.writeln(
     'Resolving workspace dependencies with `fvm flutter pub get`...',
   );
-  final result = await Process.start(
-    'fvm',
-    ['flutter', 'pub', 'get'],
-    mode: ProcessStartMode.inheritStdio,
-  );
+  final result = await Process.start('fvm', [
+    'flutter',
+    'pub',
+    'get',
+  ], mode: ProcessStartMode.inheritStdio);
   final code = await result.exitCode;
   if (code != 0) {
     exitCode = code;

--- a/scripts/run_workspace_tests.dart
+++ b/scripts/run_workspace_tests.dart
@@ -135,11 +135,11 @@ Future<void> _ensurePackageConfig() async {
   stdout.writeln(
     'Resolving workspace dependencies with `fvm flutter pub get`...',
   );
-  final result = await Process.start(
-    'fvm',
-    ['flutter', 'pub', 'get'],
-    mode: ProcessStartMode.inheritStdio,
-  );
+  final result = await Process.start('fvm', [
+    'flutter',
+    'pub',
+    'get',
+  ], mode: ProcessStartMode.inheritStdio);
   final code = await result.exitCode;
   if (code != 0) {
     exitCode = code;


### PR DESCRIPTION
## Summary
- add zizmor to the devenv toolchain and lint scripts
- run zizmor in CI, mirroring the monochange workflow lint integration
- pin GitHub Actions references and remove zizmor findings
- apply formatter updates needed for the lint gate

## Validation
- `devenv shell -- bash -lc 'lint:all'`
- PR CI passed before rebasing onto latest `main`
