### PR TITLE
docs: add package docs site coverage

### DIFF
--- a/.changeset/package-docs-site-links.md
+++ b/.changeset/package-docs-site-links.md
@@ -1,0 +1,62 @@
+---
+"solana_kit": docs
+"solana_kit_accounts": docs
+"solana_kit_address": docs
+"solana_kit_address_constants": docs
+"solana_kit_address_lookup_table": docs
+"solana_kit_addresses": docs
+"solana_kit_associated_token_account": docs
+"solana_kit_codecs": docs
+"solana_kit_codecs_core": docs
+"solana_kit_codecs_data_structures": docs
+"solana_kit_codecs_numbers": docs
+"solana_kit_codecs_strings": docs
+"solana_kit_compute_budget": docs
+"solana_kit_config": docs
+"solana_kit_errors": docs
+"solana_kit_fast_stable_stringify": docs
+"solana_kit_fixed_points": docs
+"solana_kit_functional": docs
+"solana_kit_helius": docs
+"solana_kit_instruction_plans": docs
+"solana_kit_instructions": docs
+"solana_kit_keys": docs
+"solana_kit_lints": docs
+"solana_kit_loader": docs
+"solana_kit_memo": docs
+"solana_kit_mobile_wallet_adapter": docs
+"solana_kit_mobile_wallet_adapter_protocol": docs
+"solana_kit_mpl_bubblegum": docs
+"solana_kit_offchain_messages": docs
+"solana_kit_options": docs
+"solana_kit_program_client_core": docs
+"solana_kit_programs": docs
+"solana_kit_rpc": docs
+"solana_kit_rpc_api": docs
+"solana_kit_rpc_parsed_types": docs
+"solana_kit_rpc_spec": docs
+"solana_kit_rpc_spec_types": docs
+"solana_kit_rpc_subscriptions": docs
+"solana_kit_rpc_subscriptions_api": docs
+"solana_kit_rpc_subscriptions_channel_websocket": docs
+"solana_kit_rpc_transformers": docs
+"solana_kit_rpc_transport_http": docs
+"solana_kit_rpc_types": docs
+"solana_kit_signers": docs
+"solana_kit_spl_account_compression": docs
+"solana_kit_stake": docs
+"solana_kit_subscribable": docs
+"solana_kit_subscriptions": docs
+"solana_kit_system": docs
+"solana_kit_sysvars": docs
+"solana_kit_test_matchers": docs
+"solana_kit_token": docs
+"solana_kit_token_2022": docs
+"solana_kit_transaction_confirmation": docs
+"solana_kit_transaction_messages": docs
+"solana_kit_transactions": docs
+---
+
+# Point package README website badges at package docs
+
+Updated package README website badges to link directly to each package's docs catalog entry and added missing package entries to the documentation website catalog/index.

--- a/docs/site/content/reference/package-catalog.md
+++ b/docs/site/content/reference/package-catalog.md
@@ -32,12 +32,26 @@ Each subsection below maps one package to its role in the Solana ecosystem and t
 
 ## Address, Keys, and Signers
 
+### solana_kit_address
+
+- Pub.dev: [solana_kit_address](https://pub.dev/packages/solana_kit_address)
+- Why it exists: the lowest-level address type and codecs need a small dependency surface.
+- What it does: provides the `Address` extension type, validation, codecs, comparators, and public-key conversion helpers.
+- Use it when: another package needs address primitives without the broader address helper surface.
+
 ### solana_kit_addresses
 
 - Pub.dev: [solana_kit_addresses](https://pub.dev/packages/solana_kit_addresses)
 - Why it exists: addresses are core Solana identity primitives and need strict validation.
 - What it does: validates addresses, supports encoding/decoding, and derives PDAs.
 - Use it when: creating account references, PDAs, and address comparisons.
+
+### solana_kit_address_constants
+
+- Pub.dev: [solana_kit_address_constants](https://pub.dev/packages/solana_kit_address_constants)
+- Why it exists: well-known program, sysvar, SPL, Metaplex, and mint addresses should not be hardcoded throughout the workspace.
+- What it does: centralizes typed `Address` constants for common on-chain addresses.
+- Use it when: referencing native programs, sysvars, SPL programs, Metaplex programs, or common token mints.
 
 ### solana_kit_keys
 
@@ -89,6 +103,13 @@ Each subsection below maps one package to its role in the Solana ecosystem and t
 - Why it exists: many Solana structures use optional values with Rust-like semantics.
 - What it does: offers typed option variants and optional-value codec support.
 - Use it when: serializing optional account fields or params.
+
+### solana_kit_fixed_points
+
+- Pub.dev: [solana_kit_fixed_points](https://pub.dev/packages/solana_kit_fixed_points)
+- Why it exists: token, fee, and decimal arithmetic need exact fixed-point behavior instead of floating-point approximations.
+- What it does: provides binary and decimal fixed-point arithmetic, parsing, formatting, comparison, conversion, and codecs.
+- Use it when: representing precise on-chain numeric values with explicit scale or precision.
 
 ## Instructions and Transactions
 
@@ -245,6 +266,48 @@ Each subsection below maps one package to its role in the Solana ecosystem and t
 - What it does: exposes shared utilities for building typed program clients.
 - Use it when: generating or hand-writing client SDK wrappers.
 
+### solana_kit_system
+
+- Pub.dev: [solana_kit_system](https://pub.dev/packages/solana_kit_system)
+- Why it exists: System Program instructions are foundational to account creation, lamport transfers, and ownership changes.
+- What it does: provides generated instruction builders, account decoders, errors, PDA helpers, and program constants for the System Program.
+- Use it when: creating accounts, transferring SOL, assigning ownership, allocating data, or using nonce flows.
+
+### solana_kit_config
+
+- Pub.dev: [solana_kit_config](https://pub.dev/packages/solana_kit_config)
+- Why it exists: Solana's native Config program needs typed builders and decoders.
+- What it does: provides Config program codecs, account decoders, instruction builders, and helpers for storing configuration data.
+- Use it when: reading or writing native Config program accounts.
+
+### solana_kit_loader
+
+- Pub.dev: [solana_kit_loader](https://pub.dev/packages/solana_kit_loader)
+- Why it exists: program deployment and upgrade flows require typed loader instructions and account models.
+- What it does: supports BPF Loader v3/Upgradeable and Loader v4 instructions, account codecs, and deployment/upgrade planning helpers.
+- Use it when: writing tooling around program buffers, deploys, upgrades, authority changes, or loader account decoding.
+
+### solana_kit_memo
+
+- Pub.dev: [solana_kit_memo](https://pub.dev/packages/solana_kit_memo)
+- Why it exists: memo instructions are simple but common enough to deserve a typed helper.
+- What it does: builds Memo program instructions and exposes current and legacy Memo program addresses.
+- Use it when: attaching UTF-8 memo text to transactions.
+
+### solana_kit_token
+
+- Pub.dev: [solana_kit_token](https://pub.dev/packages/solana_kit_token)
+- Why it exists: SPL Token workflows need generated coverage plus ergonomic helpers.
+- What it does: provides SPL Token instruction builders, parsers, codecs, and convenience exports for associated token account flows.
+- Use it when: minting, transferring, burning, approving, freezing, or managing classic SPL Token accounts.
+
+### solana_kit_token_2022
+
+- Pub.dev: [solana_kit_token_2022](https://pub.dev/packages/solana_kit_token_2022)
+- Why it exists: Token-2022 adds extension-aware token behavior that should be modeled separately from classic SPL Token.
+- What it does: provides generated Token-2022 builders plus focused helpers for extension-aware token workflows.
+- Use it when: working with token extensions or Token-2022 mints/accounts.
+
 ### solana_kit_associated_token_account
 
 - Pub.dev: [solana_kit_associated_token_account](https://pub.dev/packages/solana_kit_associated_token_account)
@@ -272,6 +335,27 @@ Each subsection below maps one package to its role in the Solana ecosystem and t
 - Why it exists: staking, delegation, and stake-account state decoding need a typed program client.
 - What it does: provides generated Stake Program instruction builders, stake state codecs, `StakeAccount` decoding, and instruction-plan helpers.
 - Use it when: creating stake accounts, delegating stake, parsing stake instructions, or decoding stake account data.
+
+### solana_kit_spl_account_compression
+
+- Pub.dev: [solana_kit_spl_account_compression](https://pub.dev/packages/solana_kit_spl_account_compression)
+- Why it exists: compressed account and compressed NFT flows depend on SPL Account Compression primitives.
+- What it does: provides SPL Account Compression instruction builders, program addresses, concurrent Merkle tree sizing helpers, and valid depth/size metadata.
+- Use it when: creating or interacting with concurrent Merkle trees used by compressed assets.
+
+### solana_kit_mpl_bubblegum
+
+- Pub.dev: [solana_kit_mpl_bubblegum](https://pub.dev/packages/solana_kit_mpl_bubblegum)
+- Why it exists: compressed NFT workflows need Bubblegum-specific instructions, PDAs, hashes, and proof helpers.
+- What it does: provides mpl-bubblegum instruction builders, composite helpers, DAS API abstractions, hashing utilities, and Merkle proof support.
+- Use it when: minting, transferring, burning, delegating, or querying compressed NFTs.
+
+### solana_kit_subscriptions
+
+- Pub.dev: [solana_kit_subscriptions](https://pub.dev/packages/solana_kit_subscriptions)
+- Why it exists: the Subscriptions Delegation Program needs typed generated accounts, instructions, PDAs, and codecs.
+- What it does: models subscription authorities, fixed delegations, recurring delegations, and subscription-plan flows.
+- Use it when: building token subscription, delegated payment, or recurring authorization workflows.
 
 ### solana_kit_sysvars
 

--- a/docs/site/content/reference/package-index.md
+++ b/docs/site/content/reference/package-index.md
@@ -22,7 +22,9 @@ Then move to smaller packages only when you want a narrower dependency surface o
 
 ## Core primitives
 
+- [`solana_kit_address`](https://pub.dev/packages/solana_kit_address)
 - [`solana_kit_addresses`](https://pub.dev/packages/solana_kit_addresses)
+- [`solana_kit_address_constants`](https://pub.dev/packages/solana_kit_address_constants)
 - [`solana_kit_keys`](https://pub.dev/packages/solana_kit_keys)
 - [`solana_kit_signers`](https://pub.dev/packages/solana_kit_signers)
 - [`solana_kit_errors`](https://pub.dev/packages/solana_kit_errors)
@@ -34,13 +36,17 @@ Then move to smaller packages only when you want a narrower dependency surface o
 - [`solana_kit_transactions`](https://pub.dev/packages/solana_kit_transactions)
 - [`solana_kit_transaction_confirmation`](https://pub.dev/packages/solana_kit_transaction_confirmation)
 - [`solana_kit_instruction_plans`](https://pub.dev/packages/solana_kit_instruction_plans)
+- [`solana_kit_offchain_messages`](https://pub.dev/packages/solana_kit_offchain_messages)
 
 ## RPC + subscriptions
 
 - [`solana_kit_rpc`](https://pub.dev/packages/solana_kit_rpc)
 - [`solana_kit_rpc_api`](https://pub.dev/packages/solana_kit_rpc_api)
 - [`solana_kit_rpc_types`](https://pub.dev/packages/solana_kit_rpc_types)
+- [`solana_kit_rpc_spec`](https://pub.dev/packages/solana_kit_rpc_spec)
+- [`solana_kit_rpc_spec_types`](https://pub.dev/packages/solana_kit_rpc_spec_types)
 - [`solana_kit_rpc_transport_http`](https://pub.dev/packages/solana_kit_rpc_transport_http)
+- [`solana_kit_rpc_transformers`](https://pub.dev/packages/solana_kit_rpc_transformers)
 - [`solana_kit_rpc_subscriptions`](https://pub.dev/packages/solana_kit_rpc_subscriptions)
 - [`solana_kit_rpc_subscriptions_api`](https://pub.dev/packages/solana_kit_rpc_subscriptions_api)
 - [`solana_kit_rpc_subscriptions_channel_websocket`](https://pub.dev/packages/solana_kit_rpc_subscriptions_channel_websocket)
@@ -61,16 +67,23 @@ Then move to smaller packages only when you want a narrower dependency surface o
 - [`solana_kit_codecs_strings`](https://pub.dev/packages/solana_kit_codecs_strings)
 - [`solana_kit_codecs_data_structures`](https://pub.dev/packages/solana_kit_codecs_data_structures)
 - [`solana_kit_options`](https://pub.dev/packages/solana_kit_options)
+- [`solana_kit_fixed_points`](https://pub.dev/packages/solana_kit_fixed_points)
 
 ## Program clients
 
 - [`solana_kit_system`](https://pub.dev/packages/solana_kit_system)
+- [`solana_kit_config`](https://pub.dev/packages/solana_kit_config)
+- [`solana_kit_loader`](https://pub.dev/packages/solana_kit_loader)
+- [`solana_kit_memo`](https://pub.dev/packages/solana_kit_memo)
 - [`solana_kit_token`](https://pub.dev/packages/solana_kit_token)
 - [`solana_kit_token_2022`](https://pub.dev/packages/solana_kit_token_2022)
 - [`solana_kit_associated_token_account`](https://pub.dev/packages/solana_kit_associated_token_account)
 - [`solana_kit_address_lookup_table`](https://pub.dev/packages/solana_kit_address_lookup_table)
 - [`solana_kit_compute_budget`](https://pub.dev/packages/solana_kit_compute_budget)
 - [`solana_kit_stake`](https://pub.dev/packages/solana_kit_stake)
+- [`solana_kit_spl_account_compression`](https://pub.dev/packages/solana_kit_spl_account_compression)
+- [`solana_kit_mpl_bubblegum`](https://pub.dev/packages/solana_kit_mpl_bubblegum)
+- [`solana_kit_subscriptions`](https://pub.dev/packages/solana_kit_subscriptions)
 
 ## Specialized integrations
 
@@ -82,6 +95,11 @@ Then move to smaller packages only when you want a narrower dependency surface o
 
 - [`solana_kit_functional`](https://pub.dev/packages/solana_kit_functional)
 - [`solana_kit_fast_stable_stringify`](https://pub.dev/packages/solana_kit_fast_stable_stringify)
+
+## Workspace support
+
+- [`solana_kit_lints`](https://pub.dev/packages/solana_kit_lints)
+- [`solana_kit_test_matchers`](https://pub.dev/packages/solana_kit_test_matchers)
 
 ## Helpful follow-ups
 

--- a/packages/solana_kit_accounts/README.md
+++ b/packages/solana_kit_accounts/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_accounts.svg)](https://pub.dev/packages/solana_kit_accounts)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_accounts/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_accounts)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_accounts)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_accounts)
 

--- a/packages/solana_kit_address/README.md
+++ b/packages/solana_kit_address/README.md
@@ -1,6 +1,7 @@
 # solana_kit_address
 
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_address)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_address)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_address)
 
 Core Address extension type, codecs, comparator, and PublicKey utilities for the
 [Solana Kit](https://github.com/openbudgetfun/solana_kit) Dart SDK.

--- a/packages/solana_kit_address_constants/README.md
+++ b/packages/solana_kit_address_constants/README.md
@@ -1,6 +1,7 @@
 # solana_kit_address_constants
 
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_address_constants)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_address_constants)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_address_constants)
 
 Well-known Solana address constants for programs, sysvars, SPL programs,
 Metaplex programs, and token mints for the

--- a/packages/solana_kit_address_lookup_table/README.md
+++ b/packages/solana_kit_address_lookup_table/README.md
@@ -1,5 +1,7 @@
 # solana_kit_address_lookup_table
 
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_address_lookup_table)
+
 Address Lookup Table program client for the
 [Solana Kit](https://github.com/openbudgetfun/solana_kit) Dart SDK.
 

--- a/packages/solana_kit_addresses/README.md
+++ b/packages/solana_kit_addresses/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_addresses.svg)](https://pub.dev/packages/solana_kit_addresses)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_addresses/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_addresses)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_addresses)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_addresses)
 

--- a/packages/solana_kit_associated_token_account/README.md
+++ b/packages/solana_kit_associated_token_account/README.md
@@ -1,6 +1,7 @@
 # solana_kit_associated_token_account
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_associated_token_account.svg)](https://pub.dev/packages/solana_kit_associated_token_account)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_associated_token_account)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_associated_token_account)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_associated_token_account)
 

--- a/packages/solana_kit_codecs/README.md
+++ b/packages/solana_kit_codecs/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_codecs.svg)](https://pub.dev/packages/solana_kit_codecs)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs)
 

--- a/packages/solana_kit_codecs_core/README.md
+++ b/packages/solana_kit_codecs_core/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_codecs_core.svg)](https://pub.dev/packages/solana_kit_codecs_core)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs_core/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs_core)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs_core)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs_core)
 

--- a/packages/solana_kit_codecs_data_structures/README.md
+++ b/packages/solana_kit_codecs_data_structures/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_codecs_data_structures.svg)](https://pub.dev/packages/solana_kit_codecs_data_structures)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs_data_structures/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs_data_structures)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs_data_structures)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs_data_structures)
 

--- a/packages/solana_kit_codecs_numbers/README.md
+++ b/packages/solana_kit_codecs_numbers/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_codecs_numbers.svg)](https://pub.dev/packages/solana_kit_codecs_numbers)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs_numbers/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs_numbers)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs_numbers)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs_numbers)
 

--- a/packages/solana_kit_codecs_strings/README.md
+++ b/packages/solana_kit_codecs_strings/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_codecs_strings.svg)](https://pub.dev/packages/solana_kit_codecs_strings)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_codecs_strings/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_codecs_strings)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_codecs_strings)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_codecs_strings)
 

--- a/packages/solana_kit_compute_budget/README.md
+++ b/packages/solana_kit_compute_budget/README.md
@@ -1,6 +1,7 @@
 # solana_kit_compute_budget
 
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_compute_budget)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_compute_budget)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_compute_budget)
 Compute Budget program client for the
 [Solana Kit](https://github.com/openbudgetfun/solana_kit) Dart SDK.
 

--- a/packages/solana_kit_config/README.md
+++ b/packages/solana_kit_config/README.md
@@ -1,6 +1,7 @@
 # Solana Kit Config
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_config.svg)](https://pub.dev/packages/solana_kit_config)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_config)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
 

--- a/packages/solana_kit_errors/README.md
+++ b/packages/solana_kit_errors/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_errors.svg)](https://pub.dev/packages/solana_kit_errors)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_errors/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_errors)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_errors)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_errors)
 

--- a/packages/solana_kit_fast_stable_stringify/README.md
+++ b/packages/solana_kit_fast_stable_stringify/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_fast_stable_stringify.svg)](https://pub.dev/packages/solana_kit_fast_stable_stringify)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_fast_stable_stringify/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_fast_stable_stringify)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_fast_stable_stringify)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_fast_stable_stringify)
 

--- a/packages/solana_kit_fixed_points/README.md
+++ b/packages/solana_kit_fixed_points/README.md
@@ -1,6 +1,7 @@
 # solana_kit_fixed_points
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_fixed_points.svg)](https://pub.dev/packages/solana_kit_fixed_points)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_fixed_points)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_fixed_points)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_fixed_points)
 

--- a/packages/solana_kit_functional/README.md
+++ b/packages/solana_kit_functional/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_functional.svg)](https://pub.dev/packages/solana_kit_functional)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_functional/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_functional)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_functional)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_functional)
 

--- a/packages/solana_kit_helius/README.md
+++ b/packages/solana_kit_helius/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_helius.svg)](https://pub.dev/packages/solana_kit_helius)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_helius/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_helius)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_helius)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_helius)
 

--- a/packages/solana_kit_instruction_plans/README.md
+++ b/packages/solana_kit_instruction_plans/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_instruction_plans.svg)](https://pub.dev/packages/solana_kit_instruction_plans)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_instruction_plans/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_instruction_plans)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_instruction_plans)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_instruction_plans)
 

--- a/packages/solana_kit_instructions/README.md
+++ b/packages/solana_kit_instructions/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_instructions.svg)](https://pub.dev/packages/solana_kit_instructions)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_instructions/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_instructions)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_instructions)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_instructions)
 

--- a/packages/solana_kit_keys/README.md
+++ b/packages/solana_kit_keys/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_keys.svg)](https://pub.dev/packages/solana_kit_keys)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_keys/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_keys)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_keys)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_keys)
 

--- a/packages/solana_kit_lints/README.md
+++ b/packages/solana_kit_lints/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_lints.svg)](https://pub.dev/packages/solana_kit_lints)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_lints/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_lints)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_lints)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_lints)
 

--- a/packages/solana_kit_loader/README.md
+++ b/packages/solana_kit_loader/README.md
@@ -1,6 +1,7 @@
 # solana_kit_loader
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_loader.svg)](https://pub.dev/packages/solana_kit_loader)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_loader)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg)](https://codecov.io/gh/openbudgetfun/solana_kit)
 

--- a/packages/solana_kit_memo/README.md
+++ b/packages/solana_kit_memo/README.md
@@ -1,6 +1,7 @@
 # solana_kit_memo
 
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_memo)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_memo)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_memo)
 Memo program client for the
 [Solana Kit](https://github.com/openbudgetfun/solana_kit) Dart SDK.
 

--- a/packages/solana_kit_mobile_wallet_adapter/README.md
+++ b/packages/solana_kit_mobile_wallet_adapter/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_mobile_wallet_adapter.svg)](https://pub.dev/packages/solana_kit_mobile_wallet_adapter)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_mobile_wallet_adapter/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_mobile_wallet_adapter)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_mobile_wallet_adapter)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_mobile_wallet_adapter)
 

--- a/packages/solana_kit_mobile_wallet_adapter_protocol/README.md
+++ b/packages/solana_kit_mobile_wallet_adapter_protocol/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_mobile_wallet_adapter_protocol.svg)](https://pub.dev/packages/solana_kit_mobile_wallet_adapter_protocol)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_mobile_wallet_adapter_protocol/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_mobile_wallet_adapter_protocol)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_mobile_wallet_adapter_protocol)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_mobile_wallet_adapter_protocol)
 

--- a/packages/solana_kit_mpl_bubblegum/README.md
+++ b/packages/solana_kit_mpl_bubblegum/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_mpl_bubblegum.svg)](https://pub.dev/packages/solana_kit_mpl_bubblegum)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_mpl_bubblegum/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_mpl_bubblegum)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_mpl_bubblegum)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_mpl_bubblegum)
 

--- a/packages/solana_kit_offchain_messages/README.md
+++ b/packages/solana_kit_offchain_messages/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_offchain_messages.svg)](https://pub.dev/packages/solana_kit_offchain_messages)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_offchain_messages/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_offchain_messages)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_offchain_messages)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_offchain_messages)
 

--- a/packages/solana_kit_options/README.md
+++ b/packages/solana_kit_options/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_options.svg)](https://pub.dev/packages/solana_kit_options)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_options/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_options)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_options)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_options)
 

--- a/packages/solana_kit_program_client_core/README.md
+++ b/packages/solana_kit_program_client_core/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_program_client_core.svg)](https://pub.dev/packages/solana_kit_program_client_core)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_program_client_core/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_program_client_core)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_program_client_core)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_program_client_core)
 

--- a/packages/solana_kit_programs/README.md
+++ b/packages/solana_kit_programs/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_programs.svg)](https://pub.dev/packages/solana_kit_programs)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_programs/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_programs)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_programs)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_programs)
 

--- a/packages/solana_kit_rpc/README.md
+++ b/packages/solana_kit_rpc/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc.svg)](https://pub.dev/packages/solana_kit_rpc)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc)
 

--- a/packages/solana_kit_rpc_api/README.md
+++ b/packages/solana_kit_rpc_api/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_api.svg)](https://pub.dev/packages/solana_kit_rpc_api)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_api/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_api)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_api)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_api)
 

--- a/packages/solana_kit_rpc_parsed_types/README.md
+++ b/packages/solana_kit_rpc_parsed_types/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_parsed_types.svg)](https://pub.dev/packages/solana_kit_rpc_parsed_types)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_parsed_types/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_parsed_types)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_parsed_types)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_parsed_types)
 

--- a/packages/solana_kit_rpc_spec/README.md
+++ b/packages/solana_kit_rpc_spec/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_spec.svg)](https://pub.dev/packages/solana_kit_rpc_spec)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_spec/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_spec)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_spec)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_spec)
 

--- a/packages/solana_kit_rpc_spec_types/README.md
+++ b/packages/solana_kit_rpc_spec_types/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_spec_types.svg)](https://pub.dev/packages/solana_kit_rpc_spec_types)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_spec_types/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_spec_types)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_spec_types)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_spec_types)
 

--- a/packages/solana_kit_rpc_subscriptions/README.md
+++ b/packages/solana_kit_rpc_subscriptions/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_subscriptions.svg)](https://pub.dev/packages/solana_kit_rpc_subscriptions)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_subscriptions/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_subscriptions)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_subscriptions)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_subscriptions)
 

--- a/packages/solana_kit_rpc_subscriptions_api/README.md
+++ b/packages/solana_kit_rpc_subscriptions_api/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_subscriptions_api.svg)](https://pub.dev/packages/solana_kit_rpc_subscriptions_api)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_subscriptions_api/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_subscriptions_api)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_subscriptions_api)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_subscriptions_api)
 

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/README.md
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_subscriptions_channel_websocket.svg)](https://pub.dev/packages/solana_kit_rpc_subscriptions_channel_websocket)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_subscriptions_channel_websocket/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_subscriptions_channel_websocket)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_subscriptions_channel_websocket)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_subscriptions_channel_websocket)
 

--- a/packages/solana_kit_rpc_transformers/README.md
+++ b/packages/solana_kit_rpc_transformers/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_transformers.svg)](https://pub.dev/packages/solana_kit_rpc_transformers)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_transformers/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_transformers)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_transformers)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_transformers)
 

--- a/packages/solana_kit_rpc_transport_http/README.md
+++ b/packages/solana_kit_rpc_transport_http/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_transport_http.svg)](https://pub.dev/packages/solana_kit_rpc_transport_http)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_transport_http/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_transport_http)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_transport_http)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_transport_http)
 

--- a/packages/solana_kit_rpc_types/README.md
+++ b/packages/solana_kit_rpc_types/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_rpc_types.svg)](https://pub.dev/packages/solana_kit_rpc_types)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_rpc_types/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_rpc_types)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_rpc_types)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_rpc_types)
 

--- a/packages/solana_kit_signers/README.md
+++ b/packages/solana_kit_signers/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_signers.svg)](https://pub.dev/packages/solana_kit_signers)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_signers/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_signers)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_signers)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_signers)
 

--- a/packages/solana_kit_spl_account_compression/README.md
+++ b/packages/solana_kit_spl_account_compression/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_spl_account_compression.svg)](https://pub.dev/packages/solana_kit_spl_account_compression)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_spl_account_compression/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_spl_account_compression)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_spl_account_compression)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_spl_account_compression)
 

--- a/packages/solana_kit_stake/README.md
+++ b/packages/solana_kit_stake/README.md
@@ -1,6 +1,7 @@
 # solana_kit_stake
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_stake.svg)](https://pub.dev/packages/solana_kit_stake)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_stake)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_stake)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_stake)
 

--- a/packages/solana_kit_subscribable/README.md
+++ b/packages/solana_kit_subscribable/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_subscribable.svg)](https://pub.dev/packages/solana_kit_subscribable)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_subscribable/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_subscribable)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_subscribable)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_subscribable)
 

--- a/packages/solana_kit_subscriptions/README.md
+++ b/packages/solana_kit_subscriptions/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_subscriptions.svg)](https://pub.dev/packages/solana_kit_subscriptions)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_subscriptions/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_subscriptions)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_subscriptions)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_subscriptions)
 

--- a/packages/solana_kit_system/README.md
+++ b/packages/solana_kit_system/README.md
@@ -1,6 +1,7 @@
 # solana_kit_system
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_system.svg)](https://pub.dev/packages/solana_kit_system)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_system)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_system)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_system)
 

--- a/packages/solana_kit_sysvars/README.md
+++ b/packages/solana_kit_sysvars/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_sysvars.svg)](https://pub.dev/packages/solana_kit_sysvars)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_sysvars/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_sysvars)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_sysvars)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_sysvars)
 

--- a/packages/solana_kit_test_matchers/README.md
+++ b/packages/solana_kit_test_matchers/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_test_matchers.svg)](https://pub.dev/packages/solana_kit_test_matchers)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_test_matchers/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_test_matchers)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_test_matchers)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_test_matchers)
 

--- a/packages/solana_kit_token/README.md
+++ b/packages/solana_kit_token/README.md
@@ -1,6 +1,7 @@
 # solana_kit_token
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_token.svg)](https://pub.dev/packages/solana_kit_token)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_token)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_token)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_token)
 

--- a/packages/solana_kit_token_2022/README.md
+++ b/packages/solana_kit_token_2022/README.md
@@ -1,6 +1,7 @@
 # solana_kit_token_2022
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_token_2022.svg)](https://pub.dev/packages/solana_kit_token_2022)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_token_2022)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_token_2022)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_token_2022)
 

--- a/packages/solana_kit_transaction_confirmation/README.md
+++ b/packages/solana_kit_transaction_confirmation/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_transaction_confirmation.svg)](https://pub.dev/packages/solana_kit_transaction_confirmation)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_transaction_confirmation/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_transaction_confirmation)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_transaction_confirmation)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_transaction_confirmation)
 

--- a/packages/solana_kit_transaction_messages/README.md
+++ b/packages/solana_kit_transaction_messages/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_transaction_messages.svg)](https://pub.dev/packages/solana_kit_transaction_messages)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_transaction_messages/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_transaction_messages)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_transaction_messages)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_transaction_messages)
 

--- a/packages/solana_kit_transactions/README.md
+++ b/packages/solana_kit_transactions/README.md
@@ -2,7 +2,7 @@
 
 [![pub package](https://img.shields.io/pub/v/solana_kit_transactions.svg)](https://pub.dev/packages/solana_kit_transactions)
 [![docs](https://img.shields.io/badge/docs-pub.dev-0175C2.svg)](https://pub.dev/documentation/solana_kit_transactions/latest/)
-[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/)
+[![website](https://img.shields.io/badge/website-solana__kit__docs-0A7EA4.svg)](https://openbudgetfun.github.io/solana_kit/reference/package-catalog#solana_kit_transactions)
 [![CI](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openbudgetfun/solana_kit/actions/workflows/ci.yml)
 [![coverage](https://codecov.io/gh/openbudgetfun/solana_kit/branch/main/graph/badge.svg?flag=solana_kit_transactions)](https://codecov.io/gh/openbudgetfun/solana_kit?flag=solana_kit_transactions)
 


### PR DESCRIPTION
## Summary
- add missing package entries to the docs site package index and catalog
- point package README website badges at exact package catalog anchors
- add missing website badges for packages that did not have one

## Verification
- custom package/docs coverage script: 56 packages, 0 missing catalog/index entries, 0 bad website badge links
- devenv shell docs:check
- devenv shell lint:format
- devenv shell monochange check
- devenv shell lint:all