### PR TITLE
chore(release): fail fast when no GitHub token is available

### DIFF
--- a/monochange.toml
+++ b/monochange.toml
@@ -361,6 +361,7 @@ inputs = [
   { name = "publish_release", help_text = "Whether to publish the GitHub release object for the release tag", type = "boolean", default = false },
 ]
 steps = [
+  { type = "Command", name = "check GitHub token", command = "{ [ -n \"${GH_TOKEN:-}\" ] || [ -n \"${GITHUB_TOKEN:-}\" ] || { command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; }; } || { echo 'No GitHub token found. Set GH_TOKEN or GITHUB_TOKEN, or run: gh auth login. Aborting release to avoid a partial state.' >&2; exit 1; }" },
   { type = "PrepareRelease", name = "plan release", allow_empty_changesets = true },
   { type = "Command", name = "sync dependency versions", when = "{{ number_of_changesets > 0 }}", command = "monochange versions sync" },
   { type = "Command", name = "update flutter lockfiles", when = "{{ number_of_changesets > 0 }}", command = "flutter pub get" },


### PR DESCRIPTION
## Summary

Adds a `Command` step at the very start of `[cli.release]` in `monochange.toml`, **before `PrepareRelease``, that aborts the release if no GitHub token is reachable.

## Why

The release workflow authenticates late (`CommitRelease`/`TagRelease`/`PublishRelease`). If no token is available, earlier steps can partially succeed (versions planned, files synced, lockfiles regenerated, even committed) before a later step fails on auth — leaving a botched half-release. The recent v0.6.0 release hit a version of this class of problem.

## What the check does

```sh
{ [ -n "${GH_TOKEN:-}" ] || [ -n "${GITHUB_TOKEN:-}" ] || { command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; }; } \
  || { echo 'No GitHub token found. Set GH_TOKEN or GITHUB_TOKEN, or run: gh auth login. Aborting release to avoid a partial state.' >&2; exit 1; }
```

- Passes if `GH_TOKEN` or `GITHUB_TOKEN` is set and non-empty (CI path).
- Passes if the `gh` CLI is authenticated (local maintainer path).
- Otherwise exits non-zero with a clear message before any release state is created.

## Verification

- `monochange step validate` → workspace validation passed.
- Behavior tested directly:
  - gh authenticated → exit 0 ✅
  - no env tokens + gh not authed → exit 1 with message ✅
  - `GH_TOKEN` set + no gh → exit 0 ✅

## Notes

- No `packages/*` files change, so no changeset is required.
- This complements (but does not replace) the broader release-pipeline fixes still needed: the PAT `workflow` scope for auto-triggering `publish.yml`, the group-tag vs independent-version publish mismatch, and making `publish GitHub releases` resilient (`if: always()`).