### PR TITLE
🐛 fix(security): harden recent SDK changes

### DIFF
--- a/.changeset/security-audit-recent-merges.md
+++ b/.changeset/security-audit-recent-merges.md
@@ -1,0 +1,26 @@
+---
+"codama-renderers-dart": patch
+"solana_kit_helius": patch
+"solana_kit_keys": patch
+"solana_kit_mobile_wallet_adapter_protocol": patch
+"solana_kit_rpc_subscriptions": patch
+"solana_kit_rpc_subscriptions_channel_websocket": patch
+"solana_kit_surfpool": patch
+"solana_kit_transaction_introspection": patch
+---
+
+# Harden credentials, keys, transports, and untrusted RPC decoding
+
+Align Helius signup and project provisioning with the v3 bearer-JWT API,
+generate valid Ed25519 authentication keypairs, validate payment inputs, and
+redact WebSocket credentials.
+
+Dispose or clear SDK-owned key material deterministically, create key files
+exclusively with safe POSIX permissions, and preserve caller ownership of
+Surfpool signers.
+
+Reject malformed RPC transaction and inner-instruction data instead of
+silently dropping it, expand private WebSocket literal filtering, and update
+JavaScript dependency overrides to releases without the audited advisories.
+Make the standalone Codama renderer workspace declare its own build tools and
+explicitly allow only esbuild's required install script.

--- a/docs/agents/security-audit-2026-08-17.md
+++ b/docs/agents/security-audit-2026-08-17.md
@@ -37,7 +37,7 @@ changes.
   20 known vulnerabilities (13 high, 4 medium, 3 low); the remediated scan
   reports zero.
 - Ran analyzer/lint, dependency, upstream, package regression, and workspace
-  benchmark checks. The full workspace run passed 6,730 tests with one
+  benchmark checks. The full workspace run passed 6,746 tests with one
   intentionally skipped test.
 - Manually searched security-sensitive boundaries: key generation/storage,
   signing, auth headers, URL construction, HTTP/WebSocket transport, process

--- a/docs/agents/security-audit-2026-08-17.md
+++ b/docs/agents/security-audit-2026-08-17.md
@@ -1,0 +1,206 @@
+# Security audit: recent merges and workspace review (2026-08-17)
+
+## Scope
+
+This review covered every pull request merged from 2026-07-17 through
+2026-08-17, the direct release commits in the same window, and a broader
+security pass over the workspace. No pull requests were closed without being
+merged during that period.
+
+Reviewed merged pull requests:
+
+- #198, #199: generated releases
+- #200: devenv/nixpkgs maintenance
+- #201, #202, #203: local release and token-check workflow changes
+- #204, #206: `@solana/kit` 7.0 and 7.1 parity ports
+- #205: Surfpool-backed integration tests
+- #207: Helius v3 auth, checkout, and payment helpers
+- #208, #211: Surfpool client and per-instance workdir lifecycle
+- #210: Bubblegum lifecycle and signer attachment
+
+The review also covered the direct release fixes between #198 and #199,
+including the trusted-publishing, direct-tag, release-tag, and aborted-publish
+changes.
+
+## Method
+
+- Inspected each merged diff, its discussion, and its first-parent integration
+  point. The recent pull requests had Codecov automation but no substantive
+  human review comments.
+- Compared Helius auth/payment code with `helius-labs/helius-sdk` v3.0.0 at
+  commit `4c0c55b86eab0e3abde7896c0aa23c4b6515e9b0`.
+- Checked the tracked `@solana/kit` 7.1.0 metadata, generated upstream parity
+  fixtures, and upstream commits after the pinned release.
+- Scanned all tracked history (585 commits at review time) with gitleaks; no
+  committed secrets were found.
+- Scanned every Dart and pnpm lockfile with OSV Scanner. The initial scan found
+  20 known vulnerabilities (13 high, 4 medium, 3 low); the remediated scan
+  reports zero.
+- Ran analyzer/lint, dependency, upstream, package regression, and workspace
+  benchmark checks. The full workspace run passed 6,730 tests with one
+  intentionally skipped test.
+- Manually searched security-sensitive boundaries: key generation/storage,
+  signing, auth headers, URL construction, HTTP/WebSocket transport, process
+  and temporary-directory lifecycle, untrusted RPC decoding, and release
+  publishing.
+
+## Findings fixed in this change
+
+### High: Helius generated invalid Ed25519 keypairs
+
+`AuthClient.generateKeypair()` generated 64 unrelated random bytes and treated
+the last 32 as a public key. The resulting value was almost never a valid
+Ed25519 keypair, despite the public API claiming otherwise. This originated in
+#34.
+
+The implementation now uses `solana_kit_keys.generateKeyPair`, emits the
+Solana CLI 64-byte private-seed/public-key format, validates it in regression
+tests by signing and verifying, and clears temporary key copies.
+
+### High: Helius project API keys were confused with bearer JWTs
+
+The v3 auth port in #207 called the legacy `/auth/wallet-signup` API and mapped
+its project API key to `jwt`. It then sent that value as an `Authorization:
+Bearer` credential to checkout APIs. Existing-project and post-payment
+provisioning also called legacy API-key-authenticated project endpoints instead
+of the v3 JWT endpoints.
+
+The flow now matches upstream:
+
+- `POST /v0/wallet-signup` with `message`, `signature`, and `userID`
+- use the returned `token` as the JWT and `refId` as the checkout reference
+- `GET /v0/projects` and `GET /v0/projects/:id` with the bearer JWT
+- `POST /v0/projects/:id/add-key` with the bearer JWT
+
+The code preserves the legacy Dart positional parameters for compatibility,
+but never reuses a project API key as a bearer token. It also validates plan,
+period, wallet address, contact fields, payment memo/intent consistency, and
+positive unsigned transfer amounts.
+
+### High: WebSocket SSRF filters were bypassable and Helius errors exposed URLs
+
+The literal-host protection introduced in #163 blocked only a subset of local
+ranges. Loopback addresses outside `127.0.0.1`, CGNAT, reserved ranges,
+alternate numeric IPv4 forms (`127.1`, integer, octal, hexadecimal),
+IPv4-mapped IPv6, IPv6 link-local, and multicast literals could pass. The
+separate `HeliusWebSocket` implementation did not apply private-host checks and
+included the full endpoint (commonly containing `api-key`) in connection error
+messages.
+
+The shared validator now rejects those non-public literal forms. The higher
+level RPC subscriptions factory now propagates an explicit
+`allowPrivateHosts` setting (the missing propagation previously broke local
+channels), Surfpool opts into it only for its local validator, and Helius uses
+the same policy. Helius also redacts endpoint credentials from connection
+errors.
+
+### Medium: RPC transaction introspection silently discarded malformed data
+
+The JSON decoder added in #204 used `whereType` and `continue` paths that
+silently dropped malformed accounts, instruction indices, table lookups, and
+inner instructions. `walkInstructions` appended inner groups that did not
+belong to any outer instruction. A malformed or mismatched RPC response could
+therefore be presented as a valid but different instruction/account trace.
+
+JSON transaction decoding now fails closed on mixed types, invalid header
+counts, unsupported versions, missing fields, invalid indices, malformed
+loaded addresses, and unmatched inner-instruction groups.
+
+### Medium: private-key lifecycle and key-file creation left avoidable exposure
+
+The key finalizer work in #159 did not dispose rejected key-grinding candidates,
+which can accumulate millions of private keys until GC. Key-file writes used a
+separate existence check and open, allowing a race, did not reject symbolic
+links on explicit overwrite, and ignored `chmod` failure. Helius signing,
+payment, and Surfpool lifecycle paths also retained temporary keypairs or
+secret-key copies longer than necessary.
+
+The changes:
+
+- dispose every rejected grind candidate immediately;
+- reduce redundant private-key copies;
+- create new key files exclusively, reject overwrite symlinks, require
+  successful POSIX mode `0600` before writing, and zero write buffers;
+- dispose temporary Helius signing/transfer keypairs and clear decoded keys;
+- clear Surfnet's owned payer-secret copy on every shutdown path;
+- dispose only payers owned by a freshly created `SurfpoolClient`, preserving
+  caller-owned signers passed to `connectSurfpoolClient`;
+- clear PointyCastle RNG seeds and duplicate decrypted plaintext buffers in the
+  mobile-wallet protocol.
+
+### Medium: known vulnerable JavaScript dependency graphs
+
+Both pnpm lockfiles contained vulnerable versions of `brace-expansion`,
+`esbuild`, `nanoid`, `postcss`, and `vite`. Workspace overrides now pin fixed
+releases in both the root and standalone renderer lockfiles. The only package
+with an install script, `esbuild`, is explicitly allowlisted instead of relying
+on pnpm's implicit or interactive build-script approval.
+
+## Pull-request review outcome
+
+- #204 and #206: the transaction-introspection fail-open paths above were the
+  material regression. Other v7/v7.1 migrations and generated packages did
+  not reveal an additional exploitable regression in this review.
+- #207: the JWT/API-key confusion, payment validation, key lifecycle, and URL
+  handling findings above were material.
+- #208 and #211: payer ownership/cleanup was the material lifecycle gap. The
+  per-instance workdir isolation itself correctly reduces cross-test state
+  collisions.
+- #210: signer attachment and Bubblegum lifecycle changes did not reveal an
+  exploitable regression. Manual signer promotion is intentional for generated
+  instruction account metadata.
+- #205: test-only changes did not introduce a production security boundary.
+- #198-#203 and direct release fixes: no credential was committed, actions are
+  pinned, release ancestry is checked, and npm publishing uses OIDC. No code
+  change is required from this audit.
+
+## Upstream status
+
+- `@solana/kit` 7.1.0 compatibility metadata and runtime fixtures pass.
+- The only functional upstream package commit after the tracked 7.1.0 commit
+  is `9f8e4d0` (avoid treating JavaScript protocol hooks as RPC methods). It is
+  specific to JavaScript `Proxy` property lookup and has no Dart analogue.
+- The Helius v3 JWT project/auth flow is now aligned with the pinned v3.0.0
+  source. The previous workspace audit's statement that auth/checkout/payment
+  primitives were still gaps was stale after #207 and is corrected in package
+  documentation.
+
+## Performance review
+
+No new asymptotic regression was found in the recent merges. Strict RPC
+validation remains linear in response size. Immediate grind-candidate disposal
+reduces peak private-key retention, and removing redundant byte copies reduces
+allocation pressure in key restoration. The workspace benchmarks complete;
+they cover address validation, BigInt JSON parsing, transaction compilation,
+and base64 wire encoding.
+
+## Residual risks and recommended follow-up
+
+1. **Helius smart-transaction façade (high correctness risk).** The legacy
+   `createSmartTransaction` helper only returns a recent blockhash, while
+   `sendSmartTransaction` submits the instruction list where Solana RPC expects
+   a serialized signed transaction. This does not match Helius v3. Replacing
+   it requires a deliberately breaking, typed API using `Instruction`,
+   `TransactionSigner`, compute-budget estimation, priority-fee capping, final
+   blockhash refresh, compilation, and signing. The README now warns callers
+   not to use these helpers for value transfers.
+2. **DNS-based SSRF and rebinding (medium).** Literal WebSocket destinations
+   are filtered, but portable Dart WebSocket APIs do not expose a resolved-IP
+   hook that can be pinned through connection. Applications must not accept
+   arbitrary endpoint hostnames from untrusted input. The generic HTTP RPC
+   transport likewise validates HTTPS but does not block private DNS/IP
+   destinations.
+3. **Transport resource bounds (medium).** Shared HTTP clients do not impose a
+   workspace-level timeout or maximum response size. Callers operating across
+   trust boundaries should provide a bounded `http.Client`; a future transport
+   change should add opt-in request deadlines and streaming response limits.
+4. **In-memory secret erasure is best effort (low).** Dart strings, immutable
+   `BigInt` private scalars in PointyCastle, cryptographic package internals,
+   and VM copies cannot be deterministically zeroed. The patch removes copies
+   under SDK control, but it cannot provide process-memory isolation.
+5. **Windows key-file ACLs (low).** POSIX writes require mode `0600`; Windows
+   relies on inherited ACLs. A future Windows-specific implementation should
+   create the file with an explicit user-only ACL.
+
+This review is a source and automated-tool audit, not a formal cryptographic
+proof or external penetration test.

--- a/docs/publishing-guide.md
+++ b/docs/publishing-guide.md
@@ -102,7 +102,7 @@ solana_kit_errors -> (none)
 solana_kit_fast_stable_stringify -> (none)
 solana_kit_fixed_points -> (none)
 solana_kit_functional -> (none)
-solana_kit_helius -> solana_kit_addresses, solana_kit_associated_token_account, solana_kit_codecs_strings, solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_rpc, solana_kit_signers, solana_kit_token, solana_kit_transaction_messages, solana_kit_transactions
+solana_kit_helius -> solana_kit_addresses, solana_kit_associated_token_account, solana_kit_codecs_strings, solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_rpc, solana_kit_rpc_subscriptions_channel_websocket, solana_kit_signers, solana_kit_token, solana_kit_transaction_messages, solana_kit_transactions
 solana_kit_instruction_plans -> solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_signers, solana_kit_transaction_messages, solana_kit_transactions
 solana_kit_instructions -> solana_kit_addresses, solana_kit_errors
 solana_kit_integration_tests -> solana_kit_accounts, solana_kit_address_constants, solana_kit_address_lookup_table, solana_kit_addresses, solana_kit_associated_token_account, solana_kit_codecs_core, solana_kit_compute_budget, solana_kit_config, solana_kit_errors, solana_kit_instructions, solana_kit_keys, solana_kit_loader, solana_kit_memo, solana_kit_mpl_bubblegum, solana_kit_rpc, solana_kit_rpc_api, solana_kit_rpc_spec, solana_kit_rpc_types, solana_kit_signers, solana_kit_stake, solana_kit_subscriptions, solana_kit_surfpool, solana_kit_system, solana_kit_token, solana_kit_token_2022, solana_kit_transaction_confirmation, solana_kit_transaction_messages, solana_kit_transactions

--- a/packages/codama-renderers-dart/package.json
+++ b/packages/codama-renderers-dart/package.json
@@ -9,7 +9,12 @@
   "devDependencies": {
     "@codama/nodes-from-anchor": "^1.3.9",
     "@codama/renderers-js": "^2.0.2",
-    "@vitest/coverage-v8": "4.1.0"
+    "@types/node": "25.3.0",
+    "@vitest/coverage-v8": "4.1.0",
+    "rimraf": "6.1.3",
+    "tsup": "8.5.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/codama-renderers-dart/pnpm-lock.yaml
+++ b/packages/codama-renderers-dart/pnpm-lock.yaml
@@ -5,11 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: 5.0.6
+  brace-expansion: 5.0.9
+  esbuild: 0.28.1
   minimatch: 10.2.3
+  nanoid: 3.3.18
   picomatch: 4.0.4
-  postcss: 8.5.10
-  vite: 7.3.2
+  postcss: 8.5.23
+  vite: 7.3.5
 
 importers:
 
@@ -30,13 +32,28 @@ importers:
     devDependencies:
       '@codama/nodes-from-anchor':
         specifier: ^1.3.9
-        version: 1.5.0
+        version: 1.5.0(typescript@5.9.3)
       '@codama/renderers-js':
         specifier: ^2.0.2
-        version: 2.2.0
+        version: 2.2.0(typescript@5.9.3)
+      '@types/node':
+        specifier: 25.3.0
+        version: 25.3.0
       '@vitest/coverage-v8':
         specifier: 4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.3.0)(vite@7.3.2(@types/node@25.3.0)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0)))
+      rimraf:
+        specifier: 6.1.3
+        version: 6.1.3
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(postcss@8.5.23)(supports-color@7.2.0)(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0))
 
 packages:
 
@@ -90,161 +107,164 @@ packages:
   '@codama/visitors@1.7.0':
     resolution: {integrity: sha512-wk8ufgX3AfKOnaok5H4y1UteLyY/WkDIhhKRE7y5MJqOn5JnxLgL9R4MU2+5TmZUF04sdwyUn6fPho0IqTq+BQ==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -536,7 +556,7 @@ packages:
     resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 7.3.2
+      vite: 7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -558,12 +578,38 @@ packages:
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
   ast-v8-to-istanbul@1.0.3:
     resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: 0.28.1
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -585,6 +631,10 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
@@ -593,8 +643,28 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -619,8 +689,8 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -640,6 +710,9 @@ packages:
       picomatch:
         optional: true
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -655,6 +728,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -693,6 +770,10 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -702,6 +783,21 @@ packages:
 
   jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -717,10 +813,31 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -728,6 +845,13 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -739,13 +863,51 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: 8.5.23
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
+    hasBin: true
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
     hasBin: true
 
   rollup@4.61.0:
@@ -769,18 +931,37 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
@@ -794,11 +975,45 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: 8.5.23
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -851,7 +1066,7 @@ packages:
       '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
-      vite: 7.3.2
+      vite: 7.3.5
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -906,13 +1121,13 @@ snapshots:
 
   '@codama/node-types@1.7.0': {}
 
-  '@codama/nodes-from-anchor@1.5.0':
+  '@codama/nodes-from-anchor@1.5.0(typescript@5.9.3)':
     dependencies:
       '@codama/errors': 1.7.0
       '@codama/nodes': 1.7.0
       '@codama/visitors': 1.7.0
       '@noble/hashes': 2.2.0
-      '@solana/codecs': 5.5.1
+      '@solana/codecs': 5.5.1(typescript@5.9.3)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
@@ -929,13 +1144,13 @@ snapshots:
       '@codama/nodes': 1.7.0
       '@codama/visitors-core': 1.7.0
 
-  '@codama/renderers-js@2.2.0':
+  '@codama/renderers-js@2.2.0(typescript@5.9.3)':
     dependencies:
       '@codama/errors': 1.7.0
       '@codama/nodes': 1.7.0
       '@codama/renderers-core': 1.3.8
       '@codama/visitors-core': 1.7.0
-      '@solana/codecs-strings': 6.9.0
+      '@solana/codecs-strings': 6.9.0(typescript@5.9.3)
       prettier: 3.8.3
       semver: 7.8.1
     transitivePeerDependencies:
@@ -954,83 +1169,88 @@ snapshots:
       '@codama/nodes': 1.7.0
       '@codama/visitors-core': 1.7.0
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -1118,69 +1338,91 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.61.0':
     optional: true
 
-  '@solana/codecs-core@5.5.1':
+  '@solana/codecs-core@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.5.1
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/codecs-core@6.9.0':
+  '@solana/codecs-core@6.9.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.9.0
+      '@solana/errors': 6.9.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/codecs-data-structures@5.5.1':
+  '@solana/codecs-data-structures@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1
-      '@solana/codecs-numbers': 5.5.1
-      '@solana/errors': 5.5.1
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/codecs-numbers@5.5.1':
+  '@solana/codecs-numbers@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1
-      '@solana/errors': 5.5.1
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/codecs-numbers@6.9.0':
+  '@solana/codecs-numbers@6.9.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.9.0
-      '@solana/errors': 6.9.0
+      '@solana/codecs-core': 6.9.0(typescript@5.9.3)
+      '@solana/errors': 6.9.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/codecs-strings@5.5.1':
+  '@solana/codecs-strings@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1
-      '@solana/codecs-numbers': 5.5.1
-      '@solana/errors': 5.5.1
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/codecs-strings@6.9.0':
+  '@solana/codecs-strings@6.9.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.9.0
-      '@solana/codecs-numbers': 6.9.0
-      '@solana/errors': 6.9.0
+      '@solana/codecs-core': 6.9.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.9.0(typescript@5.9.3)
+      '@solana/errors': 6.9.0(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/codecs@5.5.1':
+  '@solana/codecs@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1
-      '@solana/codecs-data-structures': 5.5.1
-      '@solana/codecs-numbers': 5.5.1
-      '@solana/codecs-strings': 5.5.1
-      '@solana/options': 5.5.1
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/options': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/errors@5.5.1':
+  '@solana/errors@5.5.1(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.2
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/errors@6.9.0':
+  '@solana/errors@6.9.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
       commander: 14.0.3
+    optionalDependencies:
+      typescript: 5.9.3
 
-  '@solana/options@5.5.1':
+  '@solana/options@5.5.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.5.1
-      '@solana/codecs-data-structures': 5.5.1
-      '@solana/codecs-numbers': 5.5.1
-      '@solana/codecs-strings': 5.5.1
-      '@solana/errors': 5.5.1
+      '@solana/codecs-core': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-data-structures': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 5.5.1(typescript@5.9.3)
+      '@solana/codecs-strings': 5.5.1(typescript@5.9.3)
+      '@solana/errors': 5.5.1(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
@@ -1198,9 +1440,8 @@ snapshots:
   '@types/node@25.3.0':
     dependencies:
       undici-types: 7.18.2
-    optional: true
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.3.0)(vite@7.3.2(@types/node@25.3.0)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -1212,7 +1453,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.3.0)(vite@7.3.2(@types/node@25.3.0))
+      vitest: 4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -1223,13 +1464,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.2(@types/node@25.3.0))':
+  '@vitest/mocker@4.1.0(vite@7.3.5(@types/node@25.3.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.3.0)
+      vite: 7.3.5(@types/node@25.3.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -1255,6 +1496,10 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  acorn@8.18.0: {}
+
+  any-promise@1.3.0: {}
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.3:
@@ -1262,6 +1507,19 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
+  bundle-require@5.1.0(esbuild@0.28.1):
+    dependencies:
+      esbuild: 0.28.1
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -1284,11 +1542,27 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   commander@14.0.2: {}
 
   commander@14.0.3: {}
 
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
   convert-source-map@2.0.0: {}
+
+  debug@4.4.3(supports-color@7.2.0):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   define-data-property@1.1.4:
     dependencies:
@@ -1312,34 +1586,34 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   estree-walker@3.0.3:
     dependencies:
@@ -1350,6 +1624,12 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.61.0
 
   fsevents@2.3.3:
     optional: true
@@ -1373,6 +1653,12 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.3
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   gopd@1.2.0: {}
 
@@ -1405,6 +1691,8 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  joycon@3.1.1: {}
+
   js-tokens@10.0.0: {}
 
   json-stable-stringify@1.3.0:
@@ -1416,6 +1704,14 @@ snapshots:
       object-keys: 1.1.1
 
   jsonify@0.0.1: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  lru-cache@11.5.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -1433,11 +1729,41 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  nanoid@3.3.12: {}
+  minimatch@10.2.3:
+    dependencies:
+      brace-expansion: 5.0.9
+
+  minipass@7.1.3: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.18: {}
+
+  object-assign@4.1.1: {}
 
   object-keys@1.1.1: {}
 
   obug@2.1.1: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -1445,13 +1771,36 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.10:
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
     dependencies:
-      nanoid: 3.3.12
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.23):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.23
+
+  postcss@8.5.23:
+    dependencies:
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   prettier@3.8.3: {}
+
+  readdirp@4.1.2: {}
+
+  resolve-from@5.0.0: {}
+
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.6
+      package-json-from-dist: 1.0.1
 
   rollup@4.61.0:
     dependencies:
@@ -1499,15 +1848,37 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.7.6: {}
+
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
   tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
 
   tinyexec@1.2.4: {}
 
@@ -1518,25 +1889,60 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  undici-types@7.18.2:
-    optional: true
+  tree-kill@1.2.2: {}
 
-  vite@7.3.2(@types/node@25.3.0):
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(postcss@8.5.23)(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
-      esbuild: 0.27.7
+      bundle-require: 5.1.0(esbuild@0.28.1)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3(supports-color@7.2.0)
+      esbuild: 0.28.1
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.23)
+      resolve-from: 5.0.0
+      rollup: 4.61.0
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.23
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
+
+  undici-types@7.18.2: {}
+
+  vite@7.3.5(@types/node@25.3.0):
+    dependencies:
+      esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.23
       rollup: 4.61.0
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.3.0
       fsevents: 2.3.3
 
-  vitest@4.1.0(@types/node@25.3.0)(vite@7.3.2(@types/node@25.3.0)):
+  vitest@4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.2(@types/node@25.3.0))
+      '@vitest/mocker': 4.1.0(vite@7.3.5(@types/node@25.3.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -1553,7 +1959,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.3.0)
+      vite: 7.3.5(@types/node@25.3.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.0

--- a/packages/codama-renderers-dart/pnpm-workspace.yaml
+++ b/packages/codama-renderers-dart/pnpm-workspace.yaml
@@ -1,8 +1,5 @@
 packages:
-  - packages/*
-
-useNodeVersion: 24.14.0
-nodeVersion: 24.14.0
+  - .
 
 overrides:
   brace-expansion: 5.0.9

--- a/packages/solana_kit_helius/README.md
+++ b/packages/solana_kit_helius/README.md
@@ -26,9 +26,9 @@ Helius client package for Solana Kit Dart. A Dart port of the [Helius TypeScript
 
 This package was audited against `helius-labs/helius-sdk` v3.0.0 at commit [`4c0c55b86eab0e3abde7896c0aa23c4b6515e9b0`](https://github.com/helius-labs/helius-sdk/commit/4c0c55b86eab0e3abde7896c0aa23c4b6515e9b0) (`chore(release): Update CHANGELOG (#330)`, 2026-05-30). Helius has not published a Git tag for that release, so this commit is the comparison baseline.
 
-The package covers the broad v3 surface: DAS, priority fees, RPC v2 including `getTransfersByAddress`, enhanced transactions, webhook CRUD/toggle, ZK compression, staking, wallet operations, Sender/smart transactions, auth/project basics, Admin project usage, and WebSocket subscriptions. The mainnet REST default follows v3's `https://api-mainnet.helius-rpc.com/v0` host, while devnet enhanced REST continues to use `https://api-devnet.helius.xyz/v0`.
+The package covers the broad v3 surface: DAS, priority fees, RPC v2 including `getTransfersByAddress`, enhanced transactions, webhook CRUD/toggle, ZK compression, staking, wallet operations, Sender, the v3 JWT-based signup/checkout/payment flow, Admin project usage, and WebSocket subscriptions. The mainnet REST default follows v3's `https://api-mainnet.helius-rpc.com/v0` host, while devnet enhanced REST continues to use `https://api-devnet.helius.xyz/v0`.
 
-Known v3 gaps to port next are the newer auth/checkout/payment primitives including `oauthTokenExchange`, smart-transaction tip helpers, and enhanced WebSocket account/transaction subscriptions.
+The legacy smart-transaction façade does not yet implement the v3 transaction-building contract: `createSmartTransaction` only fetches a blockhash and `sendSmartTransaction` does not compile or sign instructions. Do not use those two helpers to authorize value transfers. Prefer Solana Kit's transaction-message, signer, and Sender APIs until that surface is replaced. Remaining v3 gaps also include smart-transaction tip helpers and enhanced WebSocket account/transaction subscriptions.
 
 <!-- {=packageInstallSection:"solana_kit_helius"} -->
 
@@ -92,6 +92,29 @@ final txns = await helius.enhanced.getTransactions(
 );
 ```
 
+### Authenticated signup
+
+`signup` uses the developer API's wallet-signup response as a bearer JWT, then
+uses that JWT for project and checkout calls. Project API keys are only
+returned after subscription provisioning and are never reused as bearer
+tokens.
+
+```dart
+final result = await helius.auth.signup(
+  SignupRequest.secretKey(
+    secretKey: base64EncodedSolanaCliKeypair,
+    plan: 'developer',
+    email: 'ada@example.com',
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+  ),
+);
+```
+
+Only pay `PaymentLink` values received from a trusted Helius developer API.
+The payment helper rejects non-positive amounts, mismatched memo/intent IDs,
+and non-payment link kinds before constructing a transfer.
+
 ## Configuration
 
 ```dart
@@ -119,8 +142,11 @@ final helius = createHelius(
 
 ## WebSocket security defaults
 
-`HeliusWebSocket` enforces `wss://` URLs by default. Use `allowInsecureWs: true`
-only for local development and controlled tests.
+`HeliusWebSocket` enforces `wss://` URLs and rejects localhost plus non-public
+IP literals by default. Use `allowInsecureWs: true` and
+`allowPrivateHosts: true` only for local development and controlled tests.
+The private-host check does not resolve DNS names, so do not accept arbitrary
+WebSocket URLs from untrusted input.
 
 ## Testing strategy
 

--- a/packages/solana_kit_helius/lib/src/auth/auth_client.dart
+++ b/packages/solana_kit_helius/lib/src/auth/auth_client.dart
@@ -1,3 +1,4 @@
+import 'package:http/http.dart' as http;
 import 'package:solana_kit_helius/src/auth/check_balances.dart';
 import 'package:solana_kit_helius/src/auth/create_api_key.dart';
 import 'package:solana_kit_helius/src/auth/create_project.dart';
@@ -14,10 +15,15 @@ import 'package:solana_kit_helius/src/types/auth_types.dart';
 /// Client for Helius Auth API methods.
 class AuthClient {
   /// Creates an AuthClient backed by the given REST client and API key.
-  const AuthClient({required this._restClient, required this._apiKey});
+  const AuthClient({
+    required this._restClient,
+    required this._apiKey,
+    this._client,
+  });
 
   final RestClient _restClient;
   final String _apiKey;
+  final http.Client? _client;
 
   /// Performs a unified signup (v3.0.0). Replaces the legacy agenticSignup.
   ///
@@ -28,6 +34,7 @@ class AuthClient {
     _restClient,
     _apiKey,
     request,
+    httpClient: _client,
   );
 
   /// Performs a wallet signup with signature verification.

--- a/packages/solana_kit_helius/lib/src/auth/build_token_transfer.dart
+++ b/packages/solana_kit_helius/lib/src/auth/build_token_transfer.dart
@@ -52,67 +52,86 @@ Future<String> buildAndSendTokenTransfer(
   JsonRpcClient? rpcClient,
   http.Client? client,
 }) async {
-  final keyPair = createKeyPairFromBytes(params.secretKey);
-  final signerAddress = Address(
-    getBase58Decoder().decode(keyPair.publicKey),
-  );
-  final recipient = Address(params.recipientAddress);
-  final mint = Address(params.mintAddress);
-
-  final (senderAta, _) = await findAssociatedTokenPda(
-    seeds: AssociatedTokenSeeds(
-      owner: signerAddress,
-      tokenProgram: tokenProgramAddress,
-      mint: mint,
-    ),
-  );
-  final (receiverAta, _) = await findAssociatedTokenPda(
-    seeds: AssociatedTokenSeeds(
-      owner: recipient,
-      tokenProgram: tokenProgramAddress,
-      mint: mint,
-    ),
-  );
-
-  final transferInstruction = getTransferInstruction(
-    programAddress: tokenProgramAddress,
-    source: senderAta,
-    destination: receiverAta,
-    authority: signerAddress,
-    amount: params.amount,
-  );
-
-  // Fetch a recent blockhash for the transaction lifetime.
-  final effectiveRpc = rpcClient;
-  if (effectiveRpc == null) {
-    throw StateError('An RPC client is required to fetch a recent blockhash.');
+  if (params.amount <= BigInt.zero || params.amount.bitLength > 64) {
+    throw ArgumentError.value(
+      params.amount,
+      'params.amount',
+      'must be a positive unsigned 64-bit integer',
+    );
   }
-  final blockhashResult = await effectiveRpc.call('getLatestBlockhash');
-  final blockhashValue =
-      (blockhashResult! as Map<String, Object?>)['value']!
-          as Map<String, Object?>;
-  final blockhash = blockhashValue['blockhash']! as String;
+  final keyPair = createKeyPairFromBytes(params.secretKey);
+  try {
+    final signerAddress = Address(
+      getBase58Decoder().decode(keyPair.publicKey),
+    );
+    final recipient = Address(params.recipientAddress);
+    final mint = Address(params.mintAddress);
 
-  var message = createTransactionMessage(version: TransactionVersion.v0);
-  message = setTransactionMessageFeePayer(signerAddress, message);
-  message = setTransactionMessageLifetimeUsingBlockhash(
-    BlockhashLifetimeConstraint(
-      blockhash: blockhash,
-      lastValidBlockHeight: BigInt.from(
-        blockhashValue['lastValidBlockHeight']! as int,
+    final (senderAta, _) = await findAssociatedTokenPda(
+      seeds: AssociatedTokenSeeds(
+        owner: signerAddress,
+        tokenProgram: tokenProgramAddress,
+        mint: mint,
       ),
-    ),
-    message,
-  );
-  message = appendTransactionMessageInstructions(
-    [transferInstruction, ...params.additionalInstructions],
-    message,
-  );
+    );
+    final (receiverAta, _) = await findAssociatedTokenPda(
+      seeds: AssociatedTokenSeeds(
+        owner: recipient,
+        tokenProgram: tokenProgramAddress,
+        mint: mint,
+      ),
+    );
 
-  final transaction = compileTransaction(message);
-  final signed = await signTransaction([keyPair], transaction);
-  final encoded = getTransactionEncoder().encode(signed);
-  final base64Tx = base64Encode(encoded);
+    final transferInstruction = getTransferInstruction(
+      programAddress: tokenProgramAddress,
+      source: senderAta,
+      destination: receiverAta,
+      authority: signerAddress,
+      amount: params.amount,
+    );
 
-  return sendViaSender(base64Tx, client: client);
+    // Fetch a recent blockhash for the transaction lifetime.
+    final effectiveRpc = rpcClient;
+    if (effectiveRpc == null) {
+      throw StateError(
+        'An RPC client is required to fetch a recent blockhash.',
+      );
+    }
+    final blockhashResult = await effectiveRpc.call('getLatestBlockhash');
+    final blockhashValue =
+        (blockhashResult! as Map<String, Object?>)['value']!
+            as Map<String, Object?>;
+    final blockhash = blockhashValue['blockhash']! as String;
+    final lastValidBlockHeight =
+        switch (blockhashValue['lastValidBlockHeight']) {
+          final BigInt value => value,
+          final int value => BigInt.from(value),
+          final Object? value => throw FormatException(
+            'Invalid lastValidBlockHeight: $value',
+          ),
+        };
+
+    var message = createTransactionMessage(version: TransactionVersion.v0);
+    message = setTransactionMessageFeePayer(signerAddress, message);
+    message = setTransactionMessageLifetimeUsingBlockhash(
+      BlockhashLifetimeConstraint(
+        blockhash: blockhash,
+        lastValidBlockHeight: lastValidBlockHeight,
+      ),
+      message,
+    );
+    message = appendTransactionMessageInstructions(
+      [transferInstruction, ...params.additionalInstructions],
+      message,
+    );
+
+    final transaction = compileTransaction(message);
+    final signed = await signTransaction([keyPair], transaction);
+    final encoded = getTransactionEncoder().encode(signed);
+    final base64Tx = base64Encode(encoded);
+
+    return sendViaSender(base64Tx, client: client);
+  } finally {
+    keyPair.dispose();
+  }
 }

--- a/packages/solana_kit_helius/lib/src/auth/checkout.dart
+++ b/packages/solana_kit_helius/lib/src/auth/checkout.dart
@@ -383,7 +383,7 @@ Future<CheckoutInitializeResponse> getPaymentIntent(
   http.Client? client,
   String baseUrl = heliusDeveloperApiUrl,
 }) => _authRequest(
-  '/checkout/$paymentIntentId',
+  '/checkout/${Uri.encodeComponent(paymentIntentId)}',
   CheckoutInitializeResponse.fromJson,
   jwt: jwt,
   method: 'GET',
@@ -399,7 +399,7 @@ Future<CheckoutStatusResponse> getPaymentStatus(
   http.Client? client,
   String baseUrl = heliusDeveloperApiUrl,
 }) => _authRequest(
-  '/checkout/$paymentIntentId/status',
+  '/checkout/${Uri.encodeComponent(paymentIntentId)}/status',
   CheckoutStatusResponse.fromJson,
   jwt: jwt,
   method: 'GET',
@@ -494,6 +494,7 @@ String _planNameFor(String? plan, String period, String? fallback) {
 
 Future<PaymentLink> createPayment(
   CreatePaymentRequest req, {
+  String? userAgent,
   http.Client? client,
   String baseUrl = heliusDeveloperApiUrl,
 }) async {
@@ -507,6 +508,7 @@ Future<PaymentLink> createPayment(
         req.jwt,
         req.plan!,
         req.period,
+        userAgent: userAgent,
         client: client,
         baseUrl: baseUrl,
       );
@@ -518,6 +520,7 @@ Future<PaymentLink> createPayment(
             req.period,
             req.refId,
             couponCode: req.couponCode,
+            userAgent: userAgent,
             client: client,
             baseUrl: baseUrl,
           )
@@ -527,6 +530,7 @@ Future<PaymentLink> createPayment(
             req.refId,
             couponCode: req.couponCode,
             qty: req.qty,
+            userAgent: userAgent,
             client: client,
             baseUrl: baseUrl,
           );
@@ -551,6 +555,7 @@ Future<PaymentLink> createPayment(
       couponCode: req.couponCode,
       qty: req.qty,
     ),
+    userAgent: userAgent,
     client: client,
     baseUrl: baseUrl,
   );

--- a/packages/solana_kit_helius/lib/src/auth/developer_api.dart
+++ b/packages/solana_kit_helius/lib/src/auth/developer_api.dart
@@ -1,0 +1,259 @@
+// ignore_for_file: public_member_api_docs
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_helius/src/auth/oauth_token_exchange.dart';
+
+final class DeveloperSignupResponse {
+  const DeveloperSignupResponse({
+    required this.token,
+    required this.refId,
+    required this.newUser,
+  });
+
+  factory DeveloperSignupResponse.fromJson(Map<String, Object?> json) {
+    return DeveloperSignupResponse(
+      token: _requireString(json, 'token'),
+      refId: _requireString(json, 'refId'),
+      newUser: _requireBool(json, 'newUser'),
+    );
+  }
+
+  final String token;
+  final String refId;
+  final bool newUser;
+}
+
+final class DeveloperSubscription {
+  const DeveloperSubscription({
+    required this.plan,
+    required this.billingPeriodStart,
+    required this.billingPeriodEnd,
+  });
+
+  factory DeveloperSubscription.fromJson(Map<String, Object?> json) {
+    return DeveloperSubscription(
+      plan: _requireString(json, 'plan'),
+      billingPeriodStart: _requireString(json, 'billingPeriodStart'),
+      billingPeriodEnd: _requireString(json, 'billingPeriodEnd'),
+    );
+  }
+
+  final String plan;
+  final String billingPeriodStart;
+  final String billingPeriodEnd;
+}
+
+final class DeveloperProjectSummary {
+  const DeveloperProjectSummary({required this.id, required this.subscription});
+
+  factory DeveloperProjectSummary.fromJson(Map<String, Object?> json) {
+    return DeveloperProjectSummary(
+      id: _requireString(json, 'id'),
+      subscription: DeveloperSubscription.fromJson(
+        _requireMap(json, 'subscription'),
+      ),
+    );
+  }
+
+  final String id;
+  final DeveloperSubscription subscription;
+}
+
+final class DeveloperApiKey {
+  const DeveloperApiKey({required this.keyId});
+
+  factory DeveloperApiKey.fromJson(Map<String, Object?> json) {
+    return DeveloperApiKey(keyId: _requireString(json, 'keyId'));
+  }
+
+  final String keyId;
+}
+
+final class DeveloperProjectDetails {
+  const DeveloperProjectDetails({required this.apiKeys});
+
+  factory DeveloperProjectDetails.fromJson(Map<String, Object?> json) {
+    final rawApiKeys = json['apiKeys'];
+    if (rawApiKeys is! List) {
+      throw const FormatException('Expected apiKeys to be an array');
+    }
+    return DeveloperProjectDetails(
+      apiKeys: rawApiKeys
+          .map((value) => DeveloperApiKey.fromJson(_asMap(value)))
+          .toList(growable: false),
+    );
+  }
+
+  final List<DeveloperApiKey> apiKeys;
+}
+
+Future<DeveloperSignupResponse> developerWalletSignup({
+  required String message,
+  required String signature,
+  required String walletAddress,
+  String? userAgent,
+  http.Client? client,
+  String baseUrl = heliusDeveloperApiUrl,
+}) async {
+  final result = await _developerApiRequest(
+    const ['wallet-signup'],
+    method: 'POST',
+    body: <String, Object?>{
+      'message': message,
+      'signature': signature,
+      'userID': walletAddress,
+    },
+    userAgent: userAgent,
+    client: client,
+    baseUrl: baseUrl,
+  );
+  return DeveloperSignupResponse.fromJson(_asMap(result));
+}
+
+Future<List<DeveloperProjectSummary>> developerListProjects(
+  String jwt, {
+  String? userAgent,
+  http.Client? client,
+  String baseUrl = heliusDeveloperApiUrl,
+}) async {
+  final result = await _developerApiRequest(
+    const ['projects'],
+    jwt: jwt,
+    userAgent: userAgent,
+    client: client,
+    baseUrl: baseUrl,
+  );
+  if (result is! List) {
+    throw const FormatException('Expected projects to be an array');
+  }
+  return result
+      .map((value) => DeveloperProjectSummary.fromJson(_asMap(value)))
+      .toList(growable: false);
+}
+
+Future<DeveloperProjectDetails> developerGetProject(
+  String jwt,
+  String projectId, {
+  String? userAgent,
+  http.Client? client,
+  String baseUrl = heliusDeveloperApiUrl,
+}) async {
+  final result = await _developerApiRequest(
+    ['projects', projectId],
+    jwt: jwt,
+    userAgent: userAgent,
+    client: client,
+    baseUrl: baseUrl,
+  );
+  return DeveloperProjectDetails.fromJson(_asMap(result));
+}
+
+Future<DeveloperApiKey> developerCreateApiKey(
+  String jwt,
+  String projectId,
+  String walletAddress, {
+  String? userAgent,
+  http.Client? client,
+  String baseUrl = heliusDeveloperApiUrl,
+}) async {
+  final result = await _developerApiRequest(
+    ['projects', projectId, 'add-key'],
+    jwt: jwt,
+    method: 'POST',
+    body: <String, Object?>{'userId': walletAddress},
+    userAgent: userAgent,
+    client: client,
+    baseUrl: baseUrl,
+  );
+  return DeveloperApiKey.fromJson(_asMap(result));
+}
+
+Future<Object?> _developerApiRequest(
+  List<String> pathSegments, {
+  String? jwt,
+  String method = 'GET',
+  Object? body,
+  String? userAgent,
+  http.Client? client,
+  String baseUrl = heliusDeveloperApiUrl,
+}) async {
+  final baseUri = Uri.parse(baseUrl);
+  if (!baseUri.isAbsolute || baseUri.host.isEmpty) {
+    throw ArgumentError.value(baseUrl, 'baseUrl', 'must be an absolute URL');
+  }
+  if (baseUri.scheme != 'https' && baseUri.scheme != 'http') {
+    throw ArgumentError.value(
+      baseUrl,
+      'baseUrl',
+      'must use the https or http scheme',
+    );
+  }
+  final uri = baseUri.replace(
+    pathSegments: [
+      ...baseUri.pathSegments.where((segment) => segment.isNotEmpty),
+      ...pathSegments,
+    ],
+  );
+  final httpClient = client ?? http.Client();
+  final closeClient = client == null;
+  try {
+    final userAgentHeader = userAgent == null
+        ? null
+        : <String, String>{'User-Agent': userAgent};
+    final headers = <String, String>{
+      'accept': 'application/json',
+      if (body != null) 'content-type': 'application/json',
+      if (jwt != null) 'Authorization': 'Bearer $jwt',
+      ...?userAgentHeader,
+    };
+    final response = method == 'POST'
+        ? await httpClient.post(
+            uri,
+            headers: headers,
+            body: body == null ? null : jsonEncode(body),
+          )
+        : await httpClient.get(uri, headers: headers);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final responseMessage = response.body.length <= 4096
+          ? response.body
+          : '${response.body.substring(0, 4096)}…';
+      throw createSolanaError(
+        SolanaErrorCode.heliusRestError,
+        context: {
+          SolanaErrorContextKeys.operation: 'heliusDeveloperAuth',
+          SolanaErrorContextKeys.statusCode: response.statusCode,
+          'message': responseMessage,
+        },
+      );
+    }
+    return jsonDecode(response.body);
+  } finally {
+    if (closeClient) httpClient.close();
+  }
+}
+
+Map<String, Object?> _asMap(Object? value) {
+  if (value is! Map) throw const FormatException('Expected a JSON object');
+  return Map<String, Object?>.from(value);
+}
+
+Map<String, Object?> _requireMap(Map<String, Object?> json, String key) {
+  return _asMap(json[key]);
+}
+
+String _requireString(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! String || value.isEmpty) {
+    throw FormatException('Expected $key to be a non-empty string');
+  }
+  return value;
+}
+
+bool _requireBool(Map<String, Object?> json, String key) {
+  final value = json[key];
+  if (value is! bool) throw FormatException('Expected $key to be a boolean');
+  return value;
+}

--- a/packages/solana_kit_helius/lib/src/auth/generate_keypair.dart
+++ b/packages/solana_kit_helius/lib/src/auth/generate_keypair.dart
@@ -1,27 +1,30 @@
 import 'dart:convert';
-import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:solana_kit_helius/src/types/auth_types.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
 
 /// Generates a new Ed25519 keypair for authentication.
 ///
-/// Uses [Random.secure] to generate a 64-byte secret key. The public key is
-/// derived as the last 32 bytes of the secret key. Both keys are returned as
+/// The secret key uses Solana CLI format: the 32-byte Ed25519 private seed
+/// followed by its derived 32-byte public key. Both values are returned as
 /// base64-encoded strings.
-///
-/// Note: In a full implementation, this would use proper Ed25519 key
-/// derivation. The current implementation generates random bytes as a
-/// placeholder.
 KeypairResult authGenerateKeypair() {
-  final random = Random.secure();
-  final secretKey = Uint8List(64);
-  for (var i = 0; i < 64; i++) {
-    secretKey[i] = random.nextInt(256);
+  final keyPair = generateKeyPair();
+  final privateKey = keyPair.privateKey;
+  final publicKey = keyPair.publicKey;
+  final secretKey = Uint8List(64)
+    ..setRange(0, 32, privateKey)
+    ..setRange(32, 64, publicKey);
+  try {
+    return KeypairResult(
+      publicKey: base64Encode(publicKey),
+      secretKey: base64Encode(secretKey),
+    );
+  } finally {
+    privateKey.fillRange(0, privateKey.length, 0);
+    publicKey.fillRange(0, publicKey.length, 0);
+    secretKey.fillRange(0, secretKey.length, 0);
+    keyPair.dispose();
   }
-  final publicKey = Uint8List.sublistView(secretKey, 32);
-  return KeypairResult(
-    publicKey: base64Encode(publicKey),
-    secretKey: base64Encode(secretKey),
-  );
 }

--- a/packages/solana_kit_helius/lib/src/auth/payment_url.dart
+++ b/packages/solana_kit_helius/lib/src/auth/payment_url.dart
@@ -12,11 +12,11 @@ String resolvePaymentHost({
 }) {
   final explicit = override;
   if (explicit != null && explicit.isNotEmpty) {
-    return _stripTrailingSlash(explicit);
+    return _validatePaymentHost(explicit);
   }
 
   final value = (environment ?? Platform.environment)['HELIUS_PAYMENT_HOST'];
-  if (value != null && value.isNotEmpty) return _stripTrailingSlash(value);
+  if (value != null && value.isNotEmpty) return _validatePaymentHost(value);
 
   return heliusPaymentHost;
 }
@@ -24,8 +24,28 @@ String resolvePaymentHost({
 /// Builds a payment URL for the given [paymentIntentId], optionally overriding
 /// the host.
 String buildPaymentUrl(String paymentIntentId, {String? hostOverride}) {
-  return '${resolvePaymentHost(override: hostOverride)}/pay/$paymentIntentId';
+  final encodedId = Uri.encodeComponent(paymentIntentId);
+  return '${resolvePaymentHost(override: hostOverride)}/pay/$encodedId';
 }
 
 String _stripTrailingSlash(String value) =>
     value.endsWith('/') ? value.substring(0, value.length - 1) : value;
+
+String _validatePaymentHost(String value) {
+  final normalized = _stripTrailingSlash(value);
+  final uri = Uri.tryParse(normalized);
+  if (uri == null ||
+      !uri.isAbsolute ||
+      uri.host.isEmpty ||
+      (uri.scheme != 'https' && uri.scheme != 'http') ||
+      uri.userInfo.isNotEmpty ||
+      uri.query.isNotEmpty ||
+      uri.fragment.isNotEmpty) {
+    throw ArgumentError.value(
+      value,
+      'paymentHost',
+      'must be an absolute HTTP(S) origin without credentials, query, or fragment',
+    );
+  }
+  return normalized;
+}

--- a/packages/solana_kit_helius/lib/src/auth/payments.dart
+++ b/packages/solana_kit_helius/lib/src/auth/payments.dart
@@ -40,9 +40,14 @@ Future<String> payWithMemo(
   JsonRpcClient? rpcClient,
   http.Client? client,
 }) {
-  final signerAddress = Address(
-    getBase58Decoder().decode(createKeyPairFromBytes(secretKey).publicKey),
-  );
+  _assertValidTransferAmount(amount);
+  final keyPair = createKeyPairFromBytes(secretKey);
+  late final Address signerAddress;
+  try {
+    signerAddress = Address(getBase58Decoder().decode(keyPair.publicKey));
+  } finally {
+    keyPair.dispose();
+  }
   final memoInstruction = Instruction(
     programAddress: const Address(memoProgramId),
     accounts: [
@@ -72,6 +77,25 @@ Future<String> payPaymentLink(
   JsonRpcClient? rpcClient,
   http.Client? client,
 }) {
+  if (paymentLink.kind != 'payment_required') {
+    throw ArgumentError.value(
+      paymentLink.kind,
+      'paymentLink.kind',
+      'must be payment_required',
+    );
+  }
+  if (paymentLink.memo != paymentLink.paymentIntentId) {
+    throw ArgumentError(
+      'paymentLink.memo must match paymentLink.paymentIntentId',
+    );
+  }
+  if (paymentLink.amountCents <= 0) {
+    throw ArgumentError.value(
+      paymentLink.amountCents,
+      'paymentLink.amountCents',
+      'must be positive',
+    );
+  }
   final rawAmount = BigInt.from(paymentLink.amountCents) * _centsToUsdcRaw;
   return payWithMemo(
     secretKey,
@@ -81,4 +105,14 @@ Future<String> payPaymentLink(
     rpcClient: rpcClient,
     client: client,
   );
+}
+
+void _assertValidTransferAmount(BigInt amount) {
+  if (amount <= BigInt.zero || amount.bitLength > 64) {
+    throw ArgumentError.value(
+      amount,
+      'amount',
+      'must be a positive unsigned 64-bit integer',
+    );
+  }
 }

--- a/packages/solana_kit_helius/lib/src/auth/plan_management.dart
+++ b/packages/solana_kit_helius/lib/src/auth/plan_management.dart
@@ -3,9 +3,8 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:solana_kit_helius/src/auth/checkout.dart';
 import 'package:solana_kit_helius/src/auth/constants.dart';
-import 'package:solana_kit_helius/src/auth/create_api_key.dart';
-import 'package:solana_kit_helius/src/auth/get_project.dart';
-import 'package:solana_kit_helius/src/auth/list_projects.dart';
+import 'package:solana_kit_helius/src/auth/developer_api.dart';
+import 'package:solana_kit_helius/src/auth/oauth_token_exchange.dart';
 import 'package:solana_kit_helius/src/auth/payment_url.dart';
 import 'package:solana_kit_helius/src/auth/payments.dart';
 import 'package:solana_kit_helius/src/auth/signup.dart';
@@ -27,6 +26,8 @@ Future<UpgradePlanResult> upgradePlan(
   String? lastName,
   String? couponCode,
   String? paymentHost,
+  String? userAgent,
+  String baseUrl = heliusDeveloperApiUrl,
   http.Client? client,
 }) async {
   final paymentLink = await createPayment(
@@ -41,7 +42,9 @@ Future<UpgradePlanResult> upgradePlan(
       couponCode: couponCode,
       paymentHost: paymentHost,
     ),
+    userAgent: userAgent,
     client: client,
+    baseUrl: baseUrl,
   );
   return UpgradePlanResult(paymentLink: paymentLink);
 }
@@ -53,12 +56,16 @@ Future<PayRenewalResult> payRenewal(
   String jwt,
   String paymentIntentId, {
   String? paymentHost,
+  String? userAgent,
+  String baseUrl = heliusDeveloperApiUrl,
   http.Client? client,
 }) async {
   final intent = await getPaymentIntent(
     jwt,
     paymentIntentId,
+    userAgent: userAgent,
     client: client,
+    baseUrl: baseUrl,
   );
   if (intent.status != 'pending') {
     throw StateError(
@@ -85,16 +92,23 @@ Future<PayRenewalResult> payRenewal(
 /// api key, and endpoints.
 Future<({String projectId, String apiKey, SignupEndpoints endpoints})>
 _provisionApiKey(
-  RestClient restClient,
-  String apiKey,
+  String jwt,
   String walletAddress, {
+  String? userAgent,
+  http.Client? client,
+  String baseUrl = heliusDeveloperApiUrl,
   Duration timeout = const Duration(milliseconds: projectPollTimeoutMs),
   Duration interval = const Duration(milliseconds: projectPollIntervalMs),
 }) async {
   final deadline = DateTime.now().add(timeout);
   String? projectId;
   while (DateTime.now().isBefore(deadline)) {
-    final projects = await authListProjects(restClient, apiKey);
+    final projects = await developerListProjects(
+      jwt,
+      userAgent: userAgent,
+      client: client,
+      baseUrl: baseUrl,
+    );
     if (projects.isNotEmpty) {
       projectId = projects.first.id;
       break;
@@ -107,15 +121,22 @@ _provisionApiKey(
       'Payment confirmed but no project was provisioned within timeout.',
     );
   }
-  final details = await authGetProject(restClient, apiKey, projectId);
-  var provisionedApiKey = details.apiKey;
-  if (provisionedApiKey.isEmpty) {
-    provisionedApiKey = (await authCreateApiKey(
-      restClient,
-      apiKey,
-      CreateApiKeyRequest(projectId: projectId, name: walletAddress),
-    )).key;
-  }
+  final details = await developerGetProject(
+    jwt,
+    projectId,
+    userAgent: userAgent,
+    client: client,
+    baseUrl: baseUrl,
+  );
+  var provisionedApiKey = details.apiKeys.firstOrNull?.keyId;
+  provisionedApiKey ??= (await developerCreateApiKey(
+    jwt,
+    projectId,
+    walletAddress,
+    userAgent: userAgent,
+    client: client,
+    baseUrl: baseUrl,
+  )).keyId;
   return (
     projectId: projectId,
     apiKey: provisionedApiKey,
@@ -142,13 +163,14 @@ Future<SignupAndPayResult> signupAndPay(
     milliseconds: projectPollIntervalMs,
   ),
 }) async {
+  final effectiveBaseUrl = baseUrl ?? heliusDeveloperApiUrl;
   final result = await authSignup(
     restClient,
     apiKey,
     options,
     userAgent: userAgent,
     httpClient: client,
-    baseUrl: baseUrl,
+    baseUrl: effectiveBaseUrl,
   );
   if (result is AlreadySubscribedResult) {
     return SignupAndPayAlreadySubscribedResult(
@@ -182,14 +204,17 @@ Future<SignupAndPayResult> signupAndPay(
     paymentIntentId,
     userAgent: userAgent,
     client: client,
+    baseUrl: effectiveBaseUrl,
     timeout: pollTimeout,
     interval: pollInterval,
   );
   if (outcome.kind == 'completed') {
     final provisioned = await _provisionApiKey(
-      restClient,
-      apiKey,
+      paymentRequired.jwt,
       paymentRequired.walletAddress,
+      userAgent: userAgent,
+      client: client,
+      baseUrl: effectiveBaseUrl,
       timeout: provisionTimeout,
       interval: provisionInterval,
     );

--- a/packages/solana_kit_helius/lib/src/auth/sign_auth_message.dart
+++ b/packages/solana_kit_helius/lib/src/auth/sign_auth_message.dart
@@ -17,15 +17,24 @@ Future<SignAuthMessageResponse> signAuthMessage(
   SignAuthMessageRequest request,
 ) async {
   final secretKey = base64Decode(request.secretKey);
-  final keyPair = createKeyPairFromBytes(Uint8List.fromList(secretKey));
-  final message = request.message ?? _createAuthMessage(request.timestamp);
-  final messageBytes = Uint8List.fromList(utf8.encode(message));
-  final signatureBytes = signBytes(keyPair.privateKey, messageBytes);
+  KeyPair? keyPair;
+  Uint8List? privateKey;
+  try {
+    keyPair = createKeyPairFromBytes(Uint8List.fromList(secretKey));
+    final message = request.message ?? _createAuthMessage(request.timestamp);
+    final messageBytes = Uint8List.fromList(utf8.encode(message));
+    privateKey = keyPair.privateKey;
+    final signatureBytes = signBytes(privateKey, messageBytes);
 
-  return SignAuthMessageResponse(
-    message: message,
-    signature: _encodeBase58(signatureBytes.value),
-  );
+    return SignAuthMessageResponse(
+      message: message,
+      signature: _encodeBase58(signatureBytes.value),
+    );
+  } finally {
+    secretKey.fillRange(0, secretKey.length, 0);
+    privateKey?.fillRange(0, privateKey.length, 0);
+    keyPair?.dispose();
+  }
 }
 
 String _encodeBase58(Uint8List bytes) => getBase58Decoder().decode(bytes);

--- a/packages/solana_kit_helius/lib/src/auth/signup.dart
+++ b/packages/solana_kit_helius/lib/src/auth/signup.dart
@@ -1,13 +1,15 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
 import 'package:solana_kit_helius/src/auth/checkout.dart';
-import 'package:solana_kit_helius/src/auth/keypair_helpers.dart';
-import 'package:solana_kit_helius/src/auth/list_projects.dart';
+import 'package:solana_kit_helius/src/auth/developer_api.dart';
 import 'package:solana_kit_helius/src/auth/oauth_token_exchange.dart';
+import 'package:solana_kit_helius/src/auth/plan_catalog.dart';
 import 'package:solana_kit_helius/src/auth/sign_auth_message.dart';
 import 'package:solana_kit_helius/src/auth/signup_helpers.dart';
-import 'package:solana_kit_helius/src/auth/wallet_signup.dart';
 import 'package:solana_kit_helius/src/internal/rest_client.dart';
 import 'package:solana_kit_helius/src/types/auth_types.dart';
 
@@ -32,53 +34,93 @@ String _validatePlan(String plan) {
   return normalized;
 }
 
+String _validatePeriod(String period) {
+  final normalized = period.toLowerCase();
+  if (normalized != 'monthly' && normalized != 'yearly') {
+    throw ArgumentError.value(
+      period,
+      'period',
+      'must be either monthly or yearly',
+    );
+  }
+  return normalized;
+}
+
+bool _isBlank(String? value) => value == null || value.trim().isEmpty;
+
 /// Authenticates the wallet and returns JWT, refId, and wallet address.
 ///
 /// If the request is pre-authenticated (jwt provided), returns those directly.
 /// Otherwise, performs wallet signup using the secret key.
 ///
-/// Dart adaptation: the upstream `/wallet-signup` returns `{token, refId}`
-/// while our `/v0/auth/wallet-signup` returns `{apiKey, projectId}`. We map
-/// `apiKey → jwt` and `projectId → refId` for checkout compatibility.
+/// The secret-key path uses the upstream developer API's `/wallet-signup`
+/// response directly. A project API key is never reused as a bearer JWT.
 Future<Map<String, String>> _authenticate(
-  RestClient restClient,
-  String apiKey,
   SignupRequest options,
-  String? userAgent,
-) async {
+  String? userAgent, {
+  required String baseUrl,
+  http.Client? client,
+}) async {
   // Pre-authenticated path
   if (options.jwt != null) {
+    if (options.jwt!.isEmpty || options.refId!.isEmpty) {
+      throw ArgumentError('jwt and refId must not be empty');
+    }
+    final walletAddress = Address(options.walletAddress!);
     return {
       'jwt': options.jwt!,
       'refId': options.refId!,
-      'walletAddress': options.walletAddress!,
+      'walletAddress': walletAddress.value,
     };
   }
 
   // Secret key path — sign and do wallet signup
   final secretKeyBytes = base64Decode(options.secretKey!);
-  final keypairResult = loadKeypair(secretKeyBytes);
-  final walletAddress = await getAddress(keypairResult);
-  final signResponse = await signAuthMessage(
-    SignAuthMessageRequest(secretKey: options.secretKey!),
-  );
-
-  final authResponse = await authWalletSignup(
-    restClient,
-    apiKey,
-    WalletSignupRequest(
-      walletAddress: walletAddress,
-      signature: signResponse.signature,
+  try {
+    if (secretKeyBytes.length != 64) {
+      throw ArgumentError.value(
+        secretKeyBytes.length,
+        'secretKey',
+        'must decode to 64 bytes',
+      );
+    }
+    final publicKey = Uint8List.sublistView(secretKeyBytes, 32, 64);
+    final walletAddress = getBase58Decoder().decode(publicKey);
+    final signResponse = await signAuthMessage(
+      SignAuthMessageRequest(secretKey: options.secretKey!),
+    );
+    final authResponse = await developerWalletSignup(
       message: signResponse.message ?? '',
-    ),
-  );
+      signature: signResponse.signature,
+      walletAddress: walletAddress,
+      userAgent: userAgent,
+      client: client,
+      baseUrl: baseUrl,
+    );
+    return {
+      'jwt': authResponse.token,
+      'refId': authResponse.refId,
+      'walletAddress': walletAddress,
+    };
+  } finally {
+    secretKeyBytes.fillRange(0, secretKeyBytes.length, 0);
+  }
+}
 
-  // Map apiKey → jwt, projectId → refId for checkout compatibility
-  return {
-    'jwt': authResponse.apiKey,
-    'refId': authResponse.projectId,
-    'walletAddress': walletAddress,
-  };
+bool _matchesExistingPlan(
+  DeveloperProjectSummary project,
+  String plan,
+  String period,
+) {
+  if (project.subscription.plan != planToUsagePlan[plan]) return false;
+  if (plan == 'agent') return true;
+  final start = DateTime.tryParse(project.subscription.billingPeriodStart);
+  final end = DateTime.tryParse(project.subscription.billingPeriodEnd);
+  if (start == null || end == null || !end.isAfter(start)) return false;
+  final days = end.difference(start).inHours / 24;
+  return period == 'yearly'
+      ? days >= 350 && days <= 380
+      : days >= 25 && days <= 35;
 }
 
 /// Phase 1 unified signup (v3.0.0).
@@ -98,28 +140,54 @@ Future<SignupResult> authSignup(
   String? baseUrl,
 }) async {
   final plan = _validatePlan(options.plan);
+  final period = _validatePeriod(options.period);
   final effectiveBaseUrl = baseUrl ?? heliusDeveloperApiUrl;
 
-  final auth = await _authenticate(restClient, apiKey, options, userAgent);
+  final auth = await _authenticate(
+    options,
+    userAgent,
+    client: httpClient,
+    baseUrl: effectiveBaseUrl,
+  );
   final jwt = auth['jwt']!;
   final refId = auth['refId']!;
   final walletAddress = auth['walletAddress']!;
 
   // Check for existing projects
-  final projects = await authListProjects(restClient, apiKey);
+  final projects = await developerListProjects(
+    jwt,
+    userAgent: userAgent,
+    client: httpClient,
+    baseUrl: effectiveBaseUrl,
+  );
   if (projects.isNotEmpty) {
     // User has an existing project — check if already on requested plan
     final project = projects.first;
 
-    // For agent plan, any existing project with an API key counts as subscribed
-    if (plan == 'agent' && project.apiKey.isNotEmpty) {
+    if (_matchesExistingPlan(project, plan, period)) {
+      final details = await developerGetProject(
+        jwt,
+        project.id,
+        userAgent: userAgent,
+        client: httpClient,
+        baseUrl: effectiveBaseUrl,
+      );
+      var projectApiKey = details.apiKeys.firstOrNull?.keyId;
+      projectApiKey ??= (await developerCreateApiKey(
+        jwt,
+        project.id,
+        walletAddress,
+        userAgent: userAgent,
+        client: httpClient,
+        baseUrl: effectiveBaseUrl,
+      )).keyId;
       return AlreadySubscribedResult(
         jwt: jwt,
         refId: refId,
         walletAddress: walletAddress,
         projectId: project.id,
-        apiKey: project.apiKey,
-        endpoints: buildEndpoints(project.apiKey),
+        apiKey: projectApiKey,
+        endpoints: buildEndpoints(projectApiKey),
       );
     }
 
@@ -128,7 +196,7 @@ Future<SignupResult> authSignup(
       jwt: jwt,
       refId: refId,
       walletAddress: walletAddress,
-      currentPlan: 'unknown',
+      currentPlan: project.subscription.plan,
       requestedPlan: plan,
     );
   }
@@ -136,13 +204,13 @@ Future<SignupResult> authSignup(
   // No existing project — must create a fresh payment intent.
   // Contact info is required by the backend at /checkout/initialize for
   // any new subscription, so we validate up front.
-  if (options.email == null ||
-      options.firstName == null ||
-      options.lastName == null) {
+  if (_isBlank(options.email) ||
+      _isBlank(options.firstName) ||
+      _isBlank(options.lastName)) {
     final missing = <String>[];
-    if (options.email == null) missing.add('email');
-    if (options.firstName == null) missing.add('firstName');
-    if (options.lastName == null) missing.add('lastName');
+    if (_isBlank(options.email)) missing.add('email');
+    if (_isBlank(options.firstName)) missing.add('firstName');
+    if (_isBlank(options.lastName)) missing.add('lastName');
     throw StateError(
       'Signup requires contact info. Missing: ${missing.join(', ')}.',
     );
@@ -153,7 +221,7 @@ Future<SignupResult> authSignup(
       jwt: jwt,
       refId: refId,
       plan: plan,
-      period: options.period,
+      period: period,
       email: options.email,
       firstName: options.firstName,
       lastName: options.lastName,
@@ -161,6 +229,7 @@ Future<SignupResult> authSignup(
       walletAddress: walletAddress,
       paymentHost: options.paymentHost,
     ),
+    userAgent: userAgent,
     client: httpClient,
     baseUrl: effectiveBaseUrl,
   );

--- a/packages/solana_kit_helius/lib/src/helius_client.dart
+++ b/packages/solana_kit_helius/lib/src/helius_client.dart
@@ -58,6 +58,7 @@ HeliusClient createHelius(HeliusConfig config, {http.Client? client}) {
         client: effectiveClient,
       ),
       apiKey: config.apiKey,
+      client: effectiveClient,
     ),
     admin: AdminClient(
       baseUrl: config.adminBaseUrl,

--- a/packages/solana_kit_helius/lib/src/websockets/helius_websocket.dart
+++ b/packages/solana_kit_helius/lib/src/websockets/helius_websocket.dart
@@ -2,6 +2,9 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_helius/src/internal/redact_url.dart';
+import 'package:solana_kit_rpc_subscriptions_channel_websocket/solana_kit_rpc_subscriptions_channel_websocket.dart'
+    show validateWebSocketUrl;
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 /// WebSocket client for Helius real-time subscriptions.
@@ -11,7 +14,11 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 /// [Stream] of notification payloads.
 class HeliusWebSocket {
   /// Creates a new [HeliusWebSocket] with the given WebSocket [url].
-  HeliusWebSocket({required this.url, this.allowInsecureWs = false});
+  HeliusWebSocket({
+    required this.url,
+    this.allowInsecureWs = false,
+    this.allowPrivateHosts = false,
+  });
 
   /// The Helius WebSocket endpoint URL.
   final String url;
@@ -21,6 +28,12 @@ class HeliusWebSocket {
   /// Defaults to `false`, which enforces `wss://` URLs. Set to `true` only
   /// for local development and controlled tests.
   final bool allowInsecureWs;
+
+  /// Whether to allow localhost and private or non-public IP literals.
+  ///
+  /// Defaults to `false`. Enable this only for controlled local development.
+  /// Hostnames are not DNS-resolved by this best-effort SSRF protection.
+  final bool allowPrivateHosts;
 
   WebSocketChannel? _channel;
   // The WebSocket stream subscription is cancelled by close() and _onDone().
@@ -44,6 +57,7 @@ class HeliusWebSocket {
     final uri = _validateAndNormalizeWebSocketUrl(
       url,
       allowInsecureWs: allowInsecureWs,
+      allowPrivateHosts: allowPrivateHosts,
     );
 
     try {
@@ -56,12 +70,12 @@ class HeliusWebSocket {
         onError: _onError,
         onDone: _onDone,
       );
-    } on Object catch (error) {
+    } on Object {
       _channel = null;
       _subscription = null;
       _isConnected = false;
       throw SolanaError(SolanaErrorCode.heliusWebSocketError, {
-        'message': 'Failed to connect to $uri: $error',
+        'message': 'Failed to connect to ${redactUrl(uri.toString())}.',
       });
     }
   }
@@ -259,38 +273,12 @@ String _unsubscribeMethodFor(String? subscribeMethod) {
 Uri _validateAndNormalizeWebSocketUrl(
   String url, {
   required bool allowInsecureWs,
+  required bool allowPrivateHosts,
 }) {
   final parsedUrl = Uri.parse(url);
-  final scheme = parsedUrl.scheme.toLowerCase();
-
-  if (!parsedUrl.isAbsolute || parsedUrl.host.isEmpty) {
-    throw ArgumentError.value(
-      url,
-      'url',
-      'Helius WebSocket URL must be an absolute URL.',
-    );
-  }
-
-  if (scheme == 'wss') {
-    return parsedUrl;
-  }
-
-  if (scheme == 'ws' && allowInsecureWs) {
-    return parsedUrl;
-  }
-
-  if (scheme == 'ws') {
-    throw ArgumentError.value(
-      url,
-      'url',
-      'Insecure WebSocket endpoints are disabled by default. '
-          'Use a wss:// URL or set allowInsecureWs: true for development.',
-    );
-  }
-
-  throw ArgumentError.value(
-    url,
-    'url',
-    "Helius WebSocket URL must use either 'wss' or 'ws'.",
+  return validateWebSocketUrl(
+    parsedUrl,
+    allowInsecureWs: allowInsecureWs,
+    allowPrivateHosts: allowPrivateHosts,
   );
 }

--- a/packages/solana_kit_helius/pubspec.yaml
+++ b/packages/solana_kit_helius/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   solana_kit_instructions: ^0.6.0
   solana_kit_keys: ^0.6.0
   solana_kit_rpc: ^0.6.0
+  solana_kit_rpc_subscriptions_channel_websocket: ^0.6.0
   solana_kit_signers: ^0.6.0
   solana_kit_token: ^0.6.0
   solana_kit_transaction_messages: ^0.6.0

--- a/packages/solana_kit_helius/test/auth/developer_api_test.dart
+++ b/packages/solana_kit_helius/test/auth/developer_api_test.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:solana_kit_helius/src/auth/developer_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('developer API', () {
+    test('rejects relative and non-HTTP base URLs', () async {
+      final client = MockClient((_) async => http.Response('{}', 200));
+
+      for (final baseUrl in ['/v0', 'ftp://developer.example/v0']) {
+        await expectLater(
+          developerListProjects('jwt', client: client, baseUrl: baseUrl),
+          throwsA(isA<ArgumentError>()),
+        );
+      }
+    });
+
+    test('uses an owned HTTP client and forwards the user agent', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+
+      final responseFuture = developerWalletSignup(
+        message: 'message',
+        signature: 'signature',
+        walletAddress: 'wallet',
+        userAgent: 'solana-kit-test',
+        baseUrl: 'http://${server.address.host}:${server.port}/v0',
+      );
+      final request = await server.first;
+      expect(request.method, 'POST');
+      expect(request.uri.path, '/v0/wallet-signup');
+      expect(
+        request.headers.value(HttpHeaders.userAgentHeader),
+        'solana-kit-test',
+      );
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.json
+        ..write(
+          jsonEncode({'token': 'jwt', 'refId': 'ref', 'newUser': true}),
+        );
+      await request.response.close();
+
+      final response = await responseFuture;
+      expect(response.token, 'jwt');
+      expect(response.refId, 'ref');
+      expect(response.newUser, isTrue);
+    });
+
+    test(
+      'reports bounded response bodies for developer API failures',
+      () async {
+        final longBody = List.filled(5000, 'x').join();
+        for (final body in ['denied', longBody]) {
+          final client = MockClient((_) async => http.Response(body, 403));
+          await expectLater(
+            developerListProjects(
+              'jwt',
+              client: client,
+              baseUrl: 'https://developer.example/v0',
+            ),
+            throwsA(
+              isA<SolanaError>()
+                  .having(
+                    (error) => error.code,
+                    'code',
+                    SolanaErrorCode.heliusRestError,
+                  )
+                  .having(
+                    (error) => error.context[SolanaErrorContextKeys.statusCode],
+                    'statusCode',
+                    403,
+                  )
+                  .having(
+                    (error) => error.context['message'],
+                    'message',
+                    body.length <= 4096
+                        ? body
+                        : '${List.filled(4096, 'x').join()}…',
+                  ),
+            ),
+          );
+        }
+      },
+    );
+
+    test('rejects empty required response fields', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'token': '', 'refId': 'ref', 'newUser': true}),
+          200,
+        ),
+      );
+
+      await expectLater(
+        developerWalletSignup(
+          message: 'message',
+          signature: 'signature',
+          walletAddress: 'wallet',
+          client: client,
+          baseUrl: 'https://developer.example/v0',
+        ),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/packages/solana_kit_helius/test/auth/generate_keypair_test.dart
+++ b/packages/solana_kit_helius/test/auth/generate_keypair_test.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:solana_kit_helius/solana_kit_helius.dart';
+import 'package:solana_kit_keys/solana_kit_keys.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -25,6 +29,20 @@ void main() {
       // Base64 strings contain only valid base64 characters.
       expect(keypair.publicKey, matches(RegExp(r'^[A-Za-z0-9+/]+=*$')));
       expect(keypair.secretKey, matches(RegExp(r'^[A-Za-z0-9+/]+=*$')));
+    });
+
+    test('returns a valid Ed25519 keypair', () {
+      final helius = createHelius(HeliusConfig(apiKey: 'test'));
+      final generated = helius.auth.generateKeypair();
+      final publicKey = base64Decode(generated.publicKey);
+      final secretKey = base64Decode(generated.secretKey);
+      final keyPair = createKeyPairFromBytes(secretKey);
+      addTearDown(keyPair.dispose);
+      final message = Uint8List.fromList([1, 2, 3]);
+      final signature = signBytes(keyPair.privateKey, message);
+
+      expect(publicKey, keyPair.publicKey);
+      expect(verifySignature(publicKey, signature, message), isTrue);
     });
   });
 }

--- a/packages/solana_kit_helius/test/auth/payment_url_test.dart
+++ b/packages/solana_kit_helius/test/auth/payment_url_test.dart
@@ -53,9 +53,24 @@ void main() {
     test('buildPaymentUrl composes host and payment intent id', () {
       expect(buildPaymentUrl('pi_abc'), '$heliusPaymentHost/pay/pi_abc');
       expect(
-        buildPaymentUrl('pi_xyz', hostOverride: 'https://staging.example.com'),
-        'https://staging.example.com/pay/pi_xyz',
+        buildPaymentUrl('pi/a b', hostOverride: 'https://staging.example.com'),
+        'https://staging.example.com/pay/pi%2Fa%20b',
       );
+    });
+
+    test('rejects payment hosts that are not HTTP origins', () {
+      for (final host in [
+        '/relative',
+        'ftp://example.com',
+        'https://user@example.com',
+        'https://example.com?token=secret',
+        'https://example.com#fragment',
+      ]) {
+        expect(
+          () => resolvePaymentHost(override: host),
+          throwsA(isA<ArgumentError>()),
+        );
+      }
     });
   });
 }

--- a/packages/solana_kit_helius/test/auth/payments_test.dart
+++ b/packages/solana_kit_helius/test/auth/payments_test.dart
@@ -11,7 +11,11 @@ import 'package:test/test.dart';
 
 Uint8List _secretKey() {
   final keyPair = generateKeyPair();
-  return Uint8List.fromList([...keyPair.privateKey, ...keyPair.publicKey]);
+  try {
+    return Uint8List.fromList([...keyPair.privateKey, ...keyPair.publicKey]);
+  } finally {
+    keyPair.dispose();
+  }
 }
 
 http.Client _rpcAndSenderClient() {
@@ -174,6 +178,49 @@ void main() {
         client: client,
       );
       expect(signature, 'sig123');
+    });
+
+    test('payWithMemo rejects non-positive and overflowing amounts', () {
+      for (final amount in [BigInt.zero, -BigInt.one, BigInt.one << 64]) {
+        expect(
+          () => payWithMemo(
+            _secretKey(),
+            '11111111111111111111111111111111',
+            amount,
+            'memo-1',
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      }
+    });
+
+    test('payPaymentLink rejects tampered checkout data', () {
+      const base = PaymentLink(
+        kind: 'payment_required',
+        paymentIntentId: 'pi-1',
+        amountCents: 100,
+        destinationWallet: '11111111111111111111111111111111',
+        memo: 'wrong-intent',
+        expiresAt: '2026-01-01',
+        paymentUrl: 'https://dashboard.helius.dev/pay/pi-1',
+        solanaPayUrl: 'solana:pi-1',
+        planName: 'developer',
+      );
+      expect(
+        () => payPaymentLink(_secretKey(), base),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => payPaymentLink(
+          _secretKey(),
+          PaymentLink.fromJson({
+            ...base.toJson(),
+            'memo': 'pi-1',
+            'amountCents': 0,
+          }),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
     });
   });
 

--- a/packages/solana_kit_helius/test/auth/payments_test.dart
+++ b/packages/solana_kit_helius/test/auth/payments_test.dart
@@ -194,6 +194,59 @@ void main() {
       }
     });
 
+    test(
+      'token transfer rejects invalid amounts at its public boundary',
+      () async {
+        for (final amount in [BigInt.zero, BigInt.one << 64]) {
+          await expectLater(
+            buildAndSendTokenTransfer(
+              TokenTransferParams(
+                secretKey: _secretKey(),
+                recipientAddress: 'unused',
+                mintAddress: 'unused',
+                amount: amount,
+              ),
+            ),
+            throwsA(isA<ArgumentError>()),
+          );
+        }
+      },
+    );
+
+    test('token transfer rejects a malformed lastValidBlockHeight', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({
+            'jsonrpc': '2.0',
+            'id': 1,
+            'result': {
+              'value': {
+                'blockhash': '11111111111111111111111111111111',
+                'lastValidBlockHeight': 'invalid',
+              },
+            },
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+      final rpc = JsonRpcClient(url: 'https://rpc', client: client);
+
+      await expectLater(
+        buildAndSendTokenTransfer(
+          TokenTransferParams(
+            secretKey: _secretKey(),
+            recipientAddress: '11111111111111111111111111111111',
+            mintAddress: '11111111111111111111111111111111',
+            amount: BigInt.one,
+          ),
+          rpcClient: rpc,
+          client: client,
+        ),
+        throwsFormatException,
+      );
+    });
+
     test('payPaymentLink rejects tampered checkout data', () {
       const base = PaymentLink(
         kind: 'payment_required',
@@ -208,6 +261,17 @@ void main() {
       );
       expect(
         () => payPaymentLink(_secretKey(), base),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => payPaymentLink(
+          _secretKey(),
+          PaymentLink.fromJson({
+            ...base.toJson(),
+            'kind': 'already_paid',
+            'memo': 'pi-1',
+          }),
+        ),
         throwsA(isA<ArgumentError>()),
       );
       expect(

--- a/packages/solana_kit_helius/test/auth/signup_test.dart
+++ b/packages/solana_kit_helius/test/auth/signup_test.dart
@@ -11,62 +11,31 @@ import 'package:test/test.dart';
 
 Uint8List _secretKey() {
   final keyPair = generateKeyPair();
-  return Uint8List.fromList([...keyPair.privateKey, ...keyPair.publicKey]);
+  try {
+    return Uint8List.fromList([...keyPair.privateKey, ...keyPair.publicKey]);
+  } finally {
+    keyPair.dispose();
+  }
 }
 
-Map<String, Object?> _project(String id, {String apiKey = 'proj-key'}) => {
+Map<String, Object?> _project(
+  String id, {
+  String plan = 'agent_v4',
+}) => {
   'id': id,
-  'name': 'My Project',
-  'apiKey': apiKey,
-  'createdAt': 1700000000,
+  'subscription': {
+    'plan': plan,
+    'billingPeriodStart': '2026-01-01',
+    'billingPeriodEnd': '2026-02-01',
+  },
 };
 
-/// REST mock for `/v0/auth/*` endpoints. [projects] is re-evaluated on every
-/// call so tests can model the project appearing after payment.
-RestClient _restClient(List<Map<String, Object?>> Function() projects) {
+RestClient _restClient() {
   return RestClient(
     baseUrl: 'https://dev-api.helius.xyz/v0',
-    client: MockClient((request) async {
-      final path = request.url.path;
-      if (path.endsWith('/v0/auth/projects') && request.method == 'GET') {
-        return http.Response(
-          jsonEncode(projects()),
-          200,
-          headers: {'content-type': 'application/json'},
-        );
-      }
-      if (path.contains('/v0/auth/projects/') && request.method == 'GET') {
-        final id = path.split('/').last;
-        return http.Response(
-          jsonEncode(_project(id, apiKey: '')),
-          200,
-          headers: {'content-type': 'application/json'},
-        );
-      }
-      if (path.endsWith('/v0/auth/wallet-signup') && request.method == 'POST') {
-        return http.Response(
-          jsonEncode({
-            'apiKey': 'jwt-from-signup',
-            'projectId': 'ref-from-signup',
-          }),
-          200,
-          headers: {'content-type': 'application/json'},
-        );
-      }
-      if (path.endsWith('/v0/auth/api-keys') && request.method == 'POST') {
-        return http.Response(
-          jsonEncode({
-            'id': 'k-1',
-            'key': 'new-key',
-            'name': 'wallet',
-            'createdAt': 1700000000,
-          }),
-          200,
-          headers: {'content-type': 'application/json'},
-        );
-      }
-      return http.Response('{"error":"not found"}', 404);
-    }),
+    client: MockClient(
+      (request) async => http.Response('legacy API used', 500),
+    ),
   );
 }
 
@@ -76,9 +45,51 @@ http.Client _checkoutClient({
   String phase = '',
   bool readyToRedirect = false,
   String? message,
+  List<Map<String, Object?>> Function()? projects,
+  String projectApiKey = 'proj-key',
+  void Function(http.Request request)? onRequest,
 }) {
   return MockClient((request) async {
+    onRequest?.call(request);
     final path = request.url.path;
+    if (path.endsWith('/v0/wallet-signup') && request.method == 'POST') {
+      return http.Response(
+        jsonEncode({
+          'token': 'jwt-from-signup',
+          'refId': 'ref-from-signup',
+          'newUser': true,
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (path.endsWith('/v0/projects') && request.method == 'GET') {
+      return http.Response(
+        jsonEncode(projects?.call() ?? const <Object?>[]),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (path.endsWith('/add-key') && request.method == 'POST') {
+      return http.Response(
+        jsonEncode({'keyId': 'new-key'}),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
+    if (path.contains('/v0/projects/') && request.method == 'GET') {
+      return http.Response(
+        jsonEncode({
+          'apiKeys': projectApiKey.isEmpty
+              ? const <Object?>[]
+              : [
+                  {'keyId': projectApiKey},
+                ],
+        }),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    }
     if (request.url.host == 'sender.helius-rpc.com') {
       return http.Response(
         jsonEncode('sig123'),
@@ -192,7 +203,7 @@ SignupRequest _preauthenticatedRequest({String plan = 'developer'}) =>
 void main() {
   group('authSignup', () {
     test('returns a payment link for a new signup', () async {
-      final rest = _restClient(() => []);
+      final rest = _restClient();
       final result = await authSignup(
         rest,
         'api-key',
@@ -211,11 +222,12 @@ void main() {
     test(
       'short-circuits with AlreadySubscribedResult for the agent plan',
       () async {
-        final rest = _restClient(() => [_project('p-1')]);
+        final rest = _restClient();
         final result = await authSignup(
           rest,
           'api-key',
           _preauthenticatedRequest(plan: 'agent'),
+          httpClient: _checkoutClient(projects: () => [_project('p-1')]),
         );
         expect(result, isA<AlreadySubscribedResult>());
         final subscribed = result as AlreadySubscribedResult;
@@ -231,21 +243,24 @@ void main() {
     test(
       'short-circuits with UpgradeRequiredResult for another plan',
       () async {
-        final rest = _restClient(() => [_project('p-1')]);
+        final rest = _restClient();
         final result = await authSignup(
           rest,
           'api-key',
           _preauthenticatedRequest(plan: 'business'),
+          httpClient: _checkoutClient(
+            projects: () => [_project('p-1', plan: 'developer_v4')],
+          ),
         );
         expect(result, isA<UpgradeRequiredResult>());
         final upgrade = result as UpgradeRequiredResult;
-        expect(upgrade.currentPlan, 'unknown');
+        expect(upgrade.currentPlan, 'developer_v4');
         expect(upgrade.requestedPlan, 'business');
       },
     );
 
     test('throws when contact info is missing for a new signup', () async {
-      final rest = _restClient(() => []);
+      final rest = _restClient();
       const request = SignupRequest.preauthenticated(
         jwt: 'jwt',
         refId: 'ref-1',
@@ -253,13 +268,18 @@ void main() {
         plan: 'developer',
       );
       expect(
-        () => authSignup(rest, 'api-key', request),
+        () => authSignup(
+          rest,
+          'api-key',
+          request,
+          httpClient: _checkoutClient(),
+        ),
         throwsA(isA<StateError>()),
       );
     });
 
     test('throws for an unknown plan', () async {
-      final rest = _restClient(() => []);
+      final rest = _restClient();
       expect(
         () => authSignup(
           rest,
@@ -270,8 +290,45 @@ void main() {
       );
     });
 
+    test('throws for an unknown billing period', () async {
+      final rest = _restClient();
+      const request = SignupRequest.preauthenticated(
+        jwt: 'jwt',
+        refId: 'ref-1',
+        walletAddress: '11111111111111111111111111111111',
+        plan: 'developer',
+        period: 'weekly',
+      );
+      expect(
+        () => authSignup(rest, 'api-key', request),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects empty contact fields for a new signup', () async {
+      final rest = _restClient();
+      const request = SignupRequest.preauthenticated(
+        jwt: 'jwt',
+        refId: 'ref-1',
+        walletAddress: '11111111111111111111111111111111',
+        plan: 'developer',
+        email: ' ',
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+      );
+      expect(
+        () => authSignup(
+          rest,
+          'api-key',
+          request,
+          httpClient: _checkoutClient(),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
     test('authenticates with a secret key when no JWT is provided', () async {
-      final rest = _restClient(() => []);
+      final rest = _restClient();
       final request = SignupRequest.secretKey(
         secretKey: base64Encode(_secretKey()),
         plan: 'developer',
@@ -279,27 +336,40 @@ void main() {
         firstName: 'Ada',
         lastName: 'Lovelace',
       );
+      http.Request? signupRequest;
       final result = await authSignup(
         rest,
         'api-key',
         request,
-        httpClient: _checkoutClient(),
+        httpClient: _checkoutClient(
+          onRequest: (request) {
+            if (request.url.path.endsWith('/v0/wallet-signup')) {
+              signupRequest = request;
+            }
+          },
+        ),
       );
       expect(result, isA<PaymentRequiredResult>());
       final payment = result as PaymentRequiredResult;
       expect(payment.jwt, 'jwt-from-signup');
       expect(payment.refId, 'ref-from-signup');
+      expect(signupRequest?.url.queryParameters, isEmpty);
+      expect(signupRequest?.headers['Authorization'], isNull);
+      final signupBody =
+          jsonDecode(signupRequest!.body) as Map<String, Object?>;
+      expect(signupBody.keys, containsAll(['message', 'signature', 'userID']));
     });
   });
 
   group('signupAndPay', () {
     test('returns AlreadySubscribedResult for the agent plan', () async {
-      final rest = _restClient(() => [_project('p-1')]);
+      final rest = _restClient();
       final result = await signupAndPay(
         rest,
         'api-key',
         _preauthenticatedRequest(plan: 'agent'),
         secretKey: _secretKey(),
+        client: _checkoutClient(projects: () => [_project('p-1')]),
       );
       expect(result, isA<SignupAndPayAlreadySubscribedResult>());
       final subscribed = result as SignupAndPayAlreadySubscribedResult;
@@ -308,12 +378,15 @@ void main() {
     });
 
     test('returns UpgradeRequiredResult for another plan', () async {
-      final rest = _restClient(() => [_project('p-1')]);
+      final rest = _restClient();
       final result = await signupAndPay(
         rest,
         'api-key',
         _preauthenticatedRequest(plan: 'business'),
         secretKey: _secretKey(),
+        client: _checkoutClient(
+          projects: () => [_project('p-1', plan: 'developer_v4')],
+        ),
       );
       expect(result, isA<SignupAndPayUpgradeRequiredResult>());
       final upgrade = result as SignupAndPayUpgradeRequiredResult;
@@ -322,17 +395,23 @@ void main() {
 
     test('provisions a project after a completed payment', () async {
       var projectCalls = 0;
-      final rest = _restClient(() {
+      final rest = _restClient();
+      List<Map<String, Object?>> projects() {
         projectCalls++;
-        return projectCalls <= 2 ? [] : [_project('p-1', apiKey: '')];
-      });
+        return projectCalls <= 2 ? [] : [_project('p-1')];
+      }
+
       final result = await signupAndPay(
         rest,
         'api-key',
         _preauthenticatedRequest(),
         secretKey: _secretKey(),
         rpcClient: _rpcClient(),
-        client: _checkoutClient(readyToRedirect: true),
+        client: _checkoutClient(
+          readyToRedirect: true,
+          projects: projects,
+          projectApiKey: '',
+        ),
       );
       expect(result, isA<SignupAndPayCompletedResult>());
       final completed = result as SignupAndPayCompletedResult;
@@ -347,7 +426,7 @@ void main() {
     });
 
     test('throws when no project is provisioned before the timeout', () async {
-      final rest = _restClient(() => []);
+      final rest = _restClient();
       await expectLater(
         signupAndPay(
           rest,
@@ -370,7 +449,7 @@ void main() {
     });
 
     test('returns ExpiredResult when the payment expires', () async {
-      final rest = _restClient(() => []);
+      final rest = _restClient();
       final result = await signupAndPay(
         rest,
         'api-key',
@@ -384,7 +463,7 @@ void main() {
     });
 
     test('returns FailedResult when the payment fails', () async {
-      final rest = _restClient(() => []);
+      final rest = _restClient();
       final result = await signupAndPay(
         rest,
         'api-key',
@@ -398,7 +477,7 @@ void main() {
     });
 
     test('returns PendingResult when the poll times out', () async {
-      final rest = _restClient(() => []);
+      final rest = _restClient();
       final result = await signupAndPay(
         rest,
         'api-key',
@@ -419,8 +498,9 @@ void main() {
   group('AuthClient', () {
     test('signup delegates to authSignup', () async {
       final client = AuthClient(
-        restClient: _restClient(() => [_project('p-1')]),
+        restClient: _restClient(),
         apiKey: 'api-key',
+        client: _checkoutClient(projects: () => [_project('p-1')]),
       );
       final result = await client.signup(
         _preauthenticatedRequest(plan: 'agent'),

--- a/packages/solana_kit_helius/test/auth/signup_test.dart
+++ b/packages/solana_kit_helius/test/auth/signup_test.dart
@@ -21,12 +21,14 @@ Uint8List _secretKey() {
 Map<String, Object?> _project(
   String id, {
   String plan = 'agent_v4',
+  String billingPeriodStart = '2026-01-01',
+  String billingPeriodEnd = '2026-02-01',
 }) => {
   'id': id,
   'subscription': {
     'plan': plan,
-    'billingPeriodStart': '2026-01-01',
-    'billingPeriodEnd': '2026-02-01',
+    'billingPeriodStart': billingPeriodStart,
+    'billingPeriodEnd': billingPeriodEnd,
   },
 };
 
@@ -258,6 +260,81 @@ void main() {
         expect(upgrade.requestedPlan, 'business');
       },
     );
+
+    test('matches monthly and yearly existing subscriptions', () async {
+      final rest = _restClient();
+      final cases = <({String period, String start, String end})>[
+        (period: 'monthly', start: '2026-01-01', end: '2026-02-01'),
+        (period: 'yearly', start: '2026-01-01', end: '2027-01-01'),
+      ];
+
+      for (final entry in cases) {
+        final request = SignupRequest.preauthenticated(
+          jwt: 'jwt',
+          refId: 'ref-1',
+          walletAddress: '11111111111111111111111111111111',
+          plan: 'developer',
+          period: entry.period,
+        );
+        final result = await authSignup(
+          rest,
+          'api-key',
+          request,
+          httpClient: _checkoutClient(
+            projects: () => [
+              _project(
+                'p-1',
+                plan: 'developer_v4',
+                billingPeriodStart: entry.start,
+                billingPeriodEnd: entry.end,
+              ),
+            ],
+          ),
+        );
+        expect(result, isA<AlreadySubscribedResult>());
+      }
+    });
+
+    test('creates an API key when an existing project has none', () async {
+      final result = await authSignup(
+        _restClient(),
+        'api-key',
+        _preauthenticatedRequest(plan: 'agent'),
+        httpClient: _checkoutClient(
+          projects: () => [_project('p-1')],
+          projectApiKey: '',
+        ),
+      );
+
+      expect(result, isA<AlreadySubscribedResult>());
+      expect((result as AlreadySubscribedResult).apiKey, 'new-key');
+    });
+
+    test('rejects empty preauthenticated credentials', () async {
+      const request = SignupRequest.preauthenticated(
+        jwt: '',
+        refId: '',
+        walletAddress: '11111111111111111111111111111111',
+        plan: 'developer',
+      );
+
+      await expectLater(
+        authSignup(_restClient(), 'api-key', request),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('rejects secret keys that do not decode to 64 bytes', () async {
+      final request = SignupRequest.secretKey(
+        secretKey: base64Encode(Uint8List(63)),
+        plan: 'developer',
+      );
+
+      await expectLater(
+        authSignup(_restClient(), 'api-key', request),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
 
     test('throws when contact info is missing for a new signup', () async {
       final rest = _restClient();

--- a/packages/solana_kit_helius/test/websockets/helius_websocket_integration_test.dart
+++ b/packages/solana_kit_helius/test/websockets/helius_websocket_integration_test.dart
@@ -60,6 +60,7 @@ void main() {
       final ws = HeliusWebSocket(
         url: 'ws://${server.address.address}:${server.port}',
         allowInsecureWs: true,
+        allowPrivateHosts: true,
       );
       await ws.connect();
       addTearDown(ws.close);
@@ -99,6 +100,7 @@ void main() {
       final ws = HeliusWebSocket(
         url: 'ws://${server.address.address}:${server.port}',
         allowInsecureWs: true,
+        allowPrivateHosts: true,
       );
       await ws.connect();
       addTearDown(ws.close);
@@ -128,6 +130,7 @@ void main() {
       final ws = HeliusWebSocket(
         url: 'ws://${server.address.address}:${server.port}',
         allowInsecureWs: true,
+        allowPrivateHosts: true,
       );
       await ws.connect();
       addTearDown(ws.close);
@@ -157,6 +160,7 @@ void main() {
       final ws = HeliusWebSocket(
         url: 'ws://${server.address.address}:${server.port}',
         allowInsecureWs: true,
+        allowPrivateHosts: true,
       );
       await ws.connect();
       addTearDown(ws.close);
@@ -184,20 +188,25 @@ void main() {
       expect(requests, isNotEmpty);
     });
 
-    test('connection failures surface as SolanaError', () async {
+    test('connection failures redact API keys from SolanaError', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-      final url = 'ws://${server.address.address}:${server.port}';
+      final url =
+          'ws://${server.address.address}:${server.port}?api-key=secret-key';
       await server.close(force: true);
 
-      final ws = HeliusWebSocket(url: url, allowInsecureWs: true);
+      final ws = HeliusWebSocket(
+        url: url,
+        allowInsecureWs: true,
+        allowPrivateHosts: true,
+      );
 
       await expectLater(
         ws.connect(),
         throwsA(
           isA<SolanaError>().having(
-            (error) => error.code,
-            'code',
-            SolanaErrorCode.heliusWebSocketError,
+            (error) => error.context['message'],
+            'message',
+            allOf(contains('%5BREDACTED%5D'), isNot(contains('secret-key'))),
           ),
         ),
       );
@@ -214,6 +223,7 @@ void main() {
       final ws = HeliusWebSocket(
         url: 'ws://${server.address.address}:${server.port}',
         allowInsecureWs: true,
+        allowPrivateHosts: true,
       );
       await ws.connect();
       addTearDown(ws.close);
@@ -250,6 +260,7 @@ void main() {
       final ws = HeliusWebSocket(
         url: 'ws://${server.address.address}:${server.port}',
         allowInsecureWs: true,
+        allowPrivateHosts: true,
       );
       await ws.connect();
 
@@ -288,6 +299,7 @@ void main() {
         final ws = HeliusWebSocket(
           url: 'ws://${server.address.address}:${server.port}',
           allowInsecureWs: true,
+          allowPrivateHosts: true,
         );
         await ws.connect();
         addTearDown(ws.close);
@@ -327,6 +339,7 @@ void main() {
       final ws = HeliusWebSocket(
         url: 'ws://${server.address.address}:${server.port}',
         allowInsecureWs: true,
+        allowPrivateHosts: true,
       );
       await ws.connect();
       final stream = ws.subscribe('signatureSubscribe', ['sig-1']);

--- a/packages/solana_kit_helius/test/websockets/helius_websocket_session_test.dart
+++ b/packages/solana_kit_helius/test/websockets/helius_websocket_session_test.dart
@@ -43,6 +43,7 @@ void main() {
         final ws = HeliusWebSocket(
           url: 'ws://${server.address.address}:${server.port}',
           allowInsecureWs: true,
+          allowPrivateHosts: true,
         );
         await ws.connect();
         addTearDown(ws.close);
@@ -87,6 +88,7 @@ void main() {
       final ws = HeliusWebSocket(
         url: 'ws://${server.address.address}:${server.port}',
         allowInsecureWs: true,
+        allowPrivateHosts: true,
       );
       await ws.connect();
       addTearDown(ws.close);

--- a/packages/solana_kit_helius/test/websockets/helius_websocket_test.dart
+++ b/packages/solana_kit_helius/test/websockets/helius_websocket_test.dart
@@ -53,7 +53,7 @@ void main() {
     });
 
     test('connect rejects insecure ws URLs by default', () async {
-      final ws = HeliusWebSocket(url: 'ws://localhost:1234');
+      final ws = HeliusWebSocket(url: 'ws://example.com:1234');
 
       await expectLater(
         ws.connect(),
@@ -64,6 +64,15 @@ void main() {
             contains('Insecure WebSocket endpoints are disabled by default'),
           ),
         ),
+      );
+    });
+
+    test('connect rejects private IP literals by default', () async {
+      final ws = HeliusWebSocket(url: 'wss://127.0.0.2:1234');
+
+      await expectLater(
+        ws.connect(),
+        throwsA(isA<ArgumentError>()),
       );
     });
 

--- a/packages/solana_kit_keys/README.md
+++ b/packages/solana_kit_keys/README.md
@@ -71,6 +71,11 @@ public-key derivation, or low-level signature helpers.
 
 <!-- {/docsKeyPairSection} -->
 
+`KeyPair` owns sensitive memory. Call `dispose()` in a `finally` block when the
+key is no longer needed; the GC finalizer is only a fallback. `writeKeyPair`
+creates new files atomically, applies mode `0600` before writing on POSIX, and
+refuses symbolic-link overwrite targets.
+
 ## Usage
 
 ### Generating a key pair

--- a/packages/solana_kit_keys/lib/src/key_pair.dart
+++ b/packages/solana_kit_keys/lib/src/key_pair.dart
@@ -135,8 +135,18 @@ Future<List<KeyPair>> grindKeyPairs({
   while (found.length < amount) {
     for (var i = 0; i < batchSize && found.length < amount; i++) {
       final keyPair = generateKeyPair();
-      final addr = getAddressFromPublicKey(keyPair.publicKey).value;
-      if (matcher(addr)) found.add(keyPair);
+      var retained = false;
+      try {
+        final addr = getAddressFromPublicKey(keyPair.publicKey).value;
+        if (matcher(addr)) {
+          found.add(keyPair);
+          retained = true;
+        }
+      } finally {
+        // A grind can reject millions of candidates. Dispose rejected keys
+        // immediately instead of waiting for a best-effort GC finalizer.
+        if (!retained) keyPair.dispose();
+      }
     }
     await Future<void>.delayed(Duration.zero);
   }
@@ -226,8 +236,8 @@ KeyPair createKeyPairFromBytes(Uint8List bytes) {
   }
 
   return KeyPair(
-    privateKey: Uint8List.fromList(privateKeyBytes),
-    publicKey: Uint8List.fromList(publicKeyBytes),
+    privateKey: privateKeyBytes,
+    publicKey: publicKeyBytes,
   );
 }
 
@@ -240,10 +250,7 @@ KeyPair createKeyPairFromBytes(Uint8List bytes) {
 KeyPair createKeyPairFromPrivateKeyBytes(Uint8List bytes) {
   assertIsPrivateKey(bytes);
   final publicKeyBytes = getPublicKeyFromPrivateKey(bytes);
-  return KeyPair(
-    privateKey: Uint8List.fromList(bytes),
-    publicKey: publicKeyBytes,
-  );
+  return KeyPair(privateKey: bytes, publicKey: publicKeyBytes);
 }
 
 /// Writes a [KeyPair] to disk using the JSON byte-array format produced by
@@ -264,28 +271,49 @@ Future<void> writeKeyPair(
   final bytes = Uint8List(64)
     ..setRange(0, 32, privateKey)
     ..setRange(32, 64, publicKey);
-  final file = File(path);
-  final parent = file.parent;
-  if (parent.path.isNotEmpty) {
-    await parent.create(recursive: true);
-  }
-
-  if (!unsafelyOverwriteExistingKeyPair && file.existsSync()) {
-    throw FileSystemException('Key pair file already exists', path);
-  }
-
-  if (!Platform.isWindows && file.existsSync()) {
-    await Process.run('chmod', ['600', path]);
-  }
-
-  final sink = await file.open(mode: FileMode.writeOnly);
   try {
-    if (!Platform.isWindows) {
-      await Process.run('chmod', ['600', path]);
+    final file = File(path);
+    final parent = file.parent;
+    if (parent.path.isNotEmpty) {
+      await parent.create(recursive: true);
     }
-    await sink.writeString(jsonEncode(bytes.toList()));
+
+    if (unsafelyOverwriteExistingKeyPair) {
+      final type = FileSystemEntity.typeSync(path, followLinks: false);
+      if (type == FileSystemEntityType.link) {
+        throw FileSystemException(
+          'Refusing to overwrite a symbolic link',
+          path,
+        );
+      }
+      await file.create();
+    } else {
+      // `exclusive` makes the existence check and creation one atomic
+      // operation. A separate exists/open sequence could be raced into
+      // truncating another file or following an attacker-created symlink.
+      await file.create(exclusive: true);
+    }
+
+    if (!Platform.isWindows) {
+      final chmod = await Process.run('chmod', ['600', path]);
+      if (chmod.exitCode != 0) {
+        throw FileSystemException(
+          'Failed to restrict key pair file permissions',
+          path,
+        );
+      }
+    }
+
+    final sink = await file.open(mode: FileMode.writeOnly);
+    try {
+      await sink.writeString(jsonEncode(bytes.toList()));
+    } finally {
+      await sink.close();
+    }
   } finally {
-    await sink.close();
+    _zeroBytes(privateKey);
+    _zeroBytes(publicKey);
+    _zeroBytes(bytes);
   }
 }
 

--- a/packages/solana_kit_keys/lib/src/key_pair.dart
+++ b/packages/solana_kit_keys/lib/src/key_pair.dart
@@ -296,12 +296,16 @@ Future<void> writeKeyPair(
 
     if (!Platform.isWindows) {
       final chmod = await Process.run('chmod', ['600', path]);
+      // coverage:ignore-start
+      // A failing system chmod cannot be triggered portably without replacing
+      // host tooling or writing outside the test sandbox.
       if (chmod.exitCode != 0) {
         throw FileSystemException(
           'Failed to restrict key pair file permissions',
           path,
         );
       }
+      // coverage:ignore-end
     }
 
     final sink = await file.open(mode: FileMode.writeOnly);

--- a/packages/solana_kit_keys/test/key_pair_test.dart
+++ b/packages/solana_kit_keys/test/key_pair_test.dart
@@ -175,6 +175,60 @@ void main() {
               .cast<int>();
       expect(bytes, mockKeyBytes);
     });
+
+    test(
+      'creates a new key file exclusively under concurrent writes',
+      () async {
+        final directory = await Directory.systemTemp.createTemp(
+          'solana-keypair-',
+        );
+        addTearDown(() => directory.delete(recursive: true));
+        final path = '${directory.path}/keypair.json';
+        final first = createKeyPairFromBytes(mockKeyBytes);
+        final second = generateKeyPair();
+        addTearDown(first.dispose);
+        addTearDown(second.dispose);
+
+        final outcomes = await Future.wait<Object?>([
+          writeKeyPair(
+            first,
+            path,
+          ).then<Object?>(
+            (_) => null,
+            onError: (Object error, StackTrace _) => error,
+          ),
+          writeKeyPair(
+            second,
+            path,
+          ).then<Object?>(
+            (_) => null,
+            onError: (Object error, StackTrace _) => error,
+          ),
+        ]);
+
+        expect(outcomes.where((outcome) => outcome == null), hasLength(1));
+        expect(outcomes.whereType<FileSystemException>(), hasLength(1));
+      },
+    );
+
+    test('refuses to overwrite a symbolic link', () async {
+      if (Platform.isWindows) return;
+      final directory = await Directory.systemTemp.createTemp(
+        'solana-keypair-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final target = File('${directory.path}/target.json');
+      await target.writeAsString('keep-me');
+      final path = '${directory.path}/keypair.json';
+      await Link(path).create(target.path);
+      final keyPair = createKeyPairFromBytes(mockKeyBytes);
+
+      await expectLater(
+        writeKeyPair(keyPair, path, unsafelyOverwriteExistingKeyPair: true),
+        throwsA(isA<FileSystemException>()),
+      );
+      expect(await target.readAsString(), 'keep-me');
+    });
   });
 
   group('constantTimeEqual', () {

--- a/packages/solana_kit_keys/test/key_pair_test.dart
+++ b/packages/solana_kit_keys/test/key_pair_test.dart
@@ -45,6 +45,18 @@ void main() {
       expect(keyPairs, isEmpty);
     });
 
+    test('continues after disposing a rejected candidate', () async {
+      var attempts = 0;
+      final keyPairs = await grindKeyPairs(
+        matches: (String _) => ++attempts > 1,
+        concurrency: 1,
+      );
+      addTearDown(keyPairs.single.dispose);
+
+      expect(attempts, 2);
+      expect(keyPairs, hasLength(1));
+    });
+
     test('throws when regex contains impossible base58 characters', () {
       expect(
         () => grindKeyPairs(matches: RegExp('^ab0'), amount: 0),

--- a/packages/solana_kit_mobile_wallet_adapter_protocol/lib/src/crypto.dart
+++ b/packages/solana_kit_mobile_wallet_adapter_protocol/lib/src/crypto.dart
@@ -13,7 +13,11 @@ SecureRandom createSecureRandom() {
   for (var i = 0; i < 32; i++) {
     seed[i] = random.nextInt(256);
   }
-  return FortunaRandom()..seed(KeyParameter(seed));
+  try {
+    return FortunaRandom()..seed(KeyParameter(seed));
+  } finally {
+    seed.fillRange(0, seed.length, 0);
+  }
 }
 
 /// Generates a new P-256 EC keypair.
@@ -158,13 +162,21 @@ Uint8List aesGcmDecrypt({
     0,
   );
   offset += cipher.doFinal(output, offset);
-  return output.sublist(0, offset);
+  final plaintext = Uint8List.fromList(
+    Uint8List.sublistView(output, 0, offset),
+  );
+  output.fillRange(0, output.length, 0);
+  return plaintext;
 }
 
 /// Generates [length] cryptographically secure random bytes.
 Uint8List randomBytes(int length) {
   final random = Random.secure();
-  return Uint8List.fromList(List.generate(length, (_) => random.nextInt(256)));
+  final bytes = Uint8List(length);
+  for (var i = 0; i < bytes.length; i++) {
+    bytes[i] = random.nextInt(256);
+  }
+  return bytes;
 }
 
 /// Converts a [BigInt] to a fixed-length unsigned big-endian byte array.

--- a/packages/solana_kit_rpc_subscriptions/README.md
+++ b/packages/solana_kit_rpc_subscriptions/README.md
@@ -114,7 +114,10 @@ void main() async {
 
 ### Customizing channel configuration
 
-The `DefaultRpcSubscriptionsChannelConfig` class lets you tune connection pooling, autopinging intervals, and send buffer sizes.
+The `DefaultRpcSubscriptionsChannelConfig` class lets you tune connection
+pooling, autopinging intervals, send buffer sizes, and endpoint security.
+Private IP literals are rejected by default; controlled local validators must
+set `allowPrivateHosts: true` and, for `ws://`, `allowInsecureWs: true`.
 
 ```dart
 import 'package:solana_kit_rpc_subscriptions/solana_kit_rpc_subscriptions.dart';

--- a/packages/solana_kit_rpc_subscriptions/lib/src/rpc_subscriptions_channel.dart
+++ b/packages/solana_kit_rpc_subscriptions/lib/src/rpc_subscriptions_channel.dart
@@ -11,6 +11,7 @@ class DefaultRpcSubscriptionsChannelConfig {
   const DefaultRpcSubscriptionsChannelConfig({
     required this.url,
     this.allowInsecureWs = false,
+    this.allowPrivateHosts = false,
     this.intervalMs = 5000,
     this.maxSubscriptionsPerChannel = 100,
     this.minChannels = 1,
@@ -24,6 +25,11 @@ class DefaultRpcSubscriptionsChannelConfig {
   ///
   /// Defaults to `false`, which enforces `wss://` URLs.
   final bool allowInsecureWs;
+
+  /// Whether to allow localhost and private or non-public IP literals.
+  ///
+  /// Defaults to `false`. Enable only for controlled local development.
+  final bool allowPrivateHosts;
 
   /// The number of milliseconds to wait since the last message sent or
   /// received over the channel before sending a ping message to keep the
@@ -110,6 +116,7 @@ RpcSubscriptionsChannelCreator _createDefaultRpcSubscriptionsChannelCreatorImpl(
       WebSocketChannelConfig(
         url: Uri.parse(config.url),
         allowInsecureWs: config.allowInsecureWs,
+        allowPrivateHosts: config.allowPrivateHosts,
         sendBufferHighWatermark: config.sendBufferHighWatermark,
         signal: abortSignal,
       ),

--- a/packages/solana_kit_rpc_subscriptions/test/rpc_subscriptions_channel_test.dart
+++ b/packages/solana_kit_rpc_subscriptions/test/rpc_subscriptions_channel_test.dart
@@ -62,6 +62,7 @@ void main() {
 
       expect(config.url, 'ws://localhost:8900');
       expect(config.allowInsecureWs, isFalse);
+      expect(config.allowPrivateHosts, isFalse);
       expect(config.intervalMs, 5000);
       expect(config.maxSubscriptionsPerChannel, 100);
       expect(config.minChannels, 1);
@@ -72,8 +73,10 @@ void main() {
       const config = DefaultRpcSubscriptionsChannelConfig(
         url: 'ws://localhost:8900',
         allowInsecureWs: true,
+        allowPrivateHosts: true,
       );
       expect(config.allowInsecureWs, isTrue);
+      expect(config.allowPrivateHosts, isTrue);
     });
   });
 
@@ -137,6 +140,7 @@ void main() {
         DefaultRpcSubscriptionsChannelConfig(
           url: 'ws://${server.address.address}:${server.port}',
           allowInsecureWs: true,
+          allowPrivateHosts: true,
           intervalMs: 60000,
         ),
       );

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/README.md
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/README.md
@@ -10,6 +10,12 @@ WebSocket channel transport for Solana RPC subscriptions in the Solana Kit Dart 
 
 This is the Dart port of [`@solana/rpc-subscriptions-channel-websocket`](https://github.com/anza-xyz/kit/tree/main/packages/rpc-subscriptions-channel-websocket) from the Solana TypeScript SDK.
 
+By default, channel URLs must use `wss://` and may not target localhost or
+non-public IP literals. Alternate numeric IPv4 forms and IPv4-mapped private
+IPv6 literals are also rejected. This check does not resolve DNS names; do not
+accept arbitrary endpoint URLs from untrusted input. Controlled local tests
+must explicitly enable `allowPrivateHosts` (and `allowInsecureWs` for `ws://`).
+
 <!-- {=packageInstallSection:"solana_kit_rpc_subscriptions_channel_websocket"} -->
 
 ## Installation

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/lib/src/websocket_channel.dart
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/lib/src/websocket_channel.dart
@@ -92,8 +92,10 @@ class WebSocketChannelConfig {
 
   /// Whether to allow connections to private/internal hosts.
   ///
-  /// Defaults to `false`, which blocks connections to localhost, loopback,
-  /// and private IP ranges (10.x, 172.16-31.x, 192.168.x, 169.254.x, fc/fd::).
+  /// Defaults to `false`, which blocks localhost plus loopback, private,
+  /// link-local, non-canonical, and reserved IP literals. Hostnames are not
+  /// DNS-resolved, so callers must not treat this as a complete SSRF boundary
+  /// when the URL itself comes from an untrusted source.
   ///
   /// Set to `true` for local development and testing against local validators.
   final bool allowPrivateHosts;
@@ -177,7 +179,7 @@ Future<RpcSubscriptionsChannel> createWebSocketChannel(
     throw SolanaError(SolanaErrorCode.rpcSubscriptionsChannelConnectionClosed);
   }
 
-  _validateWebSocketUrl(
+  validateWebSocketUrl(
     config.url,
     allowInsecureWs: config.allowInsecureWs,
     allowPrivateHosts: config.allowPrivateHosts,
@@ -263,6 +265,25 @@ Future<RpcSubscriptionsChannel> createWebSocketChannel(
   );
 }
 
+/// Validates a WebSocket endpoint using the channel's transport and private
+/// IP-literal security policy, and returns [url] unchanged.
+///
+/// This is useful for WebSocket clients that need the same URL policy but
+/// manage their own protocol session. The private-host check is best effort:
+/// it does not resolve DNS names.
+Uri validateWebSocketUrl(
+  Uri url, {
+  bool allowInsecureWs = false,
+  bool allowPrivateHosts = false,
+}) {
+  _validateWebSocketUrl(
+    url,
+    allowInsecureWs: allowInsecureWs,
+    allowPrivateHosts: allowPrivateHosts,
+  );
+  return url;
+}
+
 void _validateWebSocketUrl(
   Uri url, {
   required bool allowInsecureWs,
@@ -327,14 +348,14 @@ const _blockedHostnames = {
   '0.0.0.0',
   '::',
   '::1',
+  '0:0:0:0:0:0:0:0',
   '0:0:0:0:0:0:0:1',
 };
 
 /// Throws [ArgumentError] if [url] targets a private/internal host.
 ///
 /// This is a best-effort SSRF mitigation. It blocks known private hostnames
-/// and IP-literal ranges (10.x, 172.16-31.x, 192.168.x, 169.254.x, fc-fd::).
-/// It does NOT perform DNS resolution.
+/// and non-public IP-literal ranges. It does NOT perform DNS resolution.
 void _assertHostIsNotPrivate(Uri url) {
   final host = url.host.toLowerCase();
 
@@ -347,7 +368,7 @@ void _assertHostIsNotPrivate(Uri url) {
   }
 
   // IPv4 private ranges: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16
-  if (_isPrivateIpv4(host)) {
+  if (_isPrivateIpv4(host) || _looksLikeNonCanonicalIpv4(host)) {
     throw ArgumentError.value(
       url.toString(),
       'url',
@@ -376,7 +397,26 @@ bool _isPrivateIpv4(String host) {
 
   final first = int.tryParse(parts[0]);
   final second = int.tryParse(parts[1]);
-  if (first == null || second == null) return false;
+  final third = int.tryParse(parts[2]);
+  final fourth = int.tryParse(parts[3]);
+  if (first == null ||
+      second == null ||
+      third == null ||
+      fourth == null ||
+      first < 0 ||
+      first > 255 ||
+      second < 0 ||
+      second > 255 ||
+      third < 0 ||
+      third > 255 ||
+      fourth < 0 ||
+      fourth > 255) {
+    return false;
+  }
+
+  // Unspecified, loopback, and carrier-grade NAT.
+  if (first == 0 || first == 127) return true;
+  if (first == 100 && second >= 64 && second <= 127) return true;
 
   // 10.0.0.0/8
   if (first == 10) return true;
@@ -390,7 +430,34 @@ bool _isPrivateIpv4(String host) {
   // 169.254.0.0/16 (link-local)
   if (first == 169 && second == 254) return true;
 
+  // IETF protocol assignments and TEST-NET ranges are not globally routable.
+  if (first == 192 && second == 0 && third == 0) return true;
+  if (first == 192 && second == 0 && third == 2) return true;
+  if (first == 198 && (second == 18 || second == 19)) return true;
+  if (first == 198 && second == 51 && third == 100) return true;
+  if (first == 203 && second == 0 && third == 113) return true;
+
+  // Multicast, reserved, and limited broadcast ranges.
+  if (first >= 224) return true;
+
   return false;
+}
+
+bool _looksLikeNonCanonicalIpv4(String host) {
+  // Reject alternate numeric forms such as 127.1, 2130706433, octal, and
+  // hexadecimal. Different socket stacks normalize these differently, which
+  // makes literal-only SSRF filters easy to bypass.
+  if (RegExp(r'^\d+(?:\.\d+){0,3}$').hasMatch(host)) {
+    final parts = host.split('.');
+    if (parts.length != 4) return true;
+    return parts.any(
+      (part) => part.length > 1 && part.startsWith('0'),
+    );
+  }
+  return RegExp(
+    r'^(?:0x[0-9a-f]+)(?:\.(?:0x[0-9a-f]+))*$',
+    caseSensitive: false,
+  ).hasMatch(host);
 }
 
 bool _isPrivateIpv6(String host) {
@@ -398,8 +465,31 @@ bool _isPrivateIpv6(String host) {
   var h = host.replaceAll('[', '').replaceAll(']', '');
   if (h.contains('%')) h = h.substring(0, h.indexOf('%'));
 
-  // fc00::/7 covers fc00:: through fdff:...
-  return h.startsWith('fc') || h.startsWith('fd');
+  h = h.toLowerCase();
+
+  if (h == '::' || h == '::1') return true;
+
+  // IPv4-compatible and IPv4-mapped literals inherit the IPv4 address's
+  // routability (for example ::ffff:127.0.0.1).
+  final lastColon = h.lastIndexOf(':');
+  if (lastColon >= 0 && h.substring(lastColon + 1).contains('.')) {
+    final ipv4 = h.substring(lastColon + 1);
+    if (_isPrivateIpv4(ipv4) || _looksLikeNonCanonicalIpv4(ipv4)) return true;
+  }
+
+  // fc00::/7 unique-local; fe80::/10 link-local; ff00::/8 multicast.
+  if (h.startsWith('fc') || h.startsWith('fd') || h.startsWith('ff')) {
+    return true;
+  }
+  if (h.startsWith('fe8') ||
+      h.startsWith('fe9') ||
+      h.startsWith('fea') ||
+      h.startsWith('feb')) {
+    return true;
+  }
+
+  // Documentation range; never a legitimate public endpoint.
+  return h.startsWith('2001:db8');
 }
 
 class _WebSocketRpcChannel implements RpcSubscriptionsChannel {

--- a/packages/solana_kit_rpc_subscriptions_channel_websocket/test/websocket_channel_test.dart
+++ b/packages/solana_kit_rpc_subscriptions_channel_websocket/test/websocket_channel_test.dart
@@ -638,6 +638,32 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
     });
+
+    for (final host in <String>[
+      '127.0.0.2',
+      '127.1',
+      '2130706433',
+      '0177.0.0.1',
+      '0x7f000001',
+      '0.1.2.3',
+      '100.64.0.1',
+      '198.18.0.1',
+      '224.0.0.1',
+      '[::]',
+      '[::1]',
+      '[::ffff:127.0.0.1]',
+      '[fe80::1]',
+      '[ff02::1]',
+    ]) {
+      test('blocks non-public IP literal $host by default', () async {
+        await expectLater(
+          () => createWebSocketChannel(
+            WebSocketChannelConfig(url: Uri.parse('wss://$host:8080')),
+          ),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    }
   });
 }
 

--- a/packages/solana_kit_surfpool/README.md
+++ b/packages/solana_kit_surfpool/README.md
@@ -108,6 +108,10 @@ Future<void> main() async {
 }
 ```
 
+Stopping a freshly created client clears Surfnet's in-memory payer bytes and
+disposes the client-owned payer signer. A signer supplied to
+`connectSurfpoolClient` remains caller-owned and is not disposed.
+
 Attach to an already-running Surfpool with `connectSurfpoolClient`; the
 [`payer`] must be a funded signer you provide:
 

--- a/packages/solana_kit_surfpool/lib/src/kit_client.dart
+++ b/packages/solana_kit_surfpool/lib/src/kit_client.dart
@@ -27,6 +27,7 @@ class SurfpoolClient {
     required this.rpcSubscriptions,
     required this.payer,
     required this.cheatcodes,
+    required this._disposePayerOnStop,
   });
 
   /// The underlying Surfnet handle (`fundSol`, `deploy`, time travel, …).
@@ -43,6 +44,8 @@ class SurfpoolClient {
 
   /// Typed cheatcode RPC (method names have the `surfnet_` prefix stripped).
   final SurfnetCheatcodes cheatcodes;
+
+  final bool _disposePayerOnStop;
 
   /// HTTP RPC URL for the Surfnet.
   String get rpcUrl => surfnet.rpcUrl;
@@ -72,7 +75,13 @@ class SurfpoolClient {
   /// Stops the Surfnet and releases its resources.
   ///
   /// Idempotent; safe to call from test teardown.
-  Future<void> stop() => surfnet.stop();
+  Future<void> stop() async {
+    try {
+      await surfnet.stop();
+    } finally {
+      if (_disposePayerOnStop) payer.keyPair.dispose();
+    }
+  }
 
   /// Creates a client bound to an existing [surfnet] for testing.
   @visibleForTesting
@@ -134,7 +143,14 @@ SurfpoolClient connectSurfpoolClient({
 
 SurfpoolClient _wireClient(Surfnet surfnet, {KeyPairSigner? payer}) {
   final rpc = createSolanaRpc(url: surfnet.rpcUrl, allowInsecureHttp: true);
-  final rpcSubscriptions = createSolanaRpcSubscriptions(surfnet.wsUrl);
+  final rpcSubscriptions = createSolanaRpcSubscriptions(
+    surfnet.wsUrl,
+    DefaultRpcSubscriptionsChannelConfig(
+      url: surfnet.wsUrl,
+      allowInsecureWs: true,
+      allowPrivateHosts: true,
+    ),
+  );
   final effectivePayer =
       payer ?? createKeyPairSignerFromBytes(surfnet.payerSecretKey);
   return SurfpoolClient._(
@@ -143,6 +159,7 @@ SurfpoolClient _wireClient(Surfnet surfnet, {KeyPairSigner? payer}) {
     rpcSubscriptions: rpcSubscriptions,
     payer: effectivePayer,
     cheatcodes: SurfnetCheatcodes(surfnet),
+    disposePayerOnStop: payer == null,
   );
 }
 

--- a/packages/solana_kit_surfpool/lib/src/surfnet.dart
+++ b/packages/solana_kit_surfpool/lib/src/surfnet.dart
@@ -241,38 +241,45 @@ class Surfnet {
     if (_stopped) return;
     _stopped = true;
 
-    final process = _process;
-    final exitCodeFuture = _exitCodeFuture;
-    if (process != null && exitCodeFuture != null) {
-      process.kill(ProcessSignal.sigint);
-      try {
-        await exitCodeFuture.timeout(timeout);
-      } on TimeoutException {
-        process.kill();
-        await exitCodeFuture.timeout(
-          const Duration(seconds: 1),
-          // Processes that ignore termination can outlive this wrapper; callers
-          // should still get resource cleanup without waiting indefinitely.
-          onTimeout: () => -1, // coverage:ignore-line
-        );
+    try {
+      final process = _process;
+      final exitCodeFuture = _exitCodeFuture;
+      if (process != null && exitCodeFuture != null) {
+        process.kill(ProcessSignal.sigint);
+        try {
+          await exitCodeFuture.timeout(timeout);
+        } on TimeoutException {
+          process.kill();
+          await exitCodeFuture.timeout(
+            const Duration(seconds: 1),
+            // Processes that ignore termination can outlive this wrapper;
+            // callers should still get resource cleanup without waiting
+            // indefinitely.
+            onTimeout: () => -1, // coverage:ignore-line
+          );
+        }
       }
-    }
 
-    await _stdoutSubscription?.cancel();
-    await _stderrSubscription?.cancel();
+      await _stdoutSubscription?.cancel();
+      await _stderrSubscription?.cancel();
 
-    final workingDirectory = _processWorkingDirectory;
-    if (workingDirectory != null) {
-      try {
-        await workingDirectory.delete(recursive: true);
-      } on Object {
-        // Best-effort cleanup of the Surfnet runtime state; the OS will
-        // eventually reap the temp directory if deletion fails here.
+      final workingDirectory = _processWorkingDirectory;
+      if (workingDirectory != null) {
+        try {
+          await workingDirectory.delete(recursive: true);
+        } on Object {
+          // Best-effort cleanup of the Surfnet runtime state; the OS will
+          // eventually reap the temp directory if deletion fails here.
+        }
       }
-    }
-
-    if (_closeClientOnStop) {
-      _client.close();
+    } finally {
+      // The Surfnet owns this copy even when the caller supplied the original
+      // payer. Clear it deterministically once the process can no longer use
+      // it, including when shutdown or cleanup raises an error.
+      _payerSecretKey.fillRange(0, _payerSecretKey.length, 0);
+      if (_closeClientOnStop) {
+        _client.close();
+      }
     }
   }
 

--- a/packages/solana_kit_surfpool/test/src/kit_client_test.dart
+++ b/packages/solana_kit_surfpool/test/src/kit_client_test.dart
@@ -27,6 +27,8 @@ void main() {
       expect(client.rpcSubscriptions, isNotNull);
 
       await client.stop();
+      expect(payer.keyPair.isDisposed, isFalse);
+      payer.keyPair.dispose();
     });
 
     test('connectSurfpoolClient derives the ws URL from the rpc URL', () async {
@@ -38,6 +40,8 @@ void main() {
 
       expect(client.wsUrl, 'ws://localhost:8899');
       await client.stop();
+      expect(payer.keyPair.isDisposed, isFalse);
+      payer.keyPair.dispose();
     });
 
     test('airdrop funds an address via the Surfnet', () async {
@@ -88,6 +92,7 @@ void main() {
       'createSurfpoolClient wires a fresh Surfnet with a funded payer',
       () async {
         final client = await createSurfpoolClient();
+        final clientOwnedKeyPair = client.payer.keyPair;
         try {
           expect(client.rpcUrl, startsWith('http://'));
           expect(client.wsUrl, startsWith('ws://'));
@@ -109,6 +114,7 @@ void main() {
         } finally {
           await client.stop();
         }
+        expect(clientOwnedKeyPair.isDisposed, isTrue);
       },
     );
   });

--- a/packages/solana_kit_surfpool/test/src/surfnet_test.dart
+++ b/packages/solana_kit_surfpool/test/src/surfnet_test.dart
@@ -449,7 +449,7 @@ void main() {
           expect(surfnet.rpcUri, Uri.parse('http://127.0.0.1:$rpcPort'));
           expect(surfnet.wsUri, Uri.parse('ws://127.0.0.1:$wsPort'));
           expect(surfnet.payer, payer.publicKey);
-          expect(surfnet.payerSecretKey, payer.secretKey);
+          expect(surfnet.payerSecretKey, everyElement(0));
           expect(surfnet.instanceId, startsWith('surfnet-'));
           expect(events.length, lessThanOrEqualTo(500));
           expect(events.map((event) => event.kind), contains('stdoutLog'));

--- a/packages/solana_kit_transaction_introspection/README.md
+++ b/packages/solana_kit_transaction_introspection/README.md
@@ -34,3 +34,9 @@ void main() {
 ```
 
 `'jsonParsed'` responses are not supported: their instructions arrive pre-parsed by the server and lack raw bytes, so they cannot be round-tripped through the auto-generated `parseXInstruction` clients. Prefer `'base64'` when bandwidth allows — it is the most compact and the returned `transaction` is re-encodable.
+
+RPC input is validated fail-closed. Mixed-type account/index arrays,
+unsupported transaction versions, incomplete compiled instructions, invalid
+header counts, malformed loaded addresses, and inner-instruction groups that
+do not match an outer instruction throw a `SolanaError` instead of being
+silently dropped or misattributed.

--- a/packages/solana_kit_transaction_introspection/lib/src/decode_rpc_transaction.dart
+++ b/packages/solana_kit_transaction_introspection/lib/src/decode_rpc_transaction.dart
@@ -40,20 +40,46 @@ const _emptyLoadedAddresses = LoadedAddresses();
 Map<String, Object?>? _asMap(Object? v) =>
     v is Map ? Map<String, Object?>.from(v) : null;
 
-List<Object?> _asList(Object? v) => v is List ? v : const [];
-
 int? _asInt(Object? v) => v is int ? v : null;
 
 String? _asString(Object? v) => v is String ? v : null;
 
-List<Address> _addressList(Object? v) =>
-    _asList(v).whereType<String>().map(Address.new).toList();
+Never _throwUnrecognized() {
+  throw SolanaError(
+    SolanaErrorCode.transactionIntrospectionUnrecognizedGetTransactionResponse,
+  );
+}
 
-List<int> _intList(Object? v) => _asList(v).whereType<int>().toList();
+List<Object?> _requireList(Object? value) {
+  if (value is! List) _throwUnrecognized();
+  return List<Object?>.from(value);
+}
+
+List<Address> _addressList(Object? value) {
+  final raw = _requireList(value);
+  final addresses = <Address>[];
+  for (final item in raw) {
+    if (item is! String) _throwUnrecognized();
+    addresses.add(Address(item));
+  }
+  return addresses;
+}
+
+List<int> _intList(Object? value) {
+  final raw = _requireList(value);
+  final integers = <int>[];
+  for (final item in raw) {
+    if (item is! int || item < 0 || item > 255) _throwUnrecognized();
+    integers.add(item);
+  }
+  return integers;
+}
 
 LoadedAddresses _getLoadedAddresses(Map<String, Object?>? meta) {
-  final loaded = _asMap(meta?['loadedAddresses']);
-  if (loaded == null) return _emptyLoadedAddresses;
+  final rawLoaded = meta?['loadedAddresses'];
+  if (rawLoaded == null) return _emptyLoadedAddresses;
+  final loaded = _asMap(rawLoaded);
+  if (loaded == null) _throwUnrecognized();
   return LoadedAddresses(
     readonly: _addressList(loaded['readonly']),
     writable: _addressList(loaded['writable']),
@@ -117,11 +143,12 @@ MessageHeader _readJsonHeader(Map<String, Object?> header) {
   );
   if (numSignerAccounts == null ||
       numReadonlySignerAccounts == null ||
-      numReadonlyNonSignerAccounts == null) {
-    throw SolanaError(
-      SolanaErrorCode
-          .transactionIntrospectionUnrecognizedGetTransactionResponse,
-    );
+      numReadonlyNonSignerAccounts == null ||
+      numSignerAccounts < 0 ||
+      numReadonlySignerAccounts < 0 ||
+      numReadonlyNonSignerAccounts < 0 ||
+      numReadonlySignerAccounts > numSignerAccounts) {
+    _throwUnrecognized();
   }
   return MessageHeader(
     numSignerAccounts: numSignerAccounts,
@@ -143,15 +170,15 @@ List<CompiledInstruction> _readJsonInstructions(
       );
     }
     final programAddressIndex = _asInt(ix['programIdIndex']);
-    if (programAddressIndex == null) {
-      throw SolanaError(
-        SolanaErrorCode
-            .transactionIntrospectionUnrecognizedGetTransactionResponse,
-      );
+    if (programAddressIndex == null ||
+        programAddressIndex < 0 ||
+        programAddressIndex > 255) {
+      _throwUnrecognized();
     }
     final accounts = _intList(ix['accounts']);
     final dataString = _asString(ix['data']);
-    final data = dataString == null ? Uint8List(0) : base58.encode(dataString);
+    if (dataString == null) _throwUnrecognized();
+    final data = base58.encode(dataString);
     return CompiledInstruction(
       programAddressIndex: programAddressIndex,
       accountIndices: accounts.isEmpty ? null : accounts,
@@ -167,13 +194,12 @@ DecodedRpcTransaction _decodeFromJson(
 ) {
   final header = _readJsonHeader(_asMap(message['header'])!);
   final staticAccounts = _addressList(message['accountKeys']);
-  final instructionsRaw = _asList(message['instructions']);
-  if (instructionsRaw.isEmpty && message['instructions'] is! List) {
-    throw SolanaError(
-      SolanaErrorCode
-          .transactionIntrospectionUnrecognizedGetTransactionResponse,
-    );
+  if (header.numSignerAccounts > staticAccounts.length ||
+      header.numReadonlyNonSignerAccounts >
+          staticAccounts.length - header.numSignerAccounts) {
+    _throwUnrecognized();
   }
+  final instructionsRaw = _requireList(message['instructions']);
   final instructions = _readJsonInstructions(instructionsRaw);
   final lifetimeToken = _asString(message['recentBlockhash']);
   if (lifetimeToken == null) {
@@ -183,14 +209,12 @@ DecodedRpcTransaction _decodeFromJson(
     );
   }
 
-  TransactionVersion resolvedVersion;
-  if (version == 0) {
-    resolvedVersion = TransactionVersion.v0;
-  } else if (version == 1) {
-    resolvedVersion = TransactionVersion.v1;
-  } else {
-    resolvedVersion = TransactionVersion.legacy;
-  }
+  final resolvedVersion = switch (version) {
+    null || 'legacy' => TransactionVersion.legacy,
+    0 => TransactionVersion.v0,
+    1 => TransactionVersion.v1,
+    _ => _throwUnrecognized(),
+  };
 
   final compiledMessage = switch (resolvedVersion) {
     TransactionVersion.legacy => CompiledTransactionMessage(
@@ -202,10 +226,10 @@ DecodedRpcTransaction _decodeFromJson(
     ),
     TransactionVersion.v0 => () {
       final lookups = <AddressTableLookup>[];
-      for (final lookup in _asList(message['addressTableLookups'])) {
+      for (final lookup in _requireList(message['addressTableLookups'])) {
         final l = _asMap(lookup);
         final accountKey = l == null ? null : _asString(l['accountKey']);
-        if (accountKey == null) continue;
+        if (accountKey == null) _throwUnrecognized();
         lookups.add(
           AddressTableLookup(
             lookupTableAddress: Address(accountKey),
@@ -229,15 +253,17 @@ DecodedRpcTransaction _decodeFromJson(
       final instructionPayloads = <V1InstructionPayload>[];
       for (final raw in instructionsRaw) {
         final ix = _asMap(raw);
-        final programAccountIndex = ix == null
-            ? null
-            : _asInt(ix['programIdIndex']);
-        if (programAccountIndex == null) continue;
-        final accounts = _intList(ix!['accounts']);
+        if (ix == null) _throwUnrecognized();
+        final programAccountIndex = _asInt(ix['programIdIndex']);
+        if (programAccountIndex == null ||
+            programAccountIndex < 0 ||
+            programAccountIndex > 255) {
+          _throwUnrecognized();
+        }
+        final accounts = _intList(ix['accounts']);
         final dataString = _asString(ix['data']);
-        final data = dataString == null
-            ? Uint8List(0)
-            : base58.encode(dataString);
+        if (dataString == null) _throwUnrecognized();
+        final data = base58.encode(dataString);
         instructionHeaders.add(
           V1InstructionHeader(
             programAccountIndex: programAccountIndex,
@@ -309,6 +335,7 @@ DecodedRpcTransaction decodeTransactionFromRpcResponse(
   }
   final tx = rpcTx['transaction'];
   final metaRaw = rpcTx['meta'];
+  if (metaRaw != null && metaRaw is! Map) _throwUnrecognized();
   final meta = metaRaw is Map<String, Object?> ? metaRaw : _asMap(metaRaw);
 
   // base64 / base58: `transaction` is a `[data, encoding]` array.

--- a/packages/solana_kit_transaction_introspection/lib/src/decode_rpc_transaction.dart
+++ b/packages/solana_kit_transaction_introspection/lib/src/decode_rpc_transaction.dart
@@ -248,25 +248,14 @@ DecodedRpcTransaction _decodeFromJson(
       );
     }(),
     TransactionVersion.v1 => () {
-      final base58 = getBase58Encoder();
       final instructionHeaders = <V1InstructionHeader>[];
       final instructionPayloads = <V1InstructionPayload>[];
-      for (final raw in instructionsRaw) {
-        final ix = _asMap(raw);
-        if (ix == null) _throwUnrecognized();
-        final programAccountIndex = _asInt(ix['programIdIndex']);
-        if (programAccountIndex == null ||
-            programAccountIndex < 0 ||
-            programAccountIndex > 255) {
-          _throwUnrecognized();
-        }
-        final accounts = _intList(ix['accounts']);
-        final dataString = _asString(ix['data']);
-        if (dataString == null) _throwUnrecognized();
-        final data = base58.encode(dataString);
+      for (final instruction in instructions) {
+        final accounts = instruction.accountIndices ?? const <int>[];
+        final data = instruction.data ?? Uint8List(0);
         instructionHeaders.add(
           V1InstructionHeader(
-            programAccountIndex: programAccountIndex,
+            programAccountIndex: instruction.programAddressIndex,
             numInstructionAccounts: accounts.length,
             numInstructionDataBytes: data.length,
           ),

--- a/packages/solana_kit_transaction_introspection/lib/src/get_inner_instructions.dart
+++ b/packages/solana_kit_transaction_introspection/lib/src/get_inner_instructions.dart
@@ -39,26 +39,38 @@ List<_RpcInnerInstructionsGroup> _parseInnerInstructions(
 ) {
   if (meta == null) return const [];
   final rawInner = meta['innerInstructions'];
-  if (rawInner is! List) return const [];
+  if (rawInner == null) return const [];
+  if (rawInner is! List) _throwUnrecognized();
   final groups = <_RpcInnerInstructionsGroup>[];
   for (final rawGroup in rawInner) {
-    if (rawGroup is! Map) continue;
+    if (rawGroup is! Map) _throwUnrecognized();
     final index = rawGroup['index'];
     final rawInstructions = rawGroup['instructions'];
-    if (index is! int || rawInstructions is! List) continue;
+    if (index is! int || index < 0 || rawInstructions is! List) {
+      _throwUnrecognized();
+    }
     final instructions = <_RpcInnerInstruction>[];
     for (final rawIx in rawInstructions) {
-      if (rawIx is! Map) continue;
+      if (rawIx is! Map) _throwUnrecognized();
       final programIdIndex = rawIx['programIdIndex'];
       final accountsRaw = rawIx['accounts'];
       final data = rawIx['data'];
       final stackHeight = rawIx['stackHeight'];
-      if (programIdIndex is! int || data is! String) continue;
+      if (programIdIndex is! int ||
+          programIdIndex < 0 ||
+          data is! String ||
+          accountsRaw is! List ||
+          (stackHeight != null && stackHeight is! int)) {
+        _throwUnrecognized();
+      }
+      final accounts = <int>[];
+      for (final account in accountsRaw) {
+        if (account is! int || account < 0) _throwUnrecognized();
+        accounts.add(account);
+      }
       instructions.add(
         _RpcInnerInstruction(
-          accounts: accountsRaw is List
-              ? accountsRaw.whereType<int>().toList()
-              : const [],
+          accounts: accounts,
           data: data,
           programIdIndex: programIdIndex,
           stackHeight: stackHeight is int ? stackHeight : null,
@@ -70,6 +82,12 @@ List<_RpcInnerInstructionsGroup> _parseInnerInstructions(
     );
   }
   return groups;
+}
+
+Never _throwUnrecognized() {
+  throw SolanaError(
+    SolanaErrorCode.transactionIntrospectionUnrecognizedGetTransactionResponse,
+  );
 }
 
 /// Returns the inner instructions in a `getTransaction` response as

--- a/packages/solana_kit_transaction_introspection/lib/src/walk_instructions.dart
+++ b/packages/solana_kit_transaction_introspection/lib/src/walk_instructions.dart
@@ -1,3 +1,4 @@
+import 'package:solana_kit_errors/solana_kit_errors.dart';
 import 'package:solana_kit_transaction_introspection/src/get_inner_instructions.dart';
 import 'package:solana_kit_transaction_introspection/src/get_instructions.dart';
 import 'package:solana_kit_transaction_introspection/src/loaded_addresses.dart';
@@ -65,11 +66,14 @@ List<TracedInstruction> walkInstructions({
       result.addAll(group);
     }
   }
-  // Inner groups whose index matches no outer instruction can only come from
-  // malformed input (e.g. `meta` paired with the wrong message). Append them
-  // rather than dropping them so no instruction is ever lost.
-  for (final group in innerByOuterIndex.values) {
-    result.addAll(group);
+  // An unmatched group means `meta` is malformed or belongs to another
+  // transaction. Fail closed instead of presenting those CPIs as if they were
+  // associated with this message.
+  if (innerByOuterIndex.isNotEmpty) {
+    throw SolanaError(
+      SolanaErrorCode
+          .transactionIntrospectionUnrecognizedGetTransactionResponse,
+    );
   }
   return result;
 }

--- a/packages/solana_kit_transaction_introspection/test/decode_rpc_transaction_test.dart
+++ b/packages/solana_kit_transaction_introspection/test/decode_rpc_transaction_test.dart
@@ -360,7 +360,7 @@ void main() {
       );
     });
 
-    test('decodes a json instruction without data as empty payload', () {
+    test('rejects an incomplete json instruction', () {
       final rpcTx = <String, Object?>{
         'version': 1,
         'transaction': {
@@ -378,11 +378,72 @@ void main() {
           },
         },
       };
-      final decoded = decodeTransactionFromRpcResponse(rpcTx);
-      expect(decoded.compiledMessage.instructionHeaders, hasLength(1));
       expect(
-        decoded.compiledMessage.instructionPayloads!.first.instructionData,
-        isEmpty,
+        () => decodeTransactionFromRpcResponse(rpcTx),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('rejects mixed-type account and instruction-index arrays', () {
+      Map<String, Object?> response({
+        required Object accountKeys,
+        Object? accounts,
+      }) => {
+        'transaction': {
+          'message': {
+            'header': {
+              'numRequiredSignatures': 1,
+              'numReadonlySignedAccounts': 0,
+              'numReadonlyUnsignedAccounts': 0,
+            },
+            'accountKeys': accountKeys,
+            'instructions': [
+              {
+                'programIdIndex': 0,
+                'accounts': accounts ?? const <int>[0],
+                'data': '',
+              },
+            ],
+            'recentBlockhash': blockhash,
+          },
+        },
+      };
+
+      expect(
+        () => decodeTransactionFromRpcResponse(
+          response(accountKeys: const <Object?>[feePayer, 42]),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+      expect(
+        () => decodeTransactionFromRpcResponse(
+          response(
+            accountKeys: const <String>[feePayer],
+            accounts: const <Object?>[0, '1'],
+          ),
+        ),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('rejects unsupported transaction versions', () {
+      expect(
+        () => decodeTransactionFromRpcResponse({
+          'version': 2,
+          'transaction': {
+            'message': {
+              'header': {
+                'numRequiredSignatures': 1,
+                'numReadonlySignedAccounts': 0,
+                'numReadonlyUnsignedAccounts': 0,
+              },
+              'accountKeys': const <String>[feePayer],
+              'instructions': const <Object?>[],
+              'recentBlockhash': blockhash,
+            },
+          },
+        }),
+        throwsA(isA<SolanaError>()),
       );
     });
   });

--- a/packages/solana_kit_transaction_introspection/test/decode_rpc_transaction_test.dart
+++ b/packages/solana_kit_transaction_introspection/test/decode_rpc_transaction_test.dart
@@ -446,5 +446,95 @@ void main() {
         throwsA(isA<SolanaError>()),
       );
     });
+
+    test('rejects malformed loaded addresses', () {
+      expect(
+        () => decodeTransactionFromRpcResponse({
+          'transaction': {
+            'message': {
+              'header': {
+                'numRequiredSignatures': 1,
+                'numReadonlySignedAccounts': 0,
+                'numReadonlyUnsignedAccounts': 0,
+              },
+              'accountKeys': const <String>[feePayer],
+              'instructions': const <Object?>[],
+              'recentBlockhash': blockhash,
+            },
+          },
+          'meta': {'loadedAddresses': 42},
+        }),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('rejects an instruction with missing data', () {
+      expect(
+        () => decodeTransactionFromRpcResponse({
+          'transaction': {
+            'message': {
+              'header': {
+                'numRequiredSignatures': 1,
+                'numReadonlySignedAccounts': 0,
+                'numReadonlyUnsignedAccounts': 0,
+              },
+              'accountKeys': const <String>[feePayer],
+              'instructions': const <Object?>[
+                {'accounts': <int>[], 'programIdIndex': 0},
+              ],
+              'recentBlockhash': blockhash,
+            },
+          },
+        }),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('rejects header counts that exceed static accounts', () {
+      expect(
+        () => decodeTransactionFromRpcResponse({
+          'transaction': {
+            'message': {
+              'header': {
+                'numRequiredSignatures': 2,
+                'numReadonlySignedAccounts': 0,
+                'numReadonlyUnsignedAccounts': 0,
+              },
+              'accountKeys': const <String>[feePayer],
+              'instructions': const <Object?>[],
+              'recentBlockhash': blockhash,
+            },
+          },
+        }),
+        throwsA(isA<SolanaError>()),
+      );
+    });
+
+    test('rejects a v0 lookup with no account key', () {
+      expect(
+        () => decodeTransactionFromRpcResponse({
+          'version': 0,
+          'transaction': {
+            'message': {
+              'header': {
+                'numRequiredSignatures': 1,
+                'numReadonlySignedAccounts': 0,
+                'numReadonlyUnsignedAccounts': 0,
+              },
+              'accountKeys': const <String>[feePayer],
+              'instructions': const <Object?>[],
+              'recentBlockhash': blockhash,
+              'addressTableLookups': const <Object?>[
+                {
+                  'writableIndexes': <int>[],
+                  'readonlyIndexes': <int>[],
+                },
+              ],
+            },
+          },
+        }),
+        throwsA(isA<SolanaError>()),
+      );
+    });
   });
 }

--- a/packages/solana_kit_transaction_introspection/test/instructions_test.dart
+++ b/packages/solana_kit_transaction_introspection/test/instructions_test.dart
@@ -359,6 +359,25 @@ void main() {
             },
           ],
         },
+        {
+          'innerInstructions': [
+            {'index': 'zero', 'instructions': const <Object?>[]},
+          ],
+        },
+        {
+          'innerInstructions': [
+            {
+              'index': 0,
+              'instructions': [
+                {
+                  'accounts': const <int>[],
+                  'data': '2',
+                  'programIdIndex': -1,
+                },
+              ],
+            },
+          ],
+        },
       ];
 
       for (final meta in malformed) {

--- a/packages/solana_kit_transaction_introspection/test/instructions_test.dart
+++ b/packages/solana_kit_transaction_introspection/test/instructions_test.dart
@@ -331,6 +331,43 @@ void main() {
         ),
       );
     });
+
+    test('rejects malformed inner-instruction entries', () {
+      final malformed = <Map<String, Object?>>[
+        {
+          'innerInstructions': [42],
+        },
+        {
+          'innerInstructions': [
+            {
+              'index': 0,
+              'instructions': [42],
+            },
+          ],
+        },
+        {
+          'innerInstructions': [
+            {
+              'index': 0,
+              'instructions': [
+                {
+                  'accounts': const <Object?>[0, '1'],
+                  'data': '2',
+                  'programIdIndex': 0,
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      for (final meta in malformed) {
+        expect(
+          () => getInnerInstructionsFromMeta(meta, metas),
+          throwsA(isA<SolanaError>()),
+        );
+      }
+    });
   });
 
   group('walkInstructions', () {
@@ -388,7 +425,7 @@ void main() {
       expect(traced.first.trace, isA<OuterInstructionTrace>());
     });
 
-    test('appends inner groups whose index matches no outer instruction', () {
+    test('rejects inner groups whose index matches no outer instruction', () {
       final message = CompiledTransactionMessage(
         version: TransactionVersion.legacy,
         header: MessageHeader(
@@ -414,10 +451,10 @@ void main() {
           },
         ],
       };
-      final traced = walkInstructions(compiledMessage: message, meta: meta);
-      // outer[0], then the orphaned inner group[9].
-      expect(traced, hasLength(2));
-      expect(traced.last.trace, isA<InnerInstructionTrace>());
+      expect(
+        () => walkInstructions(compiledMessage: message, meta: meta),
+        throwsA(isA<SolanaError>()),
+      );
     });
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: 5.0.6
+  brace-expansion: 5.0.9
+  esbuild: 0.28.1
   minimatch: 10.2.3
+  nanoid: 3.3.18
   picomatch: 4.0.4
-  postcss: 8.5.10
-  vite: 7.3.2
+  postcss: 8.5.23
+  vite: 7.3.5
 
 importers:
 
@@ -23,13 +25,13 @@ importers:
         version: 6.1.3
       tsup:
         specifier: 8.5.1
-        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.23)(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@types/node@25.3.0)(vite@7.3.2(@types/node@25.3.0))
+        version: 4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0))
 
   packages/codama-renderers-dart:
     dependencies:
@@ -52,9 +54,24 @@ importers:
       '@codama/renderers-js':
         specifier: ^2.0.2
         version: 2.2.0(typescript@5.9.3)
+      '@types/node':
+        specifier: 25.3.0
+        version: 25.3.0
       '@vitest/coverage-v8':
         specifier: 4.1.0
-        version: 4.1.0(vitest@4.1.0(@types/node@25.3.0)(vite@7.3.2(@types/node@25.3.0)))
+        version: 4.1.0(vitest@4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0)))
+      rimraf:
+        specifier: 6.1.3
+        version: 6.1.3
+      tsup:
+        specifier: 8.5.1
+        version: 8.5.1(postcss@8.5.23)(typescript@5.9.3)
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.0
+        version: 4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0))
 
 packages:
 
@@ -108,314 +125,158 @@ packages:
   '@codama/visitors@1.7.0':
     resolution: {integrity: sha512-wk8ufgX3AfKOnaok5H4y1UteLyY/WkDIhhKRE7y5MJqOn5JnxLgL9R4MU2+5TmZUF04sdwyUn6fPho0IqTq+BQ==}
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -854,7 +715,7 @@ packages:
     resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 7.3.2
+      vite: 7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -895,15 +756,15 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: '>=0.18'
+      esbuild: 0.28.1
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -987,13 +848,8 @@ packages:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1133,8 +989,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1178,7 +1034,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: 8.5.10
+      postcss: 8.5.23
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -1191,8 +1047,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.8.3:
@@ -1301,7 +1157,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: 8.5.10
+      postcss: 8.5.23
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -1324,8 +1180,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1378,7 +1234,7 @@ packages:
       '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
-      vite: 7.3.2
+      vite: 7.3.5
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -1481,160 +1337,82 @@ snapshots:
       '@codama/nodes': 1.7.0
       '@codama/visitors-core': 1.7.0
 
-  '@esbuild/aix-ppc64@0.27.3':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.3':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.3':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.3':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.3':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.3':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.3':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.3':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.7':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.3':
-    optional: true
-
-  '@esbuild/linux-x64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.3':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.3':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.3':
-    optional: true
-
-  '@esbuild/sunos-x64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.3':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.3':
-    optional: true
-
-  '@esbuild/win32-ia32@0.27.7':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.3':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1908,7 +1686,7 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.3.0)(vite@7.3.2(@types/node@25.3.0)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -1920,7 +1698,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@25.3.0)(vite@7.3.2(@types/node@25.3.0))
+      vitest: 4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -1931,13 +1709,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(vite@7.3.2(@types/node@25.3.0))':
+  '@vitest/mocker@4.1.0(vite@7.3.5(@types/node@25.3.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.3.0)
+      vite: 7.3.5(@types/node@25.3.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -1977,13 +1755,13 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
-  bundle-require@5.1.0(esbuild@0.27.3):
+  bundle-require@5.1.0(esbuild@0.28.1):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.28.1
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
@@ -2051,63 +1829,34 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  esbuild@0.27.3:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   estree-walker@3.0.3:
     dependencies:
@@ -2225,7 +1974,7 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 
@@ -2244,7 +1993,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   object-assign@4.1.1: {}
 
@@ -2273,15 +2022,15 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.10):
+  postcss-load-config@6.0.1(postcss@8.5.23):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.10
+      postcss: 8.5.23
 
-  postcss@8.5.10:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2423,18 +2172,18 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.10)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.23)(typescript@5.9.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.3)
+      bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.3
+      esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.10)
+      postcss-load-config: 6.0.1(postcss@8.5.23)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -2443,7 +2192,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.10
+      postcss: 8.5.23
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -2457,22 +2206,22 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  vite@7.3.2(@types/node@25.3.0):
+  vite@7.3.5(@types/node@25.3.0):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.23
       rollup: 4.61.0
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.3.0
       fsevents: 2.3.3
 
-  vitest@4.1.0(@types/node@25.3.0)(vite@7.3.2(@types/node@25.3.0)):
+  vitest@4.1.0(@types/node@25.3.0)(vite@7.3.5(@types/node@25.3.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.2(@types/node@25.3.0))
+      '@vitest/mocker': 4.1.0(vite@7.3.5(@types/node@25.3.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -2489,7 +2238,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.3.0)
+      vite: 7.3.5(@types/node@25.3.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.3.0


### PR DESCRIPTION
## Summary

This is the follow-up security audit of every PR merged from 2026-07-17 through 2026-08-17, the direct release commits in that window, and the broader SDK security/performance surface.

The detailed audit, methodology, PR-by-PR outcome, upstream comparison, and residual-risk register are in [docs/agents/security-audit-2026-08-17.md](https://github.com/openbudgetfun/solana_kit/blob/ifi/security-audit-recent-merges/docs/agents/security-audit-2026-08-17.md).

## Material findings fixed

- generate valid Ed25519 Helius auth keypairs instead of unrelated random public/private halves;
- align Helius v3 signup and project provisioning with bearer JWT endpoints, and validate payment inputs;
- harden WebSocket literal-host SSRF filtering, propagate the private-host opt-in, and redact credential-bearing Helius URLs;
- make RPC transaction introspection fail closed on malformed or mismatched data;
- dispose/clear SDK-owned private keys and payer secrets deterministically;
- make key-file creation exclusive, reject overwrite symlinks, and require POSIX mode 0600;
- preserve caller ownership of Surfpool signers while disposing internally created payers;
- remediate all 20 audited pnpm advisories and make the standalone renderer build reproducible;
- document the remaining Helius smart-transaction correctness risk instead of implying the façade is safe for value transfers.

## Recent PR review outcome

The material regressions traced to #204, #207, #208, and #211. The audit also found older gaps originating in #34, #37, #159, #163, and dependency drift after #186. No additional exploitable regression was found in #198–#203, #205, #206, or #210.

## Verification

- full workspace tests: 6,746 passed, 1 intentionally skipped;
- standalone renderer: typecheck, 396 tests, and all bundle targets passed;
- `lint:all`, `docs:check`, and `monochange check`: passed;
- OSV scan across all 3 lockfiles: 0 advisories (from 20 initially);
- gitleaks across 584 commits: no leaks;
- upstream metadata/parity: 16 parity tests passed against `@solana/kit@7.1.0`;
- workspace benchmarks: passed with no new asymptotic regression found.

## Residual risks

The audit report records follow-up work for the legacy Helius smart-transaction façade, DNS rebinding/private HTTP destinations, transport time/size bounds, best-effort VM secret erasure, and Windows key-file ACLs.

## Release

Includes one patch changeset covering every affected package.