### PR TITLE
🐛 fix(codecs): enforce canonical boolean bytes

### DIFF
--- a/.changeset/canonical-boolean-codecs.md
+++ b/.changeset/canonical-boolean-codecs.md
@@ -1,0 +1,8 @@
+---
+"solana_kit_codecs_data_structures": patch
+"solana_kit_errors": patch
+---
+
+# Reject non-canonical boolean decoder values
+
+Boolean codecs now reject values other than zero and one with a typed error, including nullable prefixes that use boolean tags.

--- a/packages/solana_kit_codecs_data_structures/README.md
+++ b/packages/solana_kit_codecs_data_structures/README.md
@@ -219,6 +219,8 @@ boolCodec.decode(Uint8List.fromList([1])); // true
 boolCodec.decode(Uint8List.fromList([0])); // false
 ```
 
+Decoding rejects every other numeric value with a typed `SolanaError`; this keeps optional-value prefixes and boolean fields canonical when reading untrusted account data.
+
 You can customize the underlying number codec:
 
 ```dart

--- a/packages/solana_kit_codecs_data_structures/lib/src/boolean.dart
+++ b/packages/solana_kit_codecs_data_structures/lib/src/boolean.dart
@@ -1,5 +1,6 @@
 import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
 import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
 
 /// Configuration options for boolean codecs.
 ///
@@ -29,11 +30,17 @@ Encoder<bool> getBooleanEncoder({Encoder<num>? size}) {
 /// Returns a decoder for boolean values.
 ///
 /// This decoder reads a number and interprets `1` as `true` and `0` as
-/// `false`.
+/// `false`. Any other value is invalid and throws a [SolanaError] with code
+/// [SolanaErrorCode.codecsInvalidBoolean].
 Decoder<bool> getBooleanDecoder({Decoder<num>? size}) {
   final numberDecoder = size ?? getU8Decoder();
   return transformDecoder<num, bool>(numberDecoder, (value, _, _) {
-    return value.toInt() == 1;
+    if (value == 0) return false;
+    if (value == 1) return true;
+
+    throw SolanaError(SolanaErrorCode.codecsInvalidBoolean, {
+      'value': value,
+    });
   });
 }
 

--- a/packages/solana_kit_codecs_data_structures/test/boolean_test.dart
+++ b/packages/solana_kit_codecs_data_structures/test/boolean_test.dart
@@ -1,5 +1,7 @@
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
 import 'package:solana_kit_codecs_data_structures/solana_kit_codecs_data_structures.dart';
 import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+import 'package:solana_kit_errors/solana_kit_errors.dart';
 import 'package:test/test.dart';
 
 import 'setup.dart';
@@ -26,10 +28,20 @@ void main() {
       expect(decoder.decode(b('01')), isTrue);
     });
 
-    test('decodes non-1 values as false', () {
+    test('rejects non-canonical values', () {
       final decoder = getBooleanDecoder();
-      expect(decoder.decode(b('02')), isFalse);
-      expect(decoder.decode(b('ff')), isFalse);
+      for (final bytes in [b('02'), b('ff')]) {
+        expect(
+          () => decoder.decode(bytes),
+          throwsA(
+            predicate<SolanaError>(
+              (error) =>
+                  error.code == SolanaErrorCode.codecsInvalidBoolean &&
+                  error.context['value'] == bytes[0],
+            ),
+          ),
+        );
+      }
     });
 
     test('roundtrips with codec', () {
@@ -44,6 +56,58 @@ void main() {
       expect(hex(codec.encode(true)), equals('01000000'));
       expect(codec.decode(b('00000000')), isFalse);
       expect(codec.decode(b('01000000')), isTrue);
+    });
+
+    test('validates every supported numeric prefix', () {
+      final prefixes = <(String, Decoder<num>, String, String, String)>[
+        ('u8', getU8Decoder(), '00', '01', '02'),
+        ('u16', getU16Decoder(), '0000', '0100', '0200'),
+        ('u32', getU32Decoder(), '00000000', '01000000', '02000000'),
+        ('i8', getI8Decoder(), '00', '01', 'ff'),
+        ('i16', getI16Decoder(), '0000', '0100', 'feff'),
+        ('i32', getI32Decoder(), '00000000', '01000000', 'feffffff'),
+        ('f32', getF32Decoder(), '00000000', '0000803f', '0000c03f'),
+        (
+          'f64',
+          getF64Decoder(),
+          '0000000000000000',
+          '000000000000f03f',
+          '000000000000f83f',
+        ),
+        ('shortU16', getShortU16Decoder(), '00', '01', '02'),
+      ];
+
+      for (final (name, prefix, falseValue, trueValue, invalidValue)
+          in prefixes) {
+        final decoder = getBooleanDecoder(size: prefix);
+        expect(decoder.decode(b(falseValue)), isFalse, reason: name);
+        expect(decoder.decode(b(trueValue)), isTrue, reason: name);
+        expect(
+          () => decoder.decode(b(invalidValue)),
+          throwsA(
+            predicate<SolanaError>(
+              (error) => error.code == SolanaErrorCode.codecsInvalidBoolean,
+            ),
+          ),
+          reason: name,
+        );
+      }
+    });
+
+    test('rejects a non-canonical nullable prefix', () {
+      final decoder = getNullableDecoder(
+        getU8Decoder(),
+        prefix: getU32Decoder(),
+      );
+
+      expect(
+        () => decoder.decode(b('02000000')),
+        throwsA(
+          predicate<SolanaError>(
+            (error) => error.code == SolanaErrorCode.codecsInvalidBoolean,
+          ),
+        ),
+      );
     });
   });
 }

--- a/packages/solana_kit_errors/lib/src/codes.dart
+++ b/packages/solana_kit_errors/lib/src/codes.dart
@@ -932,6 +932,9 @@ enum SolanaErrorCode {
   /// The string contains null characters.
   codecsStringContainsNullCharacters(8078026),
 
+  /// The boolean value is not encoded as zero or one.
+  codecsInvalidBoolean(8078027),
+
   // ---------------------------------------------------------------------------
   // Fixed Points (8090000 - 8090999)
   // ---------------------------------------------------------------------------

--- a/packages/solana_kit_errors/lib/src/messages.dart
+++ b/packages/solana_kit_errors/lib/src/messages.dart
@@ -66,6 +66,8 @@ const Map<SolanaErrorCode, String> solanaErrorMessages = {
       'Invalid pattern match bytes. The provided byte array does not match any of the specified patterns.',
   SolanaErrorCode.codecsStringContainsNullCharacters:
       r'Decoded $encoding string contains null characters. Use compatibility stripping or preserve mode explicitly if this payload is expected.',
+  SolanaErrorCode.codecsInvalidBoolean:
+      r'Invalid boolean value. Expected 0 or 1, got $value.',
   SolanaErrorCode.fixedPointsArithmeticOverflow:
       r'Fixed-point operation `$operation` of kind `$kind` overflowed. Expected a raw bigint in [$min, $max], got $result.',
   SolanaErrorCode.fixedPointsDivisionByZero:

--- a/packages/solana_kit_errors/test/error_test.dart
+++ b/packages/solana_kit_errors/test/error_test.dart
@@ -79,6 +79,15 @@ void main() {
       final error = SolanaError(SolanaErrorCode.blockHeightExceeded);
       expect(error.context, isEmpty);
     });
+
+    test('formats invalid boolean codec errors', () {
+      final error = SolanaError(SolanaErrorCode.codecsInvalidBoolean, {
+        'value': 2,
+      });
+
+      expect(error.code.value, 8078027);
+      expect(error.toString(), contains('Expected 0 or 1, got 2'));
+    });
   });
 
   group('SolanaErrorCode enum', () {


### PR DESCRIPTION
## Problem

The boolean decoder treated every non-zero byte as `true`. Solana wire layouts commonly define booleans canonically as exactly `0` or `1`, so accepting values such as `2` allows malformed account and instruction data to pass client-side validation.

## Changes

- accept only `0` and `1` in boolean decoders
- throw a typed Solana codec error for non-canonical bytes
- preserve nullable and codec composition behavior
- document the canonical wire contract and add focused decoder/error regressions

## Validation

- full data-structures and errors package tests
- canonical, nullable, malformed, and error-message coverage
- Dart analysis, docs checks, monochange validation, and repository linting

Created on behalf of Ifiok Jr. (@ifiokjr), using OpenAI GPT-5.6 with high reasoning.