### PR TITLE
chore(monochange): add versions sync to release and release-pr workflows

### DIFF
--- a/monochange.toml
+++ b/monochange.toml
@@ -353,6 +353,7 @@ inputs = [
 ]
 steps = [
   { type = "PrepareRelease", name = "plan release", allow_empty_changesets = true, inputs = ["format"] },
+  { type = "Command", name = "sync dependency versions", when = "{{ number_of_changesets > 0 }}", command = "monochange versions sync" },
   { type = "OpenReleaseRequest", name = "open release PR", when = "{{ number_of_changesets > 0 }}", inputs = { format = "markdown", no_verify = "{{ inputs.no_verify }}", stage_all = true } },
 ]
 
@@ -368,6 +369,7 @@ inputs = [
 ]
 steps = [
   { type = "PrepareRelease", name = "plan release", allow_empty_changesets = true },
+  { type = "Command", name = "sync dependency versions", when = "{{ number_of_changesets > 0 }}", command = "monochange versions sync" },
   { type = "Command", name = "format with dprint", when = "{{ number_of_changesets > 0 }}", command = "dprint fmt --config dprint.json" },
   { type = "Command", name = "update flutter lockfiles", when = "{{ number_of_changesets > 0 }}", command = "flutter pub get" },
   { type = "Command", name = "generate pnpm lockfile", when = "{{ number_of_changesets > 0 }}", command = "pnpm install --lockfile-only --no-frozen-lockfile --link-workspace-packages" },

--- a/monochange.toml
+++ b/monochange.toml
@@ -345,18 +345,6 @@ steps = [
   { type = "Command", name = "format with dprint", command = "dprint fmt --config dprint.json" },
 ]
 
-[cli.release-pr]
-help_text = "Prepare release changes and open or update the monochange release PR"
-inputs = [
-  { name = "format", type = "choice", choices = ["text", "json", "markdown"], default = "markdown" },
-  { name = "no_verify", type = "boolean", default = true },
-]
-steps = [
-  { type = "PrepareRelease", name = "plan release", allow_empty_changesets = true, inputs = ["format"] },
-  { type = "Command", name = "sync dependency versions", when = "{{ number_of_changesets > 0 }}", command = "monochange versions sync" },
-  { type = "OpenReleaseRequest", name = "open release PR", when = "{{ number_of_changesets > 0 }}", inputs = { format = "markdown", no_verify = "{{ inputs.no_verify }}", stage_all = true } },
-]
-
 [cli.release]
 help_text = "Prepare a local release: plan bumps, sync files, format, optionally commit, tag, and publish the GitHub release"
 inputs = [


### PR DESCRIPTION
## Summary

Add  as a Command step after  in both  and  workflows.

## Why

 bumps version numbers in package manifests and  like , but does **not** re-sync internal dependency constraints across sibling packages. After a version bump, packages that depend on the bumped package still have stale constraint ranges in their .

For example, when  goes from  → :
- ✅  → 
- ✅  → 
- ❌  → still  (stale)

Without the sync step, the release is silently broken —  has the right number but internal dependency constraints are stale.

## Changes

- Added  after  in 
- Added the same step after  in 

## Upstream issue

Opened monochange/monochange#606 proposing that  should auto-sync dependency constraints by default so this step isn't needed manually.