### PR TITLE
chore(devenv): bump nixpkgs to fix broken shell evaluation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Solana Kit is a multi-package Dart workspace that ports `@solana/kit` and relate
 - Keep affected public docs in sync when public APIs or behavior change.
 - Every package under `packages/*` must have a `LICENSE` (MIT) and `README.md` file. New packages must include both before their first publish. The README must describe the package purpose, show usage examples, and list key APIs. Use badges for pub.dev, CI, and coverage. See `packages/solana_kit_compute_budget/README.md` for the canonical structure.
 - New packages must start at `version: 0.0.0` in their `pubspec.yaml` with a `major` changeset. This ensures the first release lands at `0.1.0` (the minimum viable publishable version). Never set an unpublished package to a higher version.
+- Never push commits, edit files, or rebase generated release pull requests (branches matching `monochange/release/**`, e.g. `monochange/release/step-open-release-request`). These PRs are produced by the release tooling and must stay untouched. If a generated release PR fails CI, fix the root cause on `main` (or the appropriate feature branch) and let the release PR pick up the change on its next regeneration. Re-running failed checks (`gh run rerun`) and merging are allowed; modifying the PR content is not.
 
 ## Task-specific guides
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -95,11 +95,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783604885,
-        "narHash": "sha256-tzMgSkV7kljEkqIjlgV6F+n+xD+/a35Db8bs7a4BFAo=",
+        "lastModified": 1786410043,
+        "narHash": "sha256-JTbODJPDcd3d8U7lO4MVUU3Yo0jz2KQSAHXka+IWBEo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "767b0d3ec98a143ad9ed7dfc0d5553510ac27133",
+        "rev": "8e2eeb9477c9d40009a5bd51cd3eef2f5abb26f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

CI is failing on every job that uses the devenv shell (e.g. the `coverage` job on PR #199) during shell evaluation:

```
• Evaluating shell
✖ Evaluating shell in 472ms (failed)
error: path '/nix/store/8k5y1zg5cg3y2pjn9fh8l5ln28rq6gdy-aarch64-sve-rtx.patch' is not valid
```

### Root cause

The `nixpkgs-unstable` revision pinned in `devenv.lock` (`767b0d3…`) sits in the broken window between two nixpkgs commits:

- `eb7592e` bumped GCC 15 to 15.3.0 and removed `pkgs/development/compilers/gcc/patches/15/aarch64-sve-rtx.patch`, but `gcc15` still referenced it.
- `478605f` reverted the bump and restored the patch.

Evaluating anything that pulls in `gcc15` fails because the referenced patch file is missing from that nixpkgs tree.

### Fix

`devenv update nixpkgs` → nixpkgs rev `8e2eeb9477c9d40009a5bd51cd3eef2f5abb26f1` (past the revert). Verified locally that `devenv shell -- bash -c 'echo OK'` now evaluates and runs. Minimal diff: only the `nixpkgs` lock node changes (rev, narHash, lastModified).

Also adds a repo-wide rule to `AGENTS.md`: never edit generated release PRs (`monochange/release/**`). Fixes for failing release PRs belong on `main` so the release PR picks them up on regeneration.

### Not a changeset

No files under `packages/*` change, so no `.changeset/*.md` is required.