### PR TITLE
🐛 fix(codecs): reject generated fixed-capacity overflow

### DIFF
--- a/.changeset/fixed-capacity-codecs.md
+++ b/.changeset/fixed-capacity-codecs.md
@@ -1,0 +1,8 @@
+---
+"solana_kit_codecs_core": patch
+"codama-renderers-dart": patch
+---
+
+# Reject over-capacity generated values
+
+Adds an opt-in non-truncating mode to fixed-size encoders and codecs. Codama fixed-size types now use that mode so generated string, byte, and collection encoders pad values within capacity but reject oversized encoded values.

--- a/packages/codama-renderers-dart/readme.md
+++ b/packages/codama-renderers-dart/readme.md
@@ -6,6 +6,8 @@ A [Codama](https://github.com/codama-idl/codama) renderer that generates Dart co
 
 Given a Codama IDL (Interface Description Language) describing a Solana program, this renderer produces a complete Dart package with typed account classes, instruction builders, codec functions, error definitions, PDA helpers, and barrel exports.
 
+Fixed-size Codama types generate non-truncating encoders. Values within the declared byte capacity are zero-padded, while over-capacity values throw before any malformed bytes can be emitted. For UTF-8 strings, capacity is measured in encoded bytes rather than Dart code units.
+
 ## Installation
 
 ```bash

--- a/packages/codama-renderers-dart/src/visitors/getTypeManifestVisitor.ts
+++ b/packages/codama-renderers-dart/src/visitors/getTypeManifestVisitor.ts
@@ -228,13 +228,18 @@ export function getTypeManifestVisitor(input: {
       const itemManifest = visit(node.item, self);
       const encoderSizeExpr = getArraySizeExpression(node, "Encoder");
       const decoderSizeExpr = getArraySizeExpression(node, "Decoder");
+      const itemType = fragmentFromString(itemManifest.type.content);
+      const itemEncoder = fragment`${use(
+        "transformEncoder",
+        "solanaCodecsCore",
+      )}(${itemManifest.encoder}, (${itemType} value) => value)`;
 
       return {
         type: fragment`List<${itemManifest.type}>`,
         encoder: fragment`${use(
           "getArrayEncoder",
           "solanaCodecsDataStructures",
-        )}(${itemManifest.encoder}${encoderSizeExpr})`,
+        )}<${itemType}>(${itemEncoder}${encoderSizeExpr})`,
         decoder: fragment`${use(
           "getArrayDecoder",
           "solanaCodecsDataStructures",
@@ -499,7 +504,7 @@ export function getTypeManifestVisitor(input: {
         encoder: fragment`${use(
           "fixEncoderSize",
           "solanaCodecsCore",
-        )}(${innerManifest.encoder}, ${fragmentFromString(String(node.size))})`,
+        )}(${innerManifest.encoder}, ${fragmentFromString(String(node.size))}, allowTruncation: false)`,
         decoder: fragment`${use(
           "fixDecoderSize",
           "solanaCodecsCore",

--- a/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/fixed_capacity.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/fixed_capacity.dart
@@ -1,0 +1,5 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'programs/programs.dart';
+export 'types/types.dart';

--- a/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/programs/fixed_capacity.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/programs/fixed_capacity.dart
@@ -1,0 +1,7 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+/// The address of the FixedCapacity program.
+const fixedCapacityProgramAddress = systemProgramAddress;

--- a/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/programs/programs.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/programs/programs.dart
@@ -1,0 +1,4 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'fixed_capacity.dart';

--- a/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/types/fixed_name.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/types/fixed_name.dart
@@ -1,0 +1,19 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_strings/solana_kit_codecs_strings.dart';
+
+typedef FixedName = String;
+
+Encoder<FixedName> getFixedNameEncoder() {
+  return fixEncoderSize(getUtf8Encoder(), 4, allowTruncation: false);
+}
+
+Decoder<FixedName> getFixedNameDecoder() {
+  return fixDecoderSize(getUtf8Decoder(), 4);
+}
+
+Codec<FixedName, FixedName> getFixedNameCodec() {
+  return combineCodec(getFixedNameEncoder(), getFixedNameDecoder());
+}

--- a/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/types/fixed_values.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/types/fixed_values.dart
@@ -1,0 +1,30 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+typedef FixedValues = List<int>;
+
+Encoder<FixedValues> getFixedValuesEncoder() {
+  return fixEncoderSize(
+    getArrayEncoder<int>(
+      transformEncoder(getU8Encoder(), (int value) => value),
+      size: RemainderArraySize(),
+    ),
+    4,
+    allowTruncation: false,
+  );
+}
+
+Decoder<FixedValues> getFixedValuesDecoder() {
+  return fixDecoderSize(
+    getArrayDecoder(getU8Decoder(), size: RemainderArraySize()),
+    4,
+  );
+}
+
+Codec<FixedValues, FixedValues> getFixedValuesCodec() {
+  return combineCodec(getFixedValuesEncoder(), getFixedValuesDecoder());
+}

--- a/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/types/types.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/fixed_capacity/types/types.dart
@@ -1,0 +1,5 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'fixed_name.dart';
+export 'fixed_values.dart';

--- a/packages/codama-renderers-dart/test-generated/lib/src/staking/accounts/stake_account.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/staking/accounts/stake_account.dart
@@ -67,7 +67,10 @@ const int stakeAccountSize = 97;
 
 Encoder<StakeAccount> getStakeAccountEncoder() {
   final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
-    ('discriminator', fixEncoderSize(getBytesEncoder(), 8)),
+    (
+      'discriminator',
+      fixEncoderSize(getBytesEncoder(), 8, allowTruncation: false),
+    ),
     ('owner', getAddressEncoder()),
     ('pool', getAddressEncoder()),
     ('stakedAmount', getU64Encoder()),

--- a/packages/codama-renderers-dart/test-generated/lib/src/staking/accounts/stake_pool.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/staking/accounts/stake_pool.dart
@@ -83,7 +83,10 @@ const int stakePoolSize = 138;
 
 Encoder<StakePool> getStakePoolEncoder() {
   final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
-    ('discriminator', fixEncoderSize(getBytesEncoder(), 8)),
+    (
+      'discriminator',
+      fixEncoderSize(getBytesEncoder(), 8, allowTruncation: false),
+    ),
     ('admin', getAddressEncoder()),
     ('rewardMint', getAddressEncoder()),
     ('stakeMint', getAddressEncoder()),

--- a/packages/codama-renderers-dart/test-generated/lib/src/token_vault/accounts/deposit_record.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/token_vault/accounts/deposit_record.dart
@@ -54,7 +54,10 @@ const int depositRecordSize = 88;
 
 Encoder<DepositRecord> getDepositRecordEncoder() {
   final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
-    ('discriminator', fixEncoderSize(getBytesEncoder(), 8)),
+    (
+      'discriminator',
+      fixEncoderSize(getBytesEncoder(), 8, allowTruncation: false),
+    ),
     ('depositor', getAddressEncoder()),
     ('vault', getAddressEncoder()),
     ('amount', getU64Encoder()),

--- a/packages/codama-renderers-dart/test-generated/lib/src/token_vault/accounts/vault.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/token_vault/accounts/vault.dart
@@ -73,7 +73,10 @@ const int vaultSize = 98;
 
 Encoder<Vault> getVaultEncoder() {
   final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
-    ('discriminator', fixEncoderSize(getBytesEncoder(), 8)),
+    (
+      'discriminator',
+      fixEncoderSize(getBytesEncoder(), 8, allowTruncation: false),
+    ),
     ('authority', getAddressEncoder()),
     ('tokenMint', getAddressEncoder()),
     ('totalDeposited', getU64Encoder()),

--- a/packages/codama-renderers-dart/test-generated/test/fixed_capacity_test.dart
+++ b/packages/codama-renderers-dart/test-generated/test/fixed_capacity_test.dart
@@ -1,0 +1,91 @@
+// ignore_for_file: type=lint
+
+import 'dart:typed_data';
+
+import 'package:solana_kit_errors/solana_kit_errors.dart';
+import 'package:test/test.dart';
+import 'package:test_generated/src/fixed_capacity/types/fixed_name.dart';
+import 'package:test_generated/src/fixed_capacity/types/fixed_values.dart';
+
+void main() {
+  group('generated fixed-capacity string encoder', () {
+    test('pads under-capacity UTF-8 values', () {
+      final encoder = getFixedNameEncoder();
+
+      expect(
+        encoder.encode('é'),
+        equals(Uint8List.fromList([0xc3, 0xa9, 0, 0])),
+      );
+    });
+
+    test('preserves exact-capacity UTF-8 values', () {
+      final encoder = getFixedNameEncoder();
+
+      expect(
+        encoder.encode('éé'),
+        equals(Uint8List.fromList([0xc3, 0xa9, 0xc3, 0xa9])),
+      );
+    });
+
+    test('rejects over-capacity UTF-8 values without writing', () {
+      final encoder = getFixedNameEncoder();
+      final destination = Uint8List.fromList([9, 9, 9, 9, 9, 9]);
+
+      expect(
+        () => encoder.write('ééa', destination, 1),
+        throwsA(_isOverCapacityError(expected: 4, actual: 5)),
+      );
+      expect(destination, equals(Uint8List.fromList([9, 9, 9, 9, 9, 9])));
+    });
+  });
+
+  group('generated fixed-capacity array encoder', () {
+    test('pads under-capacity arrays', () {
+      final encoder = getFixedValuesEncoder();
+
+      expect(
+        encoder.encode([1, 2]),
+        equals(Uint8List.fromList([1, 2, 0, 0])),
+      );
+    });
+
+    test('preserves exact-capacity arrays', () {
+      final encoder = getFixedValuesEncoder();
+
+      expect(
+        encoder.encode([1, 2, 3, 4]),
+        equals(Uint8List.fromList([1, 2, 3, 4])),
+      );
+    });
+
+    test('rejects over-capacity arrays without writing', () {
+      final encoder = getFixedValuesEncoder();
+      final destination = Uint8List.fromList([9, 9, 9, 9, 9, 9]);
+
+      expect(
+        () => encoder.write([1, 2, 3, 4, 5], destination, 1),
+        throwsA(_isOverCapacityError(expected: 4, actual: 5)),
+      );
+      expect(destination, equals(Uint8List.fromList([9, 9, 9, 9, 9, 9])));
+    });
+  });
+}
+
+Matcher _isOverCapacityError({required int expected, required int actual}) {
+  return isA<SolanaError>()
+      .having(
+        (error) => error.code,
+        'code',
+        SolanaErrorCode.codecsInvalidByteLength,
+      )
+      .having(
+        (error) => error.context['expected'],
+        'expected',
+        expected,
+      )
+      .having(
+        (error) => error.context['bytesLength'],
+        'bytesLength',
+        actual,
+      );
+}

--- a/packages/codama-renderers-dart/test/e2e/__snapshots__/snapshot.test.ts.snap
+++ b/packages/codama-renderers-dart/test/e2e/__snapshots__/snapshot.test.ts.snap
@@ -75,7 +75,7 @@ const int stakeAccountSize = 97;
 
 Encoder<StakeAccount> getStakeAccountEncoder() {
   final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
-    ('discriminator', fixEncoderSize(getBytesEncoder(), 8)),
+    ('discriminator', fixEncoderSize(getBytesEncoder(), 8, allowTruncation: false)),
     ('owner', getAddressEncoder()),
     ('pool', getAddressEncoder()),
     ('stakedAmount', getU64Encoder()),
@@ -210,7 +210,7 @@ const int stakePoolSize = 138;
 
 Encoder<StakePool> getStakePoolEncoder() {
   final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
-    ('discriminator', fixEncoderSize(getBytesEncoder(), 8)),
+    ('discriminator', fixEncoderSize(getBytesEncoder(), 8, allowTruncation: false)),
     ('admin', getAddressEncoder()),
     ('rewardMint', getAddressEncoder()),
     ('stakeMint', getAddressEncoder()),
@@ -1123,7 +1123,7 @@ const int depositRecordSize = 88;
 
 Encoder<DepositRecord> getDepositRecordEncoder() {
   final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
-    ('discriminator', fixEncoderSize(getBytesEncoder(), 8)),
+    ('discriminator', fixEncoderSize(getBytesEncoder(), 8, allowTruncation: false)),
     ('depositor', getAddressEncoder()),
     ('vault', getAddressEncoder()),
     ('amount', getU64Encoder()),
@@ -1243,7 +1243,7 @@ const int vaultSize = 98;
 
 Encoder<Vault> getVaultEncoder() {
   final structEncoder = getStructEncoder(<(String, Encoder<Object?>)>[
-    ('discriminator', fixEncoderSize(getBytesEncoder(), 8)),
+    ('discriminator', fixEncoderSize(getBytesEncoder(), 8, allowTruncation: false)),
     ('authority', getAddressEncoder()),
     ('tokenMint', getAddressEncoder()),
     ('totalDeposited', getU64Encoder()),

--- a/packages/codama-renderers-dart/test/e2e/generate-dart.test.ts
+++ b/packages/codama-renderers-dart/test/e2e/generate-dart.test.ts
@@ -4,6 +4,16 @@ import { join, resolve } from "node:path";
 import { describe, it, expect, beforeAll } from "vitest";
 import { visit } from "@codama/visitors-core";
 import { rootNodeFromAnchor } from "@codama/nodes-from-anchor";
+import {
+  arrayTypeNode,
+  definedTypeNode,
+  fixedSizeTypeNode,
+  numberTypeNode,
+  programNode,
+  remainderCountNode,
+  rootNode,
+  stringTypeNode,
+} from "@codama/nodes";
 
 import { renderVisitor } from "../../src/visitors/renderVisitor.js";
 
@@ -13,6 +23,10 @@ import stakingIdl from "../fixtures/staking.json";
 const TEST_GENERATED_DIR = resolve(__dirname, "../../test-generated");
 const TOKEN_VAULT_DIR = join(TEST_GENERATED_DIR, "lib/src/token_vault");
 const STAKING_DIR = join(TEST_GENERATED_DIR, "lib/src/staking");
+const FIXED_CAPACITY_DIR = join(
+  TEST_GENERATED_DIR,
+  "lib/src/fixed_capacity",
+);
 
 /**
  * Recursively collect all file paths under a directory.
@@ -54,6 +68,33 @@ describe("Generate Dart code and validate", () => {
       }),
     );
 
+    const fixedCapacityRoot = rootNode(
+      programNode({
+        name: "fixedCapacity",
+        publicKey: "11111111111111111111111111111111",
+        definedTypes: [
+          definedTypeNode({
+            name: "fixedName",
+            type: fixedSizeTypeNode(stringTypeNode("utf8"), 4),
+          }),
+          definedTypeNode({
+            name: "fixedValues",
+            type: fixedSizeTypeNode(
+              arrayTypeNode(numberTypeNode("u8"), remainderCountNode()),
+              4,
+            ),
+          }),
+        ],
+      }),
+    );
+    visit(
+      fixedCapacityRoot,
+      renderVisitor(FIXED_CAPACITY_DIR, {
+        formatCode: false,
+        deleteFolderBeforeRendering: true,
+      }),
+    );
+
     // The workspace includes Flutter examples, so its shared resolution must
     // use Flutter's pub wrapper even though this generated package is pure Dart.
     execFileSync("flutter", ["pub", "get"], {
@@ -61,7 +102,6 @@ describe("Generate Dart code and validate", () => {
       stdio: "pipe",
       timeout: 120_000,
     });
-
   }, 180_000);
 
   it("should generate token_vault files", () => {
@@ -94,6 +134,20 @@ describe("Generate Dart code and validate", () => {
     expect(files).toContain("types/stake_info.dart");
     expect(files).toContain("errors/staking.dart");
     expect(files).toContain("programs/staking.dart");
+  });
+
+  it("should generate non-truncating fixed-capacity codecs", () => {
+    const fixedName = readFileSync(
+      join(FIXED_CAPACITY_DIR, "types/fixed_name.dart"),
+      "utf-8",
+    );
+    const fixedValues = readFileSync(
+      join(FIXED_CAPACITY_DIR, "types/fixed_values.dart"),
+      "utf-8",
+    );
+
+    expect(fixedName).toContain("allowTruncation: false");
+    expect(fixedValues).toContain("allowTruncation: false");
   });
 
   it("should generate valid Dart syntax in error page files", () => {

--- a/packages/codama-renderers-dart/test/visitors/getTypeManifestVisitor.test.ts
+++ b/packages/codama-renderers-dart/test/visitors/getTypeManifestVisitor.test.ts
@@ -281,6 +281,19 @@ describe("getTypeManifestVisitor", () => {
       expect(manifest.decoder.content).toContain("getArrayDecoder");
     });
 
+    it("narrows numeric item encoders to the generated Dart item type", () => {
+      const node = arrayTypeNode(
+        numberTypeNode("u8"),
+        remainderCountNode(),
+      );
+      const manifest = visit(node, createVisitor());
+
+      expect(manifest.encoder.content).toContain("getArrayEncoder<int>");
+      expect(manifest.encoder.content).toContain(
+        "transformEncoder(getU8Encoder(), (int value) => value)",
+      );
+    });
+
     it("includes FixedArraySize for fixed count", () => {
       const node = arrayTypeNode(numberTypeNode("u8"), fixedCountNode(5));
       const manifest = visit(node, createVisitor());
@@ -438,11 +451,12 @@ describe("getTypeManifestVisitor", () => {
   });
 
   describe("fixedSizeTypeNode", () => {
-    it("wraps encoder with fixEncoderSize", () => {
+    it("wraps encoder with a non-truncating fixed size", () => {
       const node = fixedSizeTypeNode(stringTypeNode("utf8"), 32);
       const manifest = visit(node, createVisitor());
       expect(manifest.encoder.content).toContain("fixEncoderSize");
       expect(manifest.encoder.content).toContain("32");
+      expect(manifest.encoder.content).toContain("allowTruncation: false");
     });
 
     it("wraps decoder with fixDecoderSize", () => {
@@ -471,6 +485,7 @@ describe("getTypeManifestVisitor", () => {
       const manifest = visit(node, createVisitor());
       expect(manifest.type.content).toBe("Uint8List");
       expect(manifest.encoder.content).toContain("fixEncoderSize");
+      expect(manifest.encoder.content).toContain("allowTruncation: false");
       expect(manifest.encoder.content).toContain("64");
     });
   });

--- a/packages/solana_kit_codecs_core/README.md
+++ b/packages/solana_kit_codecs_core/README.md
@@ -191,6 +191,13 @@ import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
 final fixed = fixEncoderSize(myVariableEncoder, 32);
 // fixed.fixedSize == 32
 // Shorter values are zero-padded, longer values are truncated.
+
+// Reject over-capacity values before they can be truncated.
+final strictFixed = fixEncoderSize(
+  myVariableEncoder,
+  32,
+  allowTruncation: false,
+);
 ```
 
 ### Adding size prefixes

--- a/packages/solana_kit_codecs_core/lib/src/fix_codec_size.dart
+++ b/packages/solana_kit_codecs_core/lib/src/fix_codec_size.dart
@@ -5,22 +5,37 @@ import 'package:solana_kit_codecs_core/src/bytes.dart';
 import 'package:solana_kit_codecs_core/src/codec.dart';
 import 'package:solana_kit_codecs_core/src/codec_utils.dart';
 import 'package:solana_kit_codecs_core/src/combine_codec.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
 
 /// Creates a fixed-size encoder from a given [encoder].
 ///
 /// The resulting encoder always produces exactly [fixedBytes] bytes.
-/// If the original encoded value is larger, it is truncated.
 /// If smaller, it is padded with trailing zeroes.
+///
+/// By default, values larger than [fixedBytes] are truncated for compatibility
+/// with `@solana/codecs-core`. Set [allowTruncation] to `false` for
+/// fixed-capacity fields where an oversized value must be rejected instead.
+/// The error is thrown before any bytes are written to the destination buffer.
 FixedSizeEncoder<TFrom> fixEncoderSize<TFrom>(
   Encoder<TFrom> encoder,
-  int fixedBytes,
-) {
+  int fixedBytes, {
+  bool allowTruncation = true,
+}) {
   return FixedSizeEncoder<TFrom>(
     fixedSize: fixedBytes,
     write: (value, bytes, offset) {
       // Use encode() to contain the encoder within its own bounds.
       final variableByteArray = encoder.encode(value);
       final Uint8List fixedByteArray;
+
+      if (variableByteArray.length > fixedBytes && !allowTruncation) {
+        throw SolanaError(SolanaErrorCode.codecsInvalidByteLength, {
+          'codecDescription': 'fixEncoderSize',
+          'expected': fixedBytes,
+          'bytesLength': variableByteArray.length,
+        });
+      }
+
       if (variableByteArray.length > fixedBytes) {
         fixedByteArray = variableByteArray.sublist(0, fixedBytes);
       } else {
@@ -70,12 +85,19 @@ FixedSizeDecoder<TTo> fixDecoderSize<TTo>(
 /// Creates a fixed-size codec from a given [codec].
 ///
 /// Both encoding and decoding operate on exactly [fixedBytes] bytes.
+/// Set [allowTruncation] to `false` to reject encoded values larger than the
+/// fixed capacity instead of silently truncating them.
 FixedSizeCodec<TFrom, TTo> fixCodecSize<TFrom, TTo>(
   Codec<TFrom, TTo> codec,
-  int fixedBytes,
-) {
+  int fixedBytes, {
+  bool allowTruncation = true,
+}) {
   return combineCodec(
-        fixEncoderSize(encoderFromCodec(codec), fixedBytes),
+        fixEncoderSize(
+          encoderFromCodec(codec),
+          fixedBytes,
+          allowTruncation: allowTruncation,
+        ),
         fixDecoderSize(decoderFromCodec(codec), fixedBytes),
       )
       as FixedSizeCodec<TFrom, TTo>;

--- a/packages/solana_kit_codecs_core/test/fix_codec_size_test.dart
+++ b/packages/solana_kit_codecs_core/test/fix_codec_size_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
@@ -158,6 +159,24 @@ void main() {
       expect(value, equals(42));
       expect(offset, equals(3));
     });
+
+    test('can reject over-capacity encoded values', () {
+      final codec = VariableSizeCodec<List<int>, List<int>>(
+        getSizeFromValue: (value) => value.length,
+        write: _writeIntList,
+        read: (bytes, offset) => (bytes.sublist(offset), bytes.length),
+      );
+      final strictCodec = fixCodecSize(
+        codec,
+        4,
+        allowTruncation: false,
+      );
+
+      expect(
+        () => strictCodec.encode([1, 2, 3, 4, 5]),
+        throwsA(_isOverCapacityError(expected: 4, actual: 5)),
+      );
+    });
   });
 
   group('fixEncoderSize', () {
@@ -193,6 +212,71 @@ void main() {
         fixEncoderSize(encoder5, 10).encode('hello'),
         equals(b('08050c0c0f0000000000')),
       );
+    });
+
+    group('without truncation', () {
+      test('pads and preserves UTF-8 values within byte capacity', () {
+        final encoder = VariableSizeEncoder<String>(
+          getSizeFromValue: (value) => utf8.encode(value).length,
+          write: (value, bytes, offset) {
+            final encoded = utf8.encode(value);
+            bytes.setAll(offset, encoded);
+
+            return offset + encoded.length;
+          },
+        );
+        final strictEncoder = fixEncoderSize(
+          encoder,
+          4,
+          allowTruncation: false,
+        );
+
+        expect(strictEncoder.encode('é'), equals(b('c3a90000')));
+        expect(strictEncoder.encode('éé'), equals(b('c3a9c3a9')));
+      });
+
+      test('rejects UTF-8 values over byte capacity without writing', () {
+        final encoder = VariableSizeEncoder<String>(
+          getSizeFromValue: (value) => utf8.encode(value).length,
+          write: (value, bytes, offset) {
+            final encoded = utf8.encode(value);
+            bytes.setAll(offset, encoded);
+
+            return offset + encoded.length;
+          },
+        );
+        final strictEncoder = fixEncoderSize(
+          encoder,
+          4,
+          allowTruncation: false,
+        );
+        final destination = Uint8List.fromList([9, 9, 9, 9, 9, 9]);
+
+        expect(
+          () => strictEncoder.write('ééa', destination, 1),
+          throwsA(_isOverCapacityError(expected: 4, actual: 5)),
+        );
+        expect(destination, equals(Uint8List.fromList([9, 9, 9, 9, 9, 9])));
+      });
+
+      test('pads, preserves, and rejects arrays by encoded byte length', () {
+        final encoder = VariableSizeEncoder<List<int>>(
+          getSizeFromValue: (value) => value.length,
+          write: _writeIntList,
+        );
+        final strictEncoder = fixEncoderSize(
+          encoder,
+          4,
+          allowTruncation: false,
+        );
+
+        expect(strictEncoder.encode([1, 2]), equals(b('01020000')));
+        expect(strictEncoder.encode([1, 2, 3, 4]), equals(b('01020304')));
+        expect(
+          () => strictEncoder.encode([1, 2, 3, 4, 5]),
+          throwsA(_isOverCapacityError(expected: 4, actual: 5)),
+        );
+      });
     });
   });
 
@@ -238,4 +322,29 @@ void main() {
       );
     });
   });
+}
+
+int _writeIntList(List<int> value, Uint8List bytes, int offset) {
+  bytes.setAll(offset, value);
+
+  return offset + value.length;
+}
+
+Matcher _isOverCapacityError({required int expected, required int actual}) {
+  return isA<SolanaError>()
+      .having(
+        (error) => error.code,
+        'code',
+        SolanaErrorCode.codecsInvalidByteLength,
+      )
+      .having(
+        (error) => error.context['expected'],
+        'expected',
+        expected,
+      )
+      .having(
+        (error) => error.context['bytesLength'],
+        'bytesLength',
+        actual,
+      );
 }


### PR DESCRIPTION
## Problem

Fixed-size encoders silently truncated oversized values. For generated bounded strings and vectors, that can emit a length prefix describing more data than the encoded payload and produce invalid on-chain bytes.

## Changes

- add additive `allowTruncation` control to fixed-size encoders/codecs, preserving the existing default
- make Codama fixed-size nodes opt into strict overflow rejection
- keep under-capacity padding and exact-capacity encoding unchanged
- make generated numeric array encoder transformations type-invariant
- add core and generated Dart runtime regressions, including destination-buffer immutability after overflow

## Validation

- 154 core tests and targeted fixed-size coverage
- 398 renderer tests with changed lines covered
- generated Dart analysis and six fixed-capacity runtime tests
- renderer typecheck/build, docs, monochange, lint, and `git diff --check`

Created on behalf of Ifiok Jr. (@ifiokjr), using OpenAI GPT-5.6 with high reasoning.