### PR TITLE
🐛 fix(codama-renderers-dart): support serialized Codama schemas

### DIFF
--- a/.changeset/fix-codama-dart-pina-schema.md
+++ b/.changeset/fix-codama-dart-pina-schema.md
@@ -1,0 +1,7 @@
+---
+"codama-renderers-dart": patch
+---
+
+# Support Current Codama and Serialized Pina IDLs
+
+Align the Dart renderer with Codama 1.10, normalize omitted serialized child collections from Pina IDLs, and publish valid module entry points for Node, browser, and React Native consumers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,10 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: stable
+          cache: true
       - name: install
         run: pnpm install --frozen-lockfile
       - name: typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,12 @@ jobs:
         run: test:coverage
         shell: devenv shell -- bash -e {0}
       - name: NPM renderer coverage
-        run: pnpm --filter codama-renderers-dart test:coverage
+        run: |
+          dart_bin_dir="$RUNNER_TEMP/devenv-dart-bin"
+          mkdir -p "$dart_bin_dir"
+          ln -s "$GITHUB_WORKSPACE/.devenv/profile/bin/dart" "$dart_bin_dir/dart"
+          ln -s "$GITHUB_WORKSPACE/.devenv/profile/bin/flutter" "$dart_bin_dir/flutter"
+          PATH="$dart_bin_dir:$PATH" pnpm --filter codama-renderers-dart test:coverage
       - name: prepare Codecov flag reports
         id: prepare-codecov-flags
         run: dart run scripts/prepare_codecov_flags.dart --lcov coverage/lcov.info --out-dir coverage/flags --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
       - name: install
         run: pnpm install --frozen-lockfile
       - name: typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
           mkdir -p "$dart_bin_dir"
           ln -s "$GITHUB_WORKSPACE/.devenv/profile/bin/dart" "$dart_bin_dir/dart"
           ln -s "$GITHUB_WORKSPACE/.devenv/profile/bin/flutter" "$dart_bin_dir/flutter"
+          ln -s "$GITHUB_WORKSPACE/.devenv/profile/bin/fvm" "$dart_bin_dir/fvm"
           PATH="$dart_bin_dir:$PATH" pnpm --filter codama-renderers-dart test:coverage
       - name: prepare Codecov flag reports
         id: prepare-codecov-flags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
         shell: devenv shell -- bash -e {0}
       - name: NPM renderer coverage
         run: pnpm --filter codama-renderers-dart test:coverage
+        shell: devenv shell -- bash -e {0}
       - name: prepare Codecov flag reports
         id: prepare-codecov-flags
         run: dart run scripts/prepare_codecov_flags.dart --lcov coverage/lcov.info --out-dir coverage/flags --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,6 @@ jobs:
         shell: devenv shell -- bash -e {0}
       - name: NPM renderer coverage
         run: pnpm --filter codama-renderers-dart test:coverage
-        shell: devenv shell -- bash -e {0}
       - name: prepare Codecov flag reports
         id: prepare-codecov-flags
         run: dart run scripts/prepare_codecov_flags.dart --lcov coverage/lcov.info --out-dir coverage/flags --github-output "$GITHUB_OUTPUT"

--- a/packages/codama-renderers-dart/package.json
+++ b/packages/codama-renderers-dart/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "@codama/errors": "^1.4.4",
-    "@codama/nodes": "^1.4.4",
-    "@codama/renderers-core": "^1.3.3",
-    "@codama/visitors-core": "^1.4.4"
+    "@codama/errors": "^1.10.0",
+    "@codama/nodes": "^1.10.0",
+    "@codama/renderers-core": "^1.3.12",
+    "@codama/visitors-core": "^1.10.0"
   },
   "description": "Codama renderer for generating Dart code targeting the solana_kit SDK",
   "devDependencies": {
-    "@codama/nodes-from-anchor": "^1.3.9",
-    "@codama/renderers-js": "^2.0.2",
+    "@codama/nodes-from-anchor": "^1.5.4",
+    "@codama/renderers-js": "^2.3.1",
     "@types/node": "25.3.0",
     "@vitest/coverage-v8": "4.1.0",
     "rimraf": "6.1.3",
@@ -20,16 +20,19 @@
     "node": ">=18"
   },
   "exports": {
-    "browser": {
-      "import": "./dist/index.browser.mjs",
-      "require": "./dist/index.browser.cjs"
-    },
-    "node": {
-      "import": "./dist/index.node.mjs",
-      "require": "./dist/index.node.cjs"
-    },
-    "react-native": "./dist/index.react-native.mjs",
-    "types": "./dist/types/index.d.ts"
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "react-native": "./dist/index.react-native.js",
+      "browser": {
+        "import": "./dist/index.browser.js",
+        "require": "./dist/index.browser.cjs"
+      },
+      "node": {
+        "import": "./dist/index.node.js",
+        "require": "./dist/index.node.cjs"
+      },
+      "default": "./dist/index.node.js"
+    }
   },
   "files": [
     "dist",
@@ -44,7 +47,7 @@
   ],
   "license": "MIT",
   "main": "./dist/index.node.cjs",
-  "module": "./dist/index.node.mjs",
+  "module": "./dist/index.node.js",
   "name": "codama-renderers-dart",
   "publishConfig": {
     "access": "public"

--- a/packages/codama-renderers-dart/pnpm-lock.yaml
+++ b/packages/codama-renderers-dart/pnpm-lock.yaml
@@ -18,24 +18,24 @@ importers:
   .:
     dependencies:
       '@codama/errors':
-        specifier: ^1.4.4
-        version: 1.7.0
+        specifier: ^1.10.0
+        version: 1.10.1
       '@codama/nodes':
-        specifier: ^1.4.4
-        version: 1.7.0
+        specifier: ^1.10.0
+        version: 1.10.1
       '@codama/renderers-core':
-        specifier: ^1.3.3
-        version: 1.3.8
+        specifier: ^1.3.12
+        version: 1.3.12
       '@codama/visitors-core':
-        specifier: ^1.4.4
-        version: 1.7.0
+        specifier: ^1.10.0
+        version: 1.10.1
     devDependencies:
       '@codama/nodes-from-anchor':
-        specifier: ^1.3.9
-        version: 1.5.0(typescript@5.9.3)
+        specifier: ^1.5.4
+        version: 1.5.4(typescript@5.9.3)
       '@codama/renderers-js':
-        specifier: ^2.0.2
-        version: 2.2.0(typescript@5.9.3)
+        specifier: ^2.3.1
+        version: 2.3.1(typescript@5.9.3)
       '@types/node':
         specifier: 25.3.0
         version: 25.3.0
@@ -78,34 +78,34 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@codama/errors@1.7.0':
-    resolution: {integrity: sha512-N1E4LT3XRYqHHJAnL+eVQ5V3Pc0uSPjsn4Xt6QEO6Fz1p0slF6hbD+/axkFUc7+lNCAfgnkKzhk+6SpFLU/WrQ==}
+  '@codama/errors@1.10.1':
+    resolution: {integrity: sha512-AOeZ7SuSuCHlhh2irN6nI/YSkEDh+v7+/1ihqstJpYM5mYx67MuKNw1X3COe9nF8e3lkU+eVtq51ILdAJa34jA==}
     hasBin: true
 
-  '@codama/fragments@0.1.0':
-    resolution: {integrity: sha512-rWnSKw4UA9LS7mMQyzKnR1woibVEYrYgp66+i+JB+O1lnvU/i/KCH4TmoV+S6Y3ADL2WyznrwfDA3rBET6U5Cg==}
+  '@codama/fragments@0.1.4':
+    resolution: {integrity: sha512-hDykTocyNL0nFKbYZjGPJKtAlMKtKM3PZJbzA8FPOFF1H7U2Z8zd+71UrH9jbSEzdnobAeaRqV71LMPg1yUG8w==}
 
-  '@codama/node-types@1.7.0':
-    resolution: {integrity: sha512-VDytcSgN6jOGEh4aJ1LgSnqCe1drSEUSdAeKOV92aU0MOYiDi2s2B18+Gx7dx40mex2GfVc3zamu7KGzTlxegA==}
+  '@codama/node-types@1.10.1':
+    resolution: {integrity: sha512-PANkfJ0/1rWwgWPWPRQoCoVbozWOb5YPvYDkEEvqXbnofC1qIioglMwy8pT3N1nJybMwS4J1prk05hSPmhRvag==}
 
-  '@codama/nodes-from-anchor@1.5.0':
-    resolution: {integrity: sha512-zbDkjNgMk0EGxHIOOlIq/G2KfXQ7rQrfwogw56MR7nQs6UFGKXnNLJUXiq1m8s3CzfoucvTo49z4mNKTEcGDhQ==}
+  '@codama/nodes-from-anchor@1.5.4':
+    resolution: {integrity: sha512-27Nfbu19etgnNvk5wlmbaCyHOVWYPLwXKr4kDTyuO/cmOWMYR8W4ZiFLivVV+1BYbDtNnCWuIn8RuZZSB8X+XQ==}
 
-  '@codama/nodes@1.7.0':
-    resolution: {integrity: sha512-PZ1zI+SbE1PEaGEka0KjdFrAJ7e9O0kPG4CCGYhjsqUo76OBbINRjNVx7pkP4r8Ksa2r/BLbVIfZV1M/n5J5Kg==}
+  '@codama/nodes@1.10.1':
+    resolution: {integrity: sha512-hcfCCpubRf/BA0vOSEBu95Q8R42yhs0myrqWVCYgv4DQrEqeAiTJxav5NEgmRj8kdFm04Qn854IT4vVXVLP9mA==}
 
-  '@codama/renderers-core@1.3.8':
-    resolution: {integrity: sha512-xy9Qb5BLYTi1OyvlRhRD7n0HUevOQ3QcHSPq9N3kqoUOgL2ziXPXvoejzzLC0OkvA16M7WvK3ihNx/nf4UEClQ==}
+  '@codama/renderers-core@1.3.12':
+    resolution: {integrity: sha512-LyjFPg66hgfeEI9yV952LSKH4M1UOl1zoIRZgMT25hw5rGQmxxYxNqyKSleqEzJ4uKEO4kAj2WVhFVK4F4sAbA==}
 
-  '@codama/renderers-js@2.2.0':
-    resolution: {integrity: sha512-/GWVnB329kMkeqlOqX+NWQAmd1k6yybVOp7C5X+LEvrZ2A5w1saQwWFbBMCq/EQPqnFU+CRFoG/+7KubAEa73Q==}
+  '@codama/renderers-js@2.3.1':
+    resolution: {integrity: sha512-+7WtjpcqnlPkweG+tWWiER2XkJP7SF+RJgYpI0RHc91ZP60Umt0qc+0JPuqMyiPhVrLTN2U/lpsBDQw2MeEsvA==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/visitors-core@1.7.0':
-    resolution: {integrity: sha512-ii1Z39ORzssMQdpxqpjaHCLbFwO4KZbI1SrsJ1e0r+0g03gxuYEA1H6RoxcrIOuUeOnqNtLb96cErrzHdrx23Q==}
+  '@codama/visitors-core@1.10.1':
+    resolution: {integrity: sha512-l5dEZ7Ra5KU64y0Nw79CUp4bAlKRQg9m1DlW1nfQtMEByWEzqteOYesKCgK1z3ypCOXqkN9qlrLAqaYSbOa9Vw==}
 
-  '@codama/visitors@1.7.0':
-    resolution: {integrity: sha512-wk8ufgX3AfKOnaok5H4y1UteLyY/WkDIhhKRE7y5MJqOn5JnxLgL9R4MU2+5TmZUF04sdwyUn6fPho0IqTq+BQ==}
+  '@codama/visitors@1.10.1':
+    resolution: {integrity: sha512-odsT0HMGpByL4fynLEmVJVoWB1jU5+DNg6pSiJXHmWpJE68mHvgK3tXUTj7eU8zAW+lAjfQWui6pcFp8W4xhJA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -276,8 +276,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@noble/hashes@2.2.0':
-    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
 
   '@rollup/rollup-android-arm-eabi@4.61.0':
@@ -427,8 +427,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-core@6.9.0':
-    resolution: {integrity: sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==}
+  '@solana/codecs-core@7.1.0':
+    resolution: {integrity: sha512-pl1gCCvviKekrijEDieZ1ps3LjC6ova2pZ/ZBXEJJa46nF7M0hwdZe/KzbMxKQ8WtT/WqW8Uyh6JQt8IJcMgRw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -454,8 +454,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@6.9.0':
-    resolution: {integrity: sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==}
+  '@solana/codecs-numbers@7.1.0':
+    resolution: {integrity: sha512-Hfw5OXx7tbSJ4iQ0r1ar6D+7XixkX8K36ni9cHDrunpiTo9SLIE0Lzj9/889aPNv4J4JggW1bpqzcrz3RI/o5g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -475,8 +475,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@6.9.0':
-    resolution: {integrity: sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==}
+  '@solana/codecs-strings@7.1.0':
+    resolution: {integrity: sha512-YIv/XVDYTzkYiFRdbjK6tI1BUKNlV1ta5hl9oK6+CoCDZn7nECfAN96KPYs94jzbN5VgMgbEqi6tlQcdy5KuCg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -506,8 +506,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/errors@6.9.0':
-    resolution: {integrity: sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==}
+  '@solana/errors@7.1.0':
+    resolution: {integrity: sha512-sJ0mM6SHN7fa6auHARRAGjjDpkFzhx6jmgHZAjliC/xADMfI2IYrTnAwguRV9dVBOsEHicylIXszvsyRb6BmEw==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -639,9 +639,9 @@ packages:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
 
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1109,65 +1109,65 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@codama/errors@1.7.0':
+  '@codama/errors@1.10.1':
     dependencies:
-      '@codama/node-types': 1.7.0
-      commander: 14.0.3
+      '@codama/node-types': 1.10.1
+      commander: 15.0.0
       picocolors: 1.1.1
 
-  '@codama/fragments@0.1.0':
+  '@codama/fragments@0.1.4':
     dependencies:
-      '@codama/errors': 1.7.0
+      '@codama/errors': 1.10.1
 
-  '@codama/node-types@1.7.0': {}
+  '@codama/node-types@1.10.1': {}
 
-  '@codama/nodes-from-anchor@1.5.0(typescript@5.9.3)':
+  '@codama/nodes-from-anchor@1.5.4(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors': 1.7.0
-      '@noble/hashes': 2.2.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/visitors': 1.10.1
+      '@noble/hashes': 2.3.0
       '@solana/codecs': 5.5.1(typescript@5.9.3)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/nodes@1.7.0':
+  '@codama/nodes@1.10.1':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/node-types': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/node-types': 1.10.1
 
-  '@codama/renderers-core@1.3.8':
+  '@codama/renderers-core@1.3.12':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/fragments': 0.1.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors-core': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/fragments': 0.1.4
+      '@codama/nodes': 1.10.1
+      '@codama/visitors-core': 1.10.1
 
-  '@codama/renderers-js@2.2.0(typescript@5.9.3)':
+  '@codama/renderers-js@2.3.1(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/renderers-core': 1.3.8
-      '@codama/visitors-core': 1.7.0
-      '@solana/codecs-strings': 6.9.0(typescript@5.9.3)
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/renderers-core': 1.3.12
+      '@codama/visitors-core': 1.10.1
+      '@solana/codecs-strings': 7.1.0(typescript@5.9.3)
       prettier: 3.8.3
       semver: 7.8.1
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/visitors-core@1.7.0':
+  '@codama/visitors-core@1.10.1':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors@1.7.0':
+  '@codama/visitors@1.10.1':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors-core': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/visitors-core': 1.10.1
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -1261,7 +1261,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@noble/hashes@2.2.0': {}
+  '@noble/hashes@2.3.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.61.0':
     optional: true
@@ -1344,9 +1344,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-core@6.9.0(typescript@5.9.3)':
+  '@solana/codecs-core@7.1.0(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.9.0(typescript@5.9.3)
+      '@solana/errors': 7.1.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -1365,10 +1365,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@6.9.0(typescript@5.9.3)':
+  '@solana/codecs-numbers@7.1.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.9.0(typescript@5.9.3)
-      '@solana/errors': 6.9.0(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.0(typescript@5.9.3)
+      '@solana/errors': 7.1.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -1380,11 +1380,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-strings@6.9.0(typescript@5.9.3)':
+  '@solana/codecs-strings@7.1.0(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.9.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.9.0(typescript@5.9.3)
-      '@solana/errors': 6.9.0(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.0(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.0(typescript@5.9.3)
+      '@solana/errors': 7.1.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -1407,10 +1407,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/errors@6.9.0(typescript@5.9.3)':
+  '@solana/errors@7.1.0(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
-      commander: 14.0.3
+      commander: 15.0.0
     optionalDependencies:
       typescript: 5.9.3
 
@@ -1548,7 +1548,7 @@ snapshots:
 
   commander@14.0.2: {}
 
-  commander@14.0.3: {}
+  commander@15.0.0: {}
 
   commander@4.1.1: {}
 

--- a/packages/codama-renderers-dart/readme.md
+++ b/packages/codama-renderers-dart/readme.md
@@ -37,6 +37,21 @@ visit(root, renderVisitor("lib/src/generated", {
 }));
 ```
 
+### Serialized Pina IDLs
+
+`renderVisitor` accepts parsed Codama JSON as well as roots made with Codama constructors. Pina omits empty collections from its serialized IDLs; the renderer restores those structural defaults on an internal copy before traversal, leaving the parsed object unchanged.
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { visit } from "@codama/visitors-core";
+import { renderVisitor } from "codama-renderers-dart";
+
+const idl = JSON.parse(await readFile("target/codama/my_program.json", "utf8"));
+visit(idl, renderVisitor("lib/src/generated"));
+```
+
+Use `normalizeRootNode(idl)` when calling lower-level visitors such as `getRenderMapVisitor` directly.
+
 ### Codama CLI
 
 Create a `codama.json` configuration file:

--- a/packages/codama-renderers-dart/src/fragments/accountPage.ts
+++ b/packages/codama-renderers-dart/src/fragments/accountPage.ts
@@ -23,10 +23,8 @@ export function getAccountPageFragment(
 ): Fragment {
   const name = node.name as string;
   const typeName = scope.nameApi.dataType(name);
-  const dataNode = resolveNestedTypeNode(node.data);
-
   // Fields from the struct data
-  const fields = dataNode.fields;
+  const fields = resolveNestedTypeNode(node.data).fields ?? [];
 
   // Visit each field type once and collect manifests for reuse
   const fieldManifests = fields.map((f: StructFieldTypeNode) => ({

--- a/packages/codama-renderers-dart/src/fragments/instructionPage.ts
+++ b/packages/codama-renderers-dart/src/fragments/instructionPage.ts
@@ -40,7 +40,7 @@ export function getInstructionPageFragment(
   const dataClassName = `${typeName}InstructionData`;
 
   // Visit each arg type once and collect manifests for reuse
-  const allArgManifests = allArgs.map((arg) => ({
+  const allArgManifests = (node.arguments ?? []).map((arg) => ({
     arg,
     manifest: visit(arg.type, scope.typeManifestVisitor),
   }));

--- a/packages/codama-renderers-dart/src/fragments/typePage.ts
+++ b/packages/codama-renderers-dart/src/fragments/typePage.ts
@@ -1,4 +1,9 @@
-import type { DefinedTypeNode, StructFieldTypeNode, TypeNode } from "@codama/nodes";
+import type {
+  DefinedTypeNode,
+  EnumVariantTypeNode,
+  StructFieldTypeNode,
+  TypeNode,
+} from "@codama/nodes";
 import { resolveNestedTypeNode } from "@codama/nodes";
 import { visit } from "@codama/visitors-core";
 
@@ -30,13 +35,14 @@ export function getTypePageFragment(
 
   // Check what kind of type this is
   if (typeNode.kind === "enumTypeNode") {
-    const isScalar = (typeNode.variants ?? []).every(
+    const variants = typeNode.variants ?? [];
+    const isScalar = variants.every(
       (v) => v.kind === "enumEmptyVariantTypeNode",
     );
     if (isScalar) {
-      return getScalarEnumPageFragment(node, scope);
+      return getScalarEnumPageFragment(node, variants, scope);
     }
-    return getDataEnumPageFragment(node, scope);
+    return getDataEnumPageFragment(node, variants, scope);
   }
 
   if (typeNode.kind === "structTypeNode") {
@@ -52,6 +58,7 @@ export function getTypePageFragment(
  */
 function getScalarEnumPageFragment(
   node: DefinedTypeNode,
+  enumVariants: EnumVariantTypeNode[],
   scope: RenderScope,
 ): Fragment {
   const name = node.name as string;
@@ -59,7 +66,7 @@ function getScalarEnumPageFragment(
   const enumNode = node.type;
   if (enumNode.kind !== "enumTypeNode") return emptyFragment();
 
-  const variants = (enumNode.variants ?? []).map((v) => {
+  const variants = enumVariants.map((v) => {
     const variantName = scope.nameApi.enumVariant(v.name as string);
     return variantName;
   });
@@ -115,6 +122,7 @@ Codec<${fragmentFromString(typeName)}, ${fragmentFromString(typeName)}> ${fragme
  */
 function getDataEnumPageFragment(
   node: DefinedTypeNode,
+  variants: EnumVariantTypeNode[],
   scope: RenderScope,
 ): Fragment {
   const name = node.name as string;
@@ -130,7 +138,6 @@ function getDataEnumPageFragment(
   // Collect all field type manifests from variants so we can merge their imports
   const allVariantManifests: { encoder: Fragment; decoder: Fragment; type: Fragment }[] = [];
 
-  const variants = enumNode.variants ?? [];
   for (let i = 0; i < variants.length; i++) {
     const variant = variants[i];
     const variantName = pascalCase(variant.name as string);

--- a/packages/codama-renderers-dart/src/fragments/typePage.ts
+++ b/packages/codama-renderers-dart/src/fragments/typePage.ts
@@ -30,7 +30,7 @@ export function getTypePageFragment(
 
   // Check what kind of type this is
   if (typeNode.kind === "enumTypeNode") {
-    const isScalar = typeNode.variants.every(
+    const isScalar = (typeNode.variants ?? []).every(
       (v) => v.kind === "enumEmptyVariantTypeNode",
     );
     if (isScalar) {
@@ -59,7 +59,7 @@ function getScalarEnumPageFragment(
   const enumNode = node.type;
   if (enumNode.kind !== "enumTypeNode") return emptyFragment();
 
-  const variants = enumNode.variants.map((v) => {
+  const variants = (enumNode.variants ?? []).map((v) => {
     const variantName = scope.nameApi.enumVariant(v.name as string);
     return variantName;
   });
@@ -130,8 +130,9 @@ function getDataEnumPageFragment(
   // Collect all field type manifests from variants so we can merge their imports
   const allVariantManifests: { encoder: Fragment; decoder: Fragment; type: Fragment }[] = [];
 
-  for (let i = 0; i < enumNode.variants.length; i++) {
-    const variant = enumNode.variants[i];
+  const variants = enumNode.variants ?? [];
+  for (let i = 0; i < variants.length; i++) {
+    const variant = variants[i];
     const variantName = pascalCase(variant.name as string);
     const variantClassName = scope.nameApi.sealedClassVariant(
       name,
@@ -163,7 +164,7 @@ function getDataEnumPageFragment(
       decodeCases.push(`case ${i}: return const ${variantClassName}();`);
     } else if (variant.kind === "enumStructVariantTypeNode") {
       const resolvedStruct = resolveNestedTypeNode(variant.struct);
-      const fields = resolvedStruct.fields;
+      const fields = resolvedStruct.fields ?? [];
 
       // Visit each field type once and collect manifests
       const fieldManifests = fields.map((f: StructFieldTypeNode) => ({
@@ -271,7 +272,7 @@ ${fieldDecls}
       decodeCases.push(`case ${i}: return ${variantClassName}(${fromMapFields.replace(/\n/g, ' ').replace(/,$/, '')});`);
     } else if (variant.kind === "enumTupleVariantTypeNode") {
       const resolvedTuple = resolveNestedTypeNode(variant.tuple);
-      const items = resolvedTuple.items;
+      const items = resolvedTuple.items ?? [];
       if (items.length === 1) {
         const manifest = visit(items[0], scope.typeManifestVisitor);
         allVariantManifests.push(manifest);
@@ -384,7 +385,7 @@ function getStructPageFragment(
   const structNode = node.type;
   if (structNode.kind !== "structTypeNode") return emptyFragment();
 
-  const fields = structNode.fields;
+  const fields = structNode.fields ?? [];
 
   // Visit each field type once and collect manifests for reuse
   const fieldManifests = fields.map((f: StructFieldTypeNode) => ({

--- a/packages/codama-renderers-dart/src/index.ts
+++ b/packages/codama-renderers-dart/src/index.ts
@@ -3,6 +3,7 @@ export { getRenderMapVisitor } from "./visitors/getRenderMapVisitor.js";
 export { getTypeManifestVisitor } from "./visitors/getTypeManifestVisitor.js";
 export { DartImportMap, DART_EXTERNAL_PACKAGE_MAP } from "./utils/importMap.js";
 export { createDartNameApi } from "./utils/nameTransformers.js";
+export { normalizeRootNode } from "./utils/normalizeRootNode.js";
 export type { DartNameApi } from "./utils/nameTransformers.js";
 export type { RenderOptions, GetRenderMapOptions, RenderScope } from "./utils/options.js";
 export type { TypeManifest } from "./utils/typeManifest.js";

--- a/packages/codama-renderers-dart/src/utils/formatCode.ts
+++ b/packages/codama-renderers-dart/src/utils/formatCode.ts
@@ -2,11 +2,11 @@ import { execSync } from "node:child_process";
 
 /**
  * Format Dart code using `dart format`.
- * Falls back to returning the unformatted code if dart is not available.
+ * Falls back to returning the unformatted code if Dart is not available.
  */
 export function formatDartCode(code: string): string {
   try {
-    const result = execSync("dart format --fix -", {
+    const result = execSync("dart format --output=show", {
       input: code,
       encoding: "utf-8",
       timeout: 30_000,
@@ -23,13 +23,9 @@ export function formatDartCode(code: string): string {
  * Format all Dart files in a directory using `dart format`.
  */
 export function formatDartDirectory(dir: string): void {
-  try {
-    execSync(`dart format --fix "${dir}"`, {
-      encoding: "utf-8",
-      timeout: 60_000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-  } catch {
-    // Silently ignore if dart format is not available
-  }
+  execSync(`dart format "${dir}"`, {
+    encoding: "utf-8",
+    timeout: 60_000,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
 }

--- a/packages/codama-renderers-dart/src/utils/index.ts
+++ b/packages/codama-renderers-dart/src/utils/index.ts
@@ -3,6 +3,7 @@ export * from "./formatCode.js";
 export * from "./fragment.js";
 export * from "./importMap.js";
 export * from "./nameTransformers.js";
+export * from "./normalizeRootNode.js";
 export * from "./options.js";
 export * from "./typeManifest.js";
 export * from "./wellKnownAddresses.js";

--- a/packages/codama-renderers-dart/src/utils/normalizeRootNode.ts
+++ b/packages/codama-renderers-dart/src/utils/normalizeRootNode.ts
@@ -1,0 +1,76 @@
+import type { RootNode } from "@codama/nodes";
+
+/**
+ * Normalizes a serialized Codama root before it reaches Codama's visitors.
+ *
+ * Codama constructors materialize empty child collections, while generated
+ * JSON commonly omits them. Pina intentionally omits those empty fields, so
+ * restore only the structural defaults required by Codama traversal. This is
+ * a copy: callers retain their original parsed IDL unchanged.
+ */
+export function normalizeRootNode(root: RootNode): RootNode {
+  return normalizeNode(root) as RootNode;
+}
+
+function normalizeNode(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeNode);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const normalized = Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, normalizeNode(child)]),
+  ) as Record<string, unknown>;
+
+  switch (normalized.kind) {
+    case "rootNode":
+      setEmptyCollection(normalized, "additionalPrograms");
+      break;
+    case "programNode":
+      setEmptyCollection(normalized, "accounts");
+      setEmptyCollection(normalized, "constants");
+      setEmptyCollection(normalized, "definedTypes");
+      setEmptyCollection(normalized, "errors");
+      setEmptyCollection(normalized, "events");
+      setEmptyCollection(normalized, "instructions");
+      setEmptyCollection(normalized, "pdas");
+      break;
+    case "instructionNode":
+      setEmptyCollection(normalized, "accounts");
+      setEmptyCollection(normalized, "arguments");
+      break;
+    case "pdaNode":
+      setEmptyCollection(normalized, "seeds");
+      break;
+    case "structTypeNode":
+      setEmptyCollection(normalized, "fields");
+      break;
+    case "enumTypeNode":
+      setEmptyCollection(normalized, "variants");
+      break;
+    case "tupleTypeNode":
+      setEmptyCollection(normalized, "items");
+      break;
+    case "hiddenPrefixTypeNode":
+      setEmptyCollection(normalized, "prefix");
+      break;
+    case "hiddenSuffixTypeNode":
+      setEmptyCollection(normalized, "suffix");
+      break;
+  }
+
+  return normalized;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function setEmptyCollection(record: Record<string, unknown>, key: string): void {
+  if (record[key] === undefined) {
+    record[key] = [];
+  }
+}

--- a/packages/codama-renderers-dart/src/visitors/getRenderMapVisitor.ts
+++ b/packages/codama-renderers-dart/src/visitors/getRenderMapVisitor.ts
@@ -86,7 +86,7 @@ export function getRenderMapVisitor(
         visitRoot(node: RootNode, { self }) {
           const programMaps = [
             visit(node.program, self),
-            ...node.additionalPrograms.map((p) => visit(p, self)),
+            ...(node.additionalPrograms ?? []).map((p) => visit(p, self)),
           ];
 
           const mergedProgramMap = mergeRenderMaps(programMaps);

--- a/packages/codama-renderers-dart/src/visitors/getTypeManifestVisitor.ts
+++ b/packages/codama-renderers-dart/src/visitors/getTypeManifestVisitor.ts
@@ -327,8 +327,9 @@ export function getTypeManifestVisitor(input: {
     },
 
     visitStructType(node: StructTypeNode, { self }) {
-      const fields = (node.fields ?? []).map((f) => visit(f, self));
-      const fieldNames = (node.fields ?? []).map((f) => f.name as string);
+      const nodeFields = node.fields ?? [];
+      const fields = nodeFields.map((f) => visit(f, self));
+      const fieldNames = nodeFields.map((f) => f.name as string);
 
       // Type: Map<String, Object?> (for inline structs without a name)
       const typeStr = "Map<String, Object?>";

--- a/packages/codama-renderers-dart/src/visitors/getTypeManifestVisitor.ts
+++ b/packages/codama-renderers-dart/src/visitors/getTypeManifestVisitor.ts
@@ -286,7 +286,7 @@ export function getTypeManifestVisitor(input: {
     },
 
     visitTupleType(node: TupleTypeNode, { self }) {
-      const itemManifests = node.items.map((item) => visit(item, self));
+      const itemManifests = (node.items ?? []).map((item) => visit(item, self));
       const typeList = itemManifests
         .map((m) => m.type.content)
         .join(", ");
@@ -327,8 +327,8 @@ export function getTypeManifestVisitor(input: {
     },
 
     visitStructType(node: StructTypeNode, { self }) {
-      const fields = node.fields.map((f) => visit(f, self));
-      const fieldNames = node.fields.map((f) => f.name as string);
+      const fields = (node.fields ?? []).map((f) => visit(f, self));
+      const fieldNames = (node.fields ?? []).map((f) => f.name as string);
 
       // Type: Map<String, Object?> (for inline structs without a name)
       const typeStr = "Map<String, Object?>";
@@ -371,7 +371,7 @@ export function getTypeManifestVisitor(input: {
 
     visitEnumType(node: EnumTypeNode, { self }) {
       // Check if this is a scalar enum (all empty variants)
-      const isScalar = node.variants.every(
+      const isScalar = (node.variants ?? []).every(
         (v) => v.kind === "enumEmptyVariantTypeNode",
       );
 
@@ -549,7 +549,7 @@ export function getTypeManifestVisitor(input: {
 
     visitHiddenPrefixType(node: HiddenPrefixTypeNode, { self }) {
       const innerManifest = visit(node.type, self);
-      const prefixes = node.prefix.map((p) => getHiddenAffixManifest(p, self));
+      const prefixes = (node.prefix ?? []).map((p) => getHiddenAffixManifest(p, self));
       const prefixEncoders = prefixes
         .map((p) => p.encoder.content)
         .join(", ");
@@ -584,7 +584,7 @@ export function getTypeManifestVisitor(input: {
 
     visitHiddenSuffixType(node: HiddenSuffixTypeNode, { self }) {
       const innerManifest = visit(node.type, self);
-      const suffixes = node.suffix.map((s) => getHiddenAffixManifest(s, self));
+      const suffixes = (node.suffix ?? []).map((s) => getHiddenAffixManifest(s, self));
       const suffixEncoders = suffixes
         .map((s) => s.encoder.content)
         .join(", ");

--- a/packages/codama-renderers-dart/src/visitors/renderVisitor.ts
+++ b/packages/codama-renderers-dart/src/visitors/renderVisitor.ts
@@ -9,6 +9,7 @@ import type { Fragment } from "../utils/fragment.js";
 import type { RenderOptions } from "../utils/options.js";
 import { DartImportMap, DART_EXTERNAL_PACKAGE_MAP } from "../utils/importMap.js";
 import { formatDartDirectory } from "../utils/formatCode.js";
+import { normalizeRootNode } from "../utils/normalizeRootNode.js";
 import { getRenderMapVisitor } from "./getRenderMapVisitor.js";
 
 /**
@@ -29,6 +30,8 @@ export function renderVisitor(
   } = options;
 
   return rootNodeVisitor((root: RootNode) => {
+    const normalizedRoot = normalizeRootNode(root);
+
     // 1. Optionally delete the output directory
     if (deleteFolderBeforeRendering && existsSync(outputDir)) {
       deleteDirectory(outputDir);
@@ -36,7 +39,7 @@ export function renderVisitor(
 
     // 2. Build the render map
     const renderMap = visit(
-      root,
+      normalizedRoot,
       getRenderMapVisitor({ nameApi, dependencyMap }),
     );
 

--- a/packages/codama-renderers-dart/test/e2e/generate-dart.test.ts
+++ b/packages/codama-renderers-dart/test/e2e/generate-dart.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { describe, it, expect, beforeAll } from "vitest";
@@ -13,22 +13,6 @@ import stakingIdl from "../fixtures/staking.json";
 const TEST_GENERATED_DIR = resolve(__dirname, "../../test-generated");
 const TOKEN_VAULT_DIR = join(TEST_GENERATED_DIR, "lib/src/token_vault");
 const STAKING_DIR = join(TEST_GENERATED_DIR, "lib/src/staking");
-
-/**
- * Check if dart is available in the system.
- */
-function isDartAvailable(): boolean {
-  try {
-    execSync("dart --version", {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-      timeout: 10_000,
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Recursively collect all file paths under a directory.
@@ -49,15 +33,13 @@ function collectFiles(dir: string, prefix = ""): string[] {
 }
 
 describe("Generate Dart code and validate", () => {
-  const dartAvailable = isDartAvailable();
-
   beforeAll(() => {
     // Generate token_vault code
     const tvRoot = rootNodeFromAnchor(tokenVaultIdl);
     visit(
       tvRoot,
       renderVisitor(TOKEN_VAULT_DIR, {
-        formatCode: false,
+        formatCode: true,
         deleteFolderBeforeRendering: true,
       }),
     );
@@ -67,11 +49,20 @@ describe("Generate Dart code and validate", () => {
     visit(
       stakingRoot,
       renderVisitor(STAKING_DIR, {
-        formatCode: false,
+        formatCode: true,
         deleteFolderBeforeRendering: true,
       }),
     );
-  });
+
+    // The workspace includes Flutter examples, so its shared resolution must
+    // use Flutter's pub wrapper even though this generated package is pure Dart.
+    execFileSync("flutter", ["pub", "get"], {
+      cwd: TEST_GENERATED_DIR,
+      stdio: "pipe",
+      timeout: 120_000,
+    });
+
+  }, 180_000);
 
   it("should generate token_vault files", () => {
     const files = collectFiles(TOKEN_VAULT_DIR);
@@ -205,84 +196,23 @@ describe("Generate Dart code and validate", () => {
     expect(stakeInfo).toContain("final bool isLocked;");
   });
 
-  it("should resolve dart pub get in test-generated package", { timeout: 180_000 }, () => {
-    if (!dartAvailable) {
-      console.log("Skipping: dart not available");
-      return;
-    }
+  it("formats, analyzes, and tests the complete generated Dart package", { timeout: 180_000 }, () => {
+    execFileSync("dart", ["format", "--output=none", "."], {
+      cwd: TEST_GENERATED_DIR,
+      stdio: "pipe",
+      timeout: 120_000,
+    });
 
-    try {
-      execSync("dart pub get", {
-        cwd: TEST_GENERATED_DIR,
-        encoding: "utf-8",
-        timeout: 120_000,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-    } catch (error: any) {
-      // pub get may fail due to workspace setup — report but don't fail the test
-      console.log(
-        "dart pub get had issues (may be expected in CI):",
-        error.stderr?.substring(0, 500) || error.message,
-      );
-    }
-  });
+    execFileSync("dart", ["analyze", "--fatal-infos"], {
+      cwd: TEST_GENERATED_DIR,
+      stdio: "pipe",
+      timeout: 120_000,
+    });
 
-  it("should pass dart analyze on error and program pages (cleanest generated code)", { timeout: 120_000 }, () => {
-    if (!dartAvailable) {
-      console.log("Skipping: dart not available");
-      return;
-    }
-
-    // Only analyze the cleanest generated files: errors and programs
-    // These files don't have the use() artifact issue
-    const filesToCheck = [
-      join(TOKEN_VAULT_DIR, "errors/token_vault.dart"),
-      join(TOKEN_VAULT_DIR, "programs/token_vault.dart"),
-      join(STAKING_DIR, "errors/staking.dart"),
-      join(STAKING_DIR, "programs/staking.dart"),
-    ];
-
-    for (const file of filesToCheck) {
-      expect(existsSync(file), `File should exist: ${file}`).toBe(true);
-      const content = readFileSync(file, "utf-8");
-      // These files should be clean of artifacts
-      expect(content).not.toContain("[object Object]");
-    }
-  });
-
-  it("should run dart test in test-generated/ (if dart is available and dependencies resolved)", { timeout: 180_000 }, () => {
-    if (!dartAvailable) {
-      console.log("Skipping: dart not available");
-      return;
-    }
-
-    // Check if pub get succeeded (look for .dart_tool)
-    const pubGetSucceeded = existsSync(
-      join(TEST_GENERATED_DIR, ".dart_tool"),
-    );
-    if (!pubGetSucceeded) {
-      console.log(
-        "Skipping dart test: pub get did not succeed (dependencies not resolved)",
-      );
-      return;
-    }
-
-    try {
-      const result = execSync("dart test", {
-        cwd: TEST_GENERATED_DIR,
-        encoding: "utf-8",
-        timeout: 120_000,
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      console.log("dart test output:", result.substring(0, 1000));
-    } catch (error: any) {
-      // The generated code has known issues (use() artifacts, [object Object])
-      // so dart test may fail. Report the error but don't fail the vitest test,
-      // since this is testing the generation pipeline, not the generated code quality.
-      console.log(
-        "dart test had issues (may be expected due to known generated code artifacts):",
-        error.stderr?.substring(0, 1000) || error.message,
-      );
-    }
+    execFileSync("dart", ["test"], {
+      cwd: TEST_GENERATED_DIR,
+      stdio: "pipe",
+      timeout: 120_000,
+    });
   });
 });

--- a/packages/codama-renderers-dart/test/e2e/package-exports.test.ts
+++ b/packages/codama-renderers-dart/test/e2e/package-exports.test.ts
@@ -1,0 +1,88 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, it } from "vitest";
+
+const packageDirectory = join(import.meta.dirname, "../..");
+let consumerDirectory = "";
+let packDirectory = "";
+
+describe("published package exports", () => {
+  beforeAll(() => {
+    packDirectory = mkdtempSync(join(tmpdir(), "codama-dart-pack-"));
+    consumerDirectory = mkdtempSync(join(tmpdir(), "codama-dart-consumer-"));
+
+    writeFileSync(
+      join(consumerDirectory, "package.json"),
+      JSON.stringify({ name: "codama-dart-consumer", private: true }),
+    );
+
+    execFileSync("pnpm", ["run", "build"], {
+      cwd: packageDirectory,
+      stdio: "pipe",
+      timeout: 120_000,
+    });
+
+    execFileSync("pnpm", ["pack", "--pack-destination", packDirectory], {
+      cwd: packageDirectory,
+      stdio: "pipe",
+      timeout: 120_000,
+    });
+
+    const packageManifest = JSON.parse(
+      readFileSync(join(packageDirectory, "package.json"), "utf8"),
+    ) as { name: string; version: string };
+    const tarballName = `${packageManifest.name.replace("/", "-")}-${packageManifest.version}.tgz`;
+    const tarball = join(packDirectory, tarballName);
+
+    execFileSync("pnpm", ["add", "--ignore-scripts", tarball], {
+      cwd: consumerDirectory,
+      stdio: "pipe",
+      timeout: 120_000,
+    });
+  }, 180_000);
+
+  afterAll(() => {
+    if (consumerDirectory) {
+      rmSync(consumerDirectory, { recursive: true, force: true });
+    }
+
+    if (packDirectory) {
+      rmSync(packDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("loads the node ESM export", () => {
+    assertRendererImport(["--input-type=module"]);
+  });
+
+  it("loads the node CommonJS export", () => {
+    assertRendererImport(["--input-type=commonjs"]);
+  });
+
+  it("loads the browser ESM and CommonJS exports", () => {
+    assertRendererImport(["--conditions=browser", "--input-type=module"]);
+    assertRendererImport(["--conditions=browser", "--input-type=commonjs"]);
+  });
+
+  it("loads the React Native ESM export", () => {
+    assertRendererImport(["--conditions=react-native", "--input-type=module"]);
+  });
+});
+
+function assertRendererImport(nodeArguments: string[]): void {
+  const moduleSource = nodeArguments.includes("--input-type=commonjs")
+    ? "const { renderVisitor } = require('codama-renderers-dart');"
+    : "import { renderVisitor } from 'codama-renderers-dart';";
+
+  execFileSync(
+    process.execPath,
+    [...nodeArguments, "--eval", `${moduleSource}\nif (typeof renderVisitor !== 'function') process.exit(1);`],
+    {
+      cwd: consumerDirectory,
+      stdio: "pipe",
+      timeout: 30_000,
+    },
+  );
+}

--- a/packages/codama-renderers-dart/test/e2e/pina-serialized-idls.test.ts
+++ b/packages/codama-renderers-dart/test/e2e/pina-serialized-idls.test.ts
@@ -1,0 +1,130 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { visit } from "@codama/visitors-core";
+import type { RootNode } from "@codama/nodes";
+
+import { normalizeRootNode } from "../../src/utils/normalizeRootNode.js";
+import { getRenderMapVisitor } from "../../src/visitors/getRenderMapVisitor.js";
+import { renderVisitor } from "../../src/visitors/renderVisitor.js";
+
+const fixtureNames = [
+  "pina-omitted-additional-programs",
+  "pina-omitted-account-fields",
+  "pina-omitted-program-accounts",
+  "pina-omitted-program-instructions",
+  "pina-omitted-instruction-accounts",
+  "pina-omitted-instruction-arguments",
+] as const;
+
+describe("Pina serialized IDLs", () => {
+  it.each(fixtureNames)("renders %s with omitted empty collections", (fixtureName) => {
+    const fixture = loadFixture(fixtureName);
+    const outputDir = mkdtempSync(join(tmpdir(), "codama-dart-pina-"));
+
+    try {
+      visit(fixture, renderVisitor(outputDir, { formatCode: false }));
+
+      const programName = fixture.program.name.replace(
+        /([A-Z])/g,
+        "_$1",
+      ).replace(/^_/, "").toLowerCase();
+      expect(existsSync(join(outputDir, `${programName}.dart`))).toBe(true);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the raw parsed root unchanged while making it safe for map visitors", () => {
+    const rootFixture = loadFixture("pina-omitted-additional-programs");
+    const instructionFixture = loadFixture("pina-omitted-instruction-accounts");
+    const normalizedRoot = normalizeRootNode(rootFixture);
+    const normalizedInstruction = normalizeRootNode(instructionFixture);
+    const renderMap = visit(normalizedInstruction, getRenderMapVisitor());
+
+    expect(rootFixture.additionalPrograms).toBeUndefined();
+    expect(rootFixture.program.accounts).toBeUndefined();
+    expect(rootFixture.program.errors).toBeUndefined();
+    expect(instructionFixture.program.instructions[0].accounts).toBeUndefined();
+    expect(normalizedRoot.additionalPrograms).toEqual([]);
+    expect(normalizedInstruction.program.instructions[0].accounts).toEqual([]);
+    expect(renderMap.has("instructions/hello.dart")).toBe(true);
+  });
+
+  it("normalizes nested serialized child collections without mutating the source", () => {
+    const rawRoot = {
+      kind: "rootNode",
+      program: {
+        kind: "programNode",
+        name: "pinaNestedCollections",
+        publicKey: "11111111111111111111111111111111",
+        version: "0.0.0",
+        accounts: [
+          {
+            kind: "accountNode",
+            name: "state",
+            data: { kind: "structTypeNode" },
+          },
+        ],
+        definedTypes: [
+          {
+            kind: "definedTypeNode",
+            name: "stateKind",
+            type: { kind: "enumTypeNode" },
+          },
+        ],
+        instructions: [],
+        pdas: [{ kind: "pdaNode", name: "statePda" }],
+        errors: [],
+        metadata: {
+          tuple: { kind: "tupleTypeNode" },
+          hiddenPrefix: { kind: "hiddenPrefixTypeNode" },
+          hiddenSuffix: { kind: "hiddenSuffixTypeNode" },
+        },
+      },
+    } as unknown as RootNode;
+
+    const normalized = normalizeRootNode(rawRoot) as unknown as {
+      program: {
+        accounts: Array<{ data: { fields: unknown[] } }>;
+        definedTypes: Array<{ type: { variants: unknown[] } }>;
+        metadata: {
+          tuple: { items: unknown[] };
+          hiddenPrefix: { prefix: unknown[] };
+          hiddenSuffix: { suffix: unknown[] };
+        };
+        pdas: Array<{ seeds: unknown[] }>;
+      };
+    };
+
+    expect((rawRoot as unknown as { program: { pdas: Array<{ seeds?: unknown[] }> } }).program.pdas[0].seeds).toBeUndefined();
+    expect(normalized.program.accounts[0].data.fields).toEqual([]);
+    expect(normalized.program.definedTypes[0].type.variants).toEqual([]);
+    expect(normalized.program.metadata.tuple.items).toEqual([]);
+    expect(normalized.program.metadata.hiddenPrefix.prefix).toEqual([]);
+    expect(normalized.program.metadata.hiddenSuffix.suffix).toEqual([]);
+    expect(normalized.program.pdas[0].seeds).toEqual([]);
+  });
+
+  it("renders an account with omitted struct fields", () => {
+    const fixture = loadFixture("pina-omitted-account-fields");
+    const outputDir = mkdtempSync(join(tmpdir(), "codama-dart-pina-account-"));
+
+    try {
+      visit(fixture, renderVisitor(outputDir, { formatCode: false }));
+
+      const account = readFileSync(join(outputDir, "accounts/state.dart"), "utf8");
+      expect(account).toContain("class State {");
+      expect(account).toContain("const State();");
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function loadFixture(name: (typeof fixtureNames)[number]) {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "../fixtures", `${name}.json`), "utf8"),
+  );
+}

--- a/packages/codama-renderers-dart/test/fixtures/pina-omitted-account-fields.json
+++ b/packages/codama-renderers-dart/test/fixtures/pina-omitted-account-fields.json
@@ -1,0 +1,25 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.8.0",
+  "additionalPrograms": [],
+  "program": {
+    "kind": "programNode",
+    "name": "pinaOmittedAccountFields",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.0.0",
+    "accounts": [
+      {
+        "kind": "accountNode",
+        "name": "state",
+        "data": {
+          "kind": "structTypeNode"
+        }
+      }
+    ],
+    "instructions": [],
+    "definedTypes": [],
+    "errors": [],
+    "pdas": []
+  }
+}

--- a/packages/codama-renderers-dart/test/fixtures/pina-omitted-additional-programs.json
+++ b/packages/codama-renderers-dart/test/fixtures/pina-omitted-additional-programs.json
@@ -1,0 +1,19 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.8.0",
+  "program": {
+    "kind": "programNode",
+    "name": "pinaOmittedAdditionalPrograms",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.0.0",
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "name": "hello",
+        "arguments": [],
+        "discriminators": []
+      }
+    ]
+  }
+}

--- a/packages/codama-renderers-dart/test/fixtures/pina-omitted-instruction-accounts.json
+++ b/packages/codama-renderers-dart/test/fixtures/pina-omitted-instruction-accounts.json
@@ -1,0 +1,24 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.8.0",
+  "additionalPrograms": [],
+  "program": {
+    "kind": "programNode",
+    "name": "pinaOmittedInstructionAccounts",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.0.0",
+    "accounts": [],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "name": "hello",
+        "arguments": [],
+        "discriminators": []
+      }
+    ],
+    "definedTypes": [],
+    "errors": [],
+    "pdas": []
+  }
+}

--- a/packages/codama-renderers-dart/test/fixtures/pina-omitted-instruction-arguments.json
+++ b/packages/codama-renderers-dart/test/fixtures/pina-omitted-instruction-arguments.json
@@ -1,0 +1,24 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.8.0",
+  "additionalPrograms": [],
+  "program": {
+    "kind": "programNode",
+    "name": "pinaOmittedInstructionArguments",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.0.0",
+    "accounts": [],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "name": "hello",
+        "accounts": [],
+        "discriminators": []
+      }
+    ],
+    "definedTypes": [],
+    "errors": [],
+    "pdas": []
+  }
+}

--- a/packages/codama-renderers-dart/test/fixtures/pina-omitted-program-accounts.json
+++ b/packages/codama-renderers-dart/test/fixtures/pina-omitted-program-accounts.json
@@ -1,0 +1,16 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.8.0",
+  "additionalPrograms": [],
+  "program": {
+    "kind": "programNode",
+    "name": "pinaOmittedProgramAccounts",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.0.0",
+    "instructions": [],
+    "definedTypes": [],
+    "errors": [],
+    "pdas": []
+  }
+}

--- a/packages/codama-renderers-dart/test/fixtures/pina-omitted-program-instructions.json
+++ b/packages/codama-renderers-dart/test/fixtures/pina-omitted-program-instructions.json
@@ -1,0 +1,16 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.8.0",
+  "additionalPrograms": [],
+  "program": {
+    "kind": "programNode",
+    "name": "pinaOmittedProgramInstructions",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.0.0",
+    "accounts": [],
+    "definedTypes": [],
+    "errors": [],
+    "pdas": []
+  }
+}

--- a/packages/codama-renderers-dart/test/fragments/typePage.test.ts
+++ b/packages/codama-renderers-dart/test/fragments/typePage.test.ts
@@ -1,4 +1,5 @@
 import {
+  type DefinedTypeNode,
   definedTypeNode,
   enumEmptyVariantTypeNode,
   enumStructVariantTypeNode,
@@ -421,6 +422,72 @@ describe("getTypePageFragment", () => {
 
       expect(frag.content).toContain("getDiscriminatedUnionEncoder");
       expect(frag.content).toContain("getDiscriminatedUnionDecoder");
+    });
+  });
+
+  describe("serialized nodes with omitted empty collections", () => {
+    const serializedNodes = [
+      [
+        "enum variants",
+        {
+          kind: "definedTypeNode",
+          name: "emptyEnum",
+          type: { kind: "enumTypeNode", size: numberTypeNode("u8") },
+        },
+      ],
+      [
+        "enum struct fields",
+        {
+          kind: "definedTypeNode",
+          name: "emptyStructVariant",
+          type: {
+            kind: "enumTypeNode",
+            size: numberTypeNode("u8"),
+            variants: [
+              {
+                kind: "enumStructVariantTypeNode",
+                name: "empty",
+                struct: { kind: "structTypeNode" },
+              },
+            ],
+          },
+        },
+      ],
+      [
+        "enum tuple items",
+        {
+          kind: "definedTypeNode",
+          name: "emptyTupleVariant",
+          type: {
+            kind: "enumTypeNode",
+            size: numberTypeNode("u8"),
+            variants: [
+              {
+                kind: "enumTupleVariantTypeNode",
+                name: "empty",
+                tuple: { kind: "tupleTypeNode" },
+              },
+            ],
+          },
+        },
+      ],
+      [
+        "struct fields",
+        {
+          kind: "definedTypeNode",
+          name: "emptyStruct",
+          type: { kind: "structTypeNode" },
+        },
+      ],
+    ] as const;
+
+    it.each(serializedNodes)("renders without %s", (_name, node) => {
+      const fragment = getTypePageFragment(
+        node as unknown as DefinedTypeNode,
+        createScope(),
+      );
+
+      expect(fragment.content).toContain("Auto-generated. Do not edit.");
     });
   });
 

--- a/packages/codama-renderers-dart/test/utils/formatCode.test.ts
+++ b/packages/codama-renderers-dart/test/utils/formatCode.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { formatDartCode, formatDartDirectory } from "../../src/utils/formatCode.js";
+
+describe("Dart formatting", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(() => {
+    for (const directory of temporaryDirectories) {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("formats a Dart source string", () => {
+    expect(formatDartCode("void main(){print('hello');}")).toBe(
+      "void main() {\n  print('hello');\n}\n",
+    );
+  });
+
+  it("leaves source unchanged when Dart cannot format it", () => {
+    const invalidDart = "void main( {";
+
+    expect(formatDartCode(invalidDart)).toBe(invalidDart);
+  });
+
+  it("formats every Dart file in a directory", () => {
+    const directory = mkdtempSync(join(tmpdir(), "codama-dart-format-"));
+    const sourceFile = join(directory, "example.dart");
+    temporaryDirectories.push(directory);
+    writeFileSync(sourceFile, "void main(){print('hello');}");
+
+    formatDartDirectory(directory);
+
+    expect(readFileSync(sourceFile, "utf8")).toBe(
+      "void main() {\n  print('hello');\n}\n",
+    );
+  });
+});

--- a/packages/codama-renderers-dart/test/visitors/getTypeManifestVisitor.test.ts
+++ b/packages/codama-renderers-dart/test/visitors/getTypeManifestVisitor.test.ts
@@ -2,6 +2,7 @@ import {
   arrayTypeNode,
   booleanTypeNode,
   bytesTypeNode,
+  constantValueNode,
   definedTypeLinkNode,
   enumEmptyVariantTypeNode,
   enumStructVariantTypeNode,
@@ -9,8 +10,11 @@ import {
   enumTypeNode,
   fixedCountNode,
   fixedSizeTypeNode,
+  hiddenPrefixTypeNode,
+  hiddenSuffixTypeNode,
   mapTypeNode,
   numberTypeNode,
+  numberValueNode,
   optionTypeNode,
   prefixedCountNode,
   publicKeyTypeNode,
@@ -21,6 +25,7 @@ import {
   structFieldTypeNode,
   structTypeNode,
   tupleTypeNode,
+  type TypeNode,
 } from "@codama/nodes";
 import {
   LinkableDictionary,
@@ -578,6 +583,48 @@ describe("getTypeManifestVisitor", () => {
       const manifest = visit(node, createVisitor());
       expect(manifest.encoder.content).toContain("getTupleEncoder");
       expect(manifest.decoder.content).toContain("getTupleDecoder");
+    });
+  });
+
+  describe("serialized nodes with omitted empty collections", () => {
+    const constantU8 = constantValueNode(
+      numberTypeNode("u8"),
+      numberValueNode(1),
+    );
+    const { items: _tupleItems, ...tupleWithoutItems } = tupleTypeNode([
+      numberTypeNode("u8"),
+    ]);
+    const { fields: _structFields, ...structWithoutFields } = structTypeNode([
+      structFieldTypeNode({ name: "value", type: numberTypeNode("u8") }),
+    ]);
+    const { variants: _enumVariants, ...enumWithoutVariants } = enumTypeNode([
+      enumEmptyVariantTypeNode("empty"),
+    ]);
+    const { prefix: _prefix, ...hiddenPrefixWithoutPrefix } = hiddenPrefixTypeNode(
+      numberTypeNode("u8"),
+      [constantU8],
+    );
+    const { suffix: _suffix, ...hiddenSuffixWithoutSuffix } = hiddenSuffixTypeNode(
+      numberTypeNode("u8"),
+      [constantU8],
+    );
+
+    const serializedNodes = [
+      ["tuple items", tupleWithoutItems],
+      ["struct fields", structWithoutFields],
+      ["enum variants", enumWithoutVariants],
+      ["hidden prefix values", hiddenPrefixWithoutPrefix],
+      ["hidden suffix values", hiddenSuffixWithoutSuffix],
+    ] as const;
+
+    it.each(serializedNodes)("returns a manifest without %s", (_name, node) => {
+      const manifest = visit(node as unknown as TypeNode, createVisitor());
+
+      expect(manifest).toMatchObject({
+        type: expect.any(Object),
+        encoder: expect.any(Object),
+        decoder: expect.any(Object),
+      });
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,24 +36,24 @@ importers:
   packages/codama-renderers-dart:
     dependencies:
       '@codama/errors':
-        specifier: ^1.4.4
-        version: 1.7.0
+        specifier: ^1.10.0
+        version: 1.10.1
       '@codama/nodes':
-        specifier: ^1.4.4
-        version: 1.7.0
+        specifier: ^1.10.0
+        version: 1.10.1
       '@codama/renderers-core':
-        specifier: ^1.3.3
-        version: 1.3.8
+        specifier: ^1.3.12
+        version: 1.3.12
       '@codama/visitors-core':
-        specifier: ^1.4.4
-        version: 1.7.0
+        specifier: ^1.10.0
+        version: 1.10.1
     devDependencies:
       '@codama/nodes-from-anchor':
-        specifier: ^1.3.9
-        version: 1.5.0(typescript@5.9.3)
+        specifier: ^1.5.4
+        version: 1.5.4(typescript@5.9.3)
       '@codama/renderers-js':
-        specifier: ^2.0.2
-        version: 2.2.0(typescript@5.9.3)
+        specifier: ^2.3.1
+        version: 2.3.1(typescript@5.9.3)
       '@types/node':
         specifier: 25.3.0
         version: 25.3.0
@@ -96,34 +96,34 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@codama/errors@1.7.0':
-    resolution: {integrity: sha512-N1E4LT3XRYqHHJAnL+eVQ5V3Pc0uSPjsn4Xt6QEO6Fz1p0slF6hbD+/axkFUc7+lNCAfgnkKzhk+6SpFLU/WrQ==}
+  '@codama/errors@1.10.1':
+    resolution: {integrity: sha512-AOeZ7SuSuCHlhh2irN6nI/YSkEDh+v7+/1ihqstJpYM5mYx67MuKNw1X3COe9nF8e3lkU+eVtq51ILdAJa34jA==}
     hasBin: true
 
-  '@codama/fragments@0.1.0':
-    resolution: {integrity: sha512-rWnSKw4UA9LS7mMQyzKnR1woibVEYrYgp66+i+JB+O1lnvU/i/KCH4TmoV+S6Y3ADL2WyznrwfDA3rBET6U5Cg==}
+  '@codama/fragments@0.1.4':
+    resolution: {integrity: sha512-hDykTocyNL0nFKbYZjGPJKtAlMKtKM3PZJbzA8FPOFF1H7U2Z8zd+71UrH9jbSEzdnobAeaRqV71LMPg1yUG8w==}
 
-  '@codama/node-types@1.7.0':
-    resolution: {integrity: sha512-VDytcSgN6jOGEh4aJ1LgSnqCe1drSEUSdAeKOV92aU0MOYiDi2s2B18+Gx7dx40mex2GfVc3zamu7KGzTlxegA==}
+  '@codama/node-types@1.10.1':
+    resolution: {integrity: sha512-PANkfJ0/1rWwgWPWPRQoCoVbozWOb5YPvYDkEEvqXbnofC1qIioglMwy8pT3N1nJybMwS4J1prk05hSPmhRvag==}
 
-  '@codama/nodes-from-anchor@1.5.0':
-    resolution: {integrity: sha512-zbDkjNgMk0EGxHIOOlIq/G2KfXQ7rQrfwogw56MR7nQs6UFGKXnNLJUXiq1m8s3CzfoucvTo49z4mNKTEcGDhQ==}
+  '@codama/nodes-from-anchor@1.5.4':
+    resolution: {integrity: sha512-27Nfbu19etgnNvk5wlmbaCyHOVWYPLwXKr4kDTyuO/cmOWMYR8W4ZiFLivVV+1BYbDtNnCWuIn8RuZZSB8X+XQ==}
 
-  '@codama/nodes@1.7.0':
-    resolution: {integrity: sha512-PZ1zI+SbE1PEaGEka0KjdFrAJ7e9O0kPG4CCGYhjsqUo76OBbINRjNVx7pkP4r8Ksa2r/BLbVIfZV1M/n5J5Kg==}
+  '@codama/nodes@1.10.1':
+    resolution: {integrity: sha512-hcfCCpubRf/BA0vOSEBu95Q8R42yhs0myrqWVCYgv4DQrEqeAiTJxav5NEgmRj8kdFm04Qn854IT4vVXVLP9mA==}
 
-  '@codama/renderers-core@1.3.8':
-    resolution: {integrity: sha512-xy9Qb5BLYTi1OyvlRhRD7n0HUevOQ3QcHSPq9N3kqoUOgL2ziXPXvoejzzLC0OkvA16M7WvK3ihNx/nf4UEClQ==}
+  '@codama/renderers-core@1.3.12':
+    resolution: {integrity: sha512-LyjFPg66hgfeEI9yV952LSKH4M1UOl1zoIRZgMT25hw5rGQmxxYxNqyKSleqEzJ4uKEO4kAj2WVhFVK4F4sAbA==}
 
-  '@codama/renderers-js@2.2.0':
-    resolution: {integrity: sha512-/GWVnB329kMkeqlOqX+NWQAmd1k6yybVOp7C5X+LEvrZ2A5w1saQwWFbBMCq/EQPqnFU+CRFoG/+7KubAEa73Q==}
+  '@codama/renderers-js@2.3.1':
+    resolution: {integrity: sha512-+7WtjpcqnlPkweG+tWWiER2XkJP7SF+RJgYpI0RHc91ZP60Umt0qc+0JPuqMyiPhVrLTN2U/lpsBDQw2MeEsvA==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/visitors-core@1.7.0':
-    resolution: {integrity: sha512-ii1Z39ORzssMQdpxqpjaHCLbFwO4KZbI1SrsJ1e0r+0g03gxuYEA1H6RoxcrIOuUeOnqNtLb96cErrzHdrx23Q==}
+  '@codama/visitors-core@1.10.1':
+    resolution: {integrity: sha512-l5dEZ7Ra5KU64y0Nw79CUp4bAlKRQg9m1DlW1nfQtMEByWEzqteOYesKCgK1z3ypCOXqkN9qlrLAqaYSbOa9Vw==}
 
-  '@codama/visitors@1.7.0':
-    resolution: {integrity: sha512-wk8ufgX3AfKOnaok5H4y1UteLyY/WkDIhhKRE7y5MJqOn5JnxLgL9R4MU2+5TmZUF04sdwyUn6fPho0IqTq+BQ==}
+  '@codama/visitors@1.10.1':
+    resolution: {integrity: sha512-odsT0HMGpByL4fynLEmVJVoWB1jU5+DNg6pSiJXHmWpJE68mHvgK3tXUTj7eU8zAW+lAjfQWui6pcFp8W4xhJA==}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -294,8 +294,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@noble/hashes@2.2.0':
-    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+  '@noble/hashes@2.3.0':
+    resolution: {integrity: sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==}
     engines: {node: '>= 20.19.0'}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
@@ -583,8 +583,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-core@6.9.0':
-    resolution: {integrity: sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==}
+  '@solana/codecs-core@7.1.1':
+    resolution: {integrity: sha512-C1UOAQ7LH8RuCTfaij6hthTZeBlpp8GuD2g9Nag/xgiNKJGvAfVrcorb+kO/sufdYI8Lu+BiVvPeKOjQDQiKqg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -610,8 +610,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-numbers@6.9.0':
-    resolution: {integrity: sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==}
+  '@solana/codecs-numbers@7.1.1':
+    resolution: {integrity: sha512-TWWrQq6Wp5Yf5bSc6RbxDDYCRUBBmRtRgjvUMHGp0P9K+4uFwxllRjSZFzBPHgXj3UTeZmFJdcoD271QhAgibg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       typescript: '>=5.4.0'
@@ -631,8 +631,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/codecs-strings@6.9.0':
-    resolution: {integrity: sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==}
+  '@solana/codecs-strings@7.1.1':
+    resolution: {integrity: sha512-6qWl+atG60D2LmP47GyGapQFhVsG1sVhVrEaM3lV09vwrGOMeOZARZ4ObaQ5m6uQmM04G+f8dY9d17nCMbGHGg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
@@ -662,8 +662,8 @@ packages:
       typescript:
         optional: true
 
-  '@solana/errors@6.9.0':
-    resolution: {integrity: sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==}
+  '@solana/errors@7.1.1':
+    resolution: {integrity: sha512-q35qck8rBnNvJlPU00mnHEQm7gWvghzYz8khqVoLhjgodTzGp46VqnIOyI1LXOAF6XDal58bMNDO980MQgq8yw==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
@@ -798,9 +798,9 @@ packages:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
 
-  commander@14.0.3:
-    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
-    engines: {node: '>=20'}
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1277,65 +1277,65 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@codama/errors@1.7.0':
+  '@codama/errors@1.10.1':
     dependencies:
-      '@codama/node-types': 1.7.0
-      commander: 14.0.3
+      '@codama/node-types': 1.10.1
+      commander: 15.0.0
       picocolors: 1.1.1
 
-  '@codama/fragments@0.1.0':
+  '@codama/fragments@0.1.4':
     dependencies:
-      '@codama/errors': 1.7.0
+      '@codama/errors': 1.10.1
 
-  '@codama/node-types@1.7.0': {}
+  '@codama/node-types@1.10.1': {}
 
-  '@codama/nodes-from-anchor@1.5.0(typescript@5.9.3)':
+  '@codama/nodes-from-anchor@1.5.4(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors': 1.7.0
-      '@noble/hashes': 2.2.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/visitors': 1.10.1
+      '@noble/hashes': 2.3.0
       '@solana/codecs': 5.5.1(typescript@5.9.3)
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/nodes@1.7.0':
+  '@codama/nodes@1.10.1':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/node-types': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/node-types': 1.10.1
 
-  '@codama/renderers-core@1.3.8':
+  '@codama/renderers-core@1.3.12':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/fragments': 0.1.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors-core': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/fragments': 0.1.4
+      '@codama/nodes': 1.10.1
+      '@codama/visitors-core': 1.10.1
 
-  '@codama/renderers-js@2.2.0(typescript@5.9.3)':
+  '@codama/renderers-js@2.3.1(typescript@5.9.3)':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/renderers-core': 1.3.8
-      '@codama/visitors-core': 1.7.0
-      '@solana/codecs-strings': 6.9.0(typescript@5.9.3)
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/renderers-core': 1.3.12
+      '@codama/visitors-core': 1.10.1
+      '@solana/codecs-strings': 7.1.1(typescript@5.9.3)
       prettier: 3.8.3
       semver: 7.8.1
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/visitors-core@1.7.0':
+  '@codama/visitors-core@1.10.1':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors@1.7.0':
+  '@codama/visitors@1.10.1':
     dependencies:
-      '@codama/errors': 1.7.0
-      '@codama/nodes': 1.7.0
-      '@codama/visitors-core': 1.7.0
+      '@codama/errors': 1.10.1
+      '@codama/nodes': 1.10.1
+      '@codama/visitors-core': 1.10.1
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -1429,7 +1429,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@noble/hashes@2.2.0': {}
+  '@noble/hashes@2.3.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -1587,9 +1587,9 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-core@6.9.0(typescript@5.9.3)':
+  '@solana/codecs-core@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 6.9.0(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -1608,10 +1608,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@6.9.0(typescript@5.9.3)':
+  '@solana/codecs-numbers@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.9.0(typescript@5.9.3)
-      '@solana/errors': 6.9.0(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -1623,11 +1623,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-strings@6.9.0(typescript@5.9.3)':
+  '@solana/codecs-strings@7.1.1(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 6.9.0(typescript@5.9.3)
-      '@solana/codecs-numbers': 6.9.0(typescript@5.9.3)
-      '@solana/errors': 6.9.0(typescript@5.9.3)
+      '@solana/codecs-core': 7.1.1(typescript@5.9.3)
+      '@solana/codecs-numbers': 7.1.1(typescript@5.9.3)
+      '@solana/errors': 7.1.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -1650,10 +1650,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/errors@6.9.0(typescript@5.9.3)':
+  '@solana/errors@7.1.1(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
-      commander: 14.0.3
+      commander: 15.0.0
     optionalDependencies:
       typescript: 5.9.3
 
@@ -1793,7 +1793,7 @@ snapshots:
 
   commander@14.0.2: {}
 
-  commander@14.0.3: {}
+  commander@15.0.0: {}
 
   commander@4.1.1: {}
 


### PR DESCRIPTION
## Problem

Serialized Codama root nodes may omit empty child collections. The Dart renderer assumed constructor-populated arrays were always present, so valid Pina IDLs could fail during traversal. The published package also referenced module files that were not present in its tarball, and Dart formatter failures could be swallowed.

## Changes

- normalize omitted Codama 1.10 child collections on a non-mutating internal copy
- guard optional account fields and instruction arguments directly at their render boundaries
- publish valid Node, browser, and React Native package entry points
- propagate Dart formatter failures and use the supported formatter invocation
- add raw Pina-style schema fixtures, tarball consumer tests, and generated Dart validation

## Validation

- `pnpm typecheck`
- `pnpm test:coverage` (410 tests; new normalizer/formatter paths at 100% coverage)
- `pnpm build` and packed-tarball import checks
- generated Dart format, fatal-info analysis, and tests
- `monochange check` and `git diff --check`

Created on behalf of Ifiok Jr. (@ifiokjr), using OpenAI GPT-5.6 with high reasoning.