### PR TITLE
🐛 fix(surfpool): isolate each Surfnet in its own working directory

### DIFF
--- a/.changeset/surfpool-instance-isolation.md
+++ b/.changeset/surfpool-instance-isolation.md
@@ -1,0 +1,27 @@
+---
+"solana_kit_surfpool": patch
+---
+
+# Isolate each Surfnet's runtime state in its own working directory
+
+`Surfnet.startWithConfig` (and therefore `Surfnet.start`,
+`createSurfpoolClient`, and the integration-test environment) now runs the
+`surfpool start` process in a dedicated per-instance temporary working
+directory instead of the caller's current directory.
+
+The `surfpool` CLI writes its runtime state — log files, validator keypairs,
+ledger, and other `.surfpool/` files — next to its working directory. When
+several Surfnets started concurrently (e.g. parallel test files under
+`test:all`, which runs all packages in one process with up to 12-way
+concurrency), those instances raced on the shared `.surfpool` directory: one
+instance's startup cleanup could delete another's freshly-created directory,
+making `surfpool start` exit with `Failed to create log file
+.surfpool/logs/...: unable to create parent directory .surfpool/logs` before
+the readiness check.
+
+Each instance now gets its own working directory, so concurrent Surfnets can
+never clobber each other's state. The temporary directory is removed when the
+instance is stopped (including when startup fails). Artifact discovery for
+`deployProgram` is unaffected: it still resolves `target/deploy/` from the
+caller-provided (or current) directory, independent of the process working
+directory.

--- a/packages/solana_kit_surfpool/lib/src/surfnet.dart
+++ b/packages/solana_kit_surfpool/lib/src/surfnet.dart
@@ -41,11 +41,14 @@ class Surfnet {
     required http.Client client,
     required bool closeClientOnStop,
     Process? process,
+    Directory? processWorkingDirectory,
   }) : _payerSecretKey = Uint8List.fromList(payerSecretKey),
        _client = client,
        // ignore: prefer_initializing_formals
        _closeClientOnStop = closeClientOnStop,
        _process = process,
+       // ignore: prefer_initializing_formals
+       _processWorkingDirectory = processWorkingDirectory,
        _exitCodeFuture = process?.exitCode,
        _rpcClient = SurfpoolJsonRpcClient(url: rpcUri, client: client) {
     final exitCodeFuture = _exitCodeFuture;
@@ -100,7 +103,10 @@ class Surfnet {
   /// Starts a CLI-backed Surfnet with [config].
   ///
   /// This mirrors the upstream JS `Surfnet.startWithConfig` shape but uses a
-  /// separate `surfpool start` process instead of native napi bindings.
+  /// separate `surfpool start` process instead of native napi bindings. The
+  /// process runs in a dedicated temporary working directory per instance, so
+  /// multiple Surfnets can run concurrently without racing on the `.surfpool`
+  /// runtime state the CLI creates next to its working directory.
   static Future<Surfnet> startWithConfig(
     SurfnetConfig config, {
     String command = 'surfpool',
@@ -125,10 +131,26 @@ class Surfnet {
       payer: payerInfo.publicKey,
     );
 
+    Directory? processWorkingDirectory;
     final Process process;
     try {
-      process = await Process.start(command, args);
+      // Run each Surfnet in its own working directory so concurrent instances
+      // never race on the shared `.surfpool` runtime state the CLI creates in
+      // its working directory (log files, validator keypairs, ledger, ...).
+      processWorkingDirectory = await Directory.systemTemp.createTemp(
+        'surfpool-instance-',
+      );
+      process = await Process.start(
+        command,
+        args,
+        workingDirectory: processWorkingDirectory.path,
+      );
     } on Object catch (error) {
+      try {
+        await processWorkingDirectory?.delete(recursive: true);
+      } on Object {
+        // Best-effort cleanup of the abandoned temp directory.
+      }
       throw SurfnetProcessException(
         'Failed to start `$command start`',
         cause: error,
@@ -145,6 +167,7 @@ class Surfnet {
       client: effectiveClient,
       closeClientOnStop: client == null,
       process: process,
+      processWorkingDirectory: processWorkingDirectory,
     ).._captureProcessOutput(process);
 
     try {
@@ -191,6 +214,14 @@ class Surfnet {
   final http.Client _client;
   final bool _closeClientOnStop;
   final Process? _process;
+
+  /// Working directory the CLI-backed process runs in, when one was spawned.
+  ///
+  /// Each instance gets its own directory so that concurrent Surfnets never
+  /// race on the shared `.surfpool` runtime state the CLI writes next to its
+  /// working directory. Removed when this instance is stopped.
+  final Directory? _processWorkingDirectory;
+
   final Future<int>? _exitCodeFuture;
   final SurfpoolJsonRpcClient _rpcClient;
   int? _exitCode;
@@ -229,6 +260,16 @@ class Surfnet {
 
     await _stdoutSubscription?.cancel();
     await _stderrSubscription?.cancel();
+
+    final workingDirectory = _processWorkingDirectory;
+    if (workingDirectory != null) {
+      try {
+        await workingDirectory.delete(recursive: true);
+      } on Object {
+        // Best-effort cleanup of the Surfnet runtime state; the OS will
+        // eventually reap the temp directory if deletion fails here.
+      }
+    }
 
     if (_closeClientOnStop) {
       _client.close();


### PR DESCRIPTION
## Summary

Fixes the flaky CI failure on `main` (run 31963550752, job 95205090206): `SurfpoolClient createSurfpoolClient wires a fresh Surfnet with a funded payer` intermittently failed with

```
Error: Failed to create log file .surfpool/logs/simnet_2026-08-16--18-10-24.log: unable to create parent directory .surfpool/logs
```

## Root cause

`test:all` runs all 59 test directories in a single Dart test process with up to 12-way concurrency. Multiple surfpool tests spawn `surfpool start` concurrently, and `Surfnet.startWithConfig` launched the process with **no working directory** — so every instance shared the repo-root CWD and raced on the `.surfpool` directory the CLI creates there. One instance's startup cleanup could delete another's freshly-created `.surfpool`, making the non-recursive `create_dir(".surfpool/logs")` fail with ENOENT before the readiness check.

## Fix

`Surfnet.startWithConfig` now runs each `surfpool start` process in a dedicated per-instance temporary working directory (`Directory.systemTemp.createTemp('surfpool-instance-')`), passed as `workingDirectory` to `Process.start`. The directory is removed when the instance is stopped — including when startup fails. Concurrent Surfnets are now fully isolated and can never clobber each other's runtime state.

- Covers all spawn sites (`Surfnet.start`, `createSurfpoolClient`, integration-test env) since they all route through `startWithConfig`
- `deployProgram` artifact discovery is unaffected (it resolves `target/deploy/` from the caller-provided/current directory, independent of the process CWD)
- Verified: surfpool suite passes at `-j 4` and `-j 12` (CI's concurrency cap); no leftover temp dirs after stop; repo-root `.surfpool` no longer accumulates logs

## Changeset

`.changeset/surfpool-instance-isolation.md` — `solana_kit_surfpool: patch`
