### PR TITLE
🐛 fix(codama-renderers-dart): support wide scalar enums

### DIFF
--- a/.changeset/codama-dart-wide-enums.md
+++ b/.changeset/codama-dart-wide-enums.md
@@ -1,0 +1,7 @@
+---
+"codama-renderers-dart": patch
+---
+
+# Fix Wide Scalar Enum Codecs
+
+Generate type-correct Dart codecs for scalar enums with `u64` discriminators. The encoder now converts enum indices to `BigInt`, while the decoder validates the decoded discriminator before converting it to a Dart enum index.

--- a/packages/codama-renderers-dart/readme.md
+++ b/packages/codama-renderers-dart/readme.md
@@ -171,6 +171,8 @@ Encoder<AccountStatus> getAccountStatusEncoder() { ... }
 Decoder<AccountStatus> getAccountStatusDecoder() { ... }
 ```
 
+The generated enum API is the same for `u8`, `u16`, `u32`, and `u64` discriminators. The renderer converts `u64` indices to and from `BigInt` at the codec boundary and rejects out-of-range discriminators before converting them to Dart enum indices.
+
 ### Data Enums (Discriminated Unions)
 
 Data enums generate Dart 3 `sealed class` hierarchies:

--- a/packages/codama-renderers-dart/src/fragments/typePage.ts
+++ b/packages/codama-renderers-dart/src/fragments/typePage.ts
@@ -80,6 +80,18 @@ function getScalarEnumPageFragment(
   const resolvedSize = resolveNestedTypeNode(enumNode.size);
   const sizeType = resolvedSize.format ?? "u8";
   const sizeCodecName = getNumberCodecName(sizeType);
+  const isU64 = sizeType === "u64";
+  const encodedVariantIndex = isU64
+    ? "BigInt.from(value.index)"
+    : "value.index";
+  const decodedVariant = isU64
+    ? `(BigInt value, Uint8List bytes, int offset) {
+      if (value.isNegative || value >= BigInt.from(${typeName}.values.length)) {
+        throw RangeError('Invalid ${typeName} discriminator: ' + value.toString());
+      }
+      return ${typeName}.values[value.toInt()];
+    }`
+    : `(int value, Uint8List bytes, int offset) => ${typeName}.values[value]`;
 
   return fragment`// Auto-generated. Do not edit.
 // ignore_for_file: type=lint
@@ -101,14 +113,14 @@ ${fragmentFromString(variantLines)}
 Encoder<${fragmentFromString(typeName)}> ${fragmentFromString(encoderName)}() {
   return transformEncoder(
     get${fragmentFromString(sizeCodecName)}Encoder(),
-    (${fragmentFromString(typeName)} value) => value.index,
+    (${fragmentFromString(typeName)} value) => ${fragmentFromString(encodedVariantIndex)},
   );
 }
 
 Decoder<${fragmentFromString(typeName)}> ${fragmentFromString(decoderName)}() {
   return transformDecoder(
     get${fragmentFromString(sizeCodecName)}Decoder(),
-    (int value, Uint8List bytes, int offset) => ${fragmentFromString(typeName)}.values[value],
+    ${fragmentFromString(decodedVariant)},
   );
 }
 

--- a/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/programs/programs.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/programs/programs.dart
@@ -1,0 +1,4 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'wide_enums.dart';

--- a/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/programs/wide_enums.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/programs/wide_enums.dart
@@ -1,0 +1,7 @@
+import 'package:solana_kit_addresses/solana_kit_addresses.dart';
+
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+/// The address of the WideEnums program.
+const wideEnumsProgramAddress = systemProgramAddress;

--- a/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/status_u16.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/status_u16.dart
@@ -1,0 +1,30 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+enum StatusU16 {
+  inactive,
+  active,
+}
+
+Encoder<StatusU16> getStatusU16Encoder() {
+  return transformEncoder(
+    getU16Encoder(),
+    (StatusU16 value) => value.index,
+  );
+}
+
+Decoder<StatusU16> getStatusU16Decoder() {
+  return transformDecoder(
+    getU16Decoder(),
+    (int value, Uint8List bytes, int offset) => StatusU16.values[value],
+  );
+}
+
+Codec<StatusU16, StatusU16> getStatusU16Codec() {
+  return combineCodec(getStatusU16Encoder(), getStatusU16Decoder());
+}

--- a/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/status_u32.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/status_u32.dart
@@ -1,0 +1,30 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+enum StatusU32 {
+  inactive,
+  active,
+}
+
+Encoder<StatusU32> getStatusU32Encoder() {
+  return transformEncoder(
+    getU32Encoder(),
+    (StatusU32 value) => value.index,
+  );
+}
+
+Decoder<StatusU32> getStatusU32Decoder() {
+  return transformDecoder(
+    getU32Decoder(),
+    (int value, Uint8List bytes, int offset) => StatusU32.values[value],
+  );
+}
+
+Codec<StatusU32, StatusU32> getStatusU32Codec() {
+  return combineCodec(getStatusU32Encoder(), getStatusU32Decoder());
+}

--- a/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/status_u64.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/status_u64.dart
@@ -1,0 +1,37 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+enum StatusU64 {
+  inactive,
+  active,
+}
+
+Encoder<StatusU64> getStatusU64Encoder() {
+  return transformEncoder(
+    getU64Encoder(),
+    (StatusU64 value) => BigInt.from(value.index),
+  );
+}
+
+Decoder<StatusU64> getStatusU64Decoder() {
+  return transformDecoder(
+    getU64Decoder(),
+    (BigInt value, Uint8List bytes, int offset) {
+      if (value.isNegative || value >= BigInt.from(StatusU64.values.length)) {
+        throw RangeError(
+          'Invalid StatusU64 discriminator: ' + value.toString(),
+        );
+      }
+      return StatusU64.values[value.toInt()];
+    },
+  );
+}
+
+Codec<StatusU64, StatusU64> getStatusU64Codec() {
+  return combineCodec(getStatusU64Encoder(), getStatusU64Decoder());
+}

--- a/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/status_u8.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/status_u8.dart
@@ -1,0 +1,30 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:solana_kit_codecs_numbers/solana_kit_codecs_numbers.dart';
+
+enum StatusU8 {
+  inactive,
+  active,
+}
+
+Encoder<StatusU8> getStatusU8Encoder() {
+  return transformEncoder(
+    getU8Encoder(),
+    (StatusU8 value) => value.index,
+  );
+}
+
+Decoder<StatusU8> getStatusU8Decoder() {
+  return transformDecoder(
+    getU8Decoder(),
+    (int value, Uint8List bytes, int offset) => StatusU8.values[value],
+  );
+}
+
+Codec<StatusU8, StatusU8> getStatusU8Codec() {
+  return combineCodec(getStatusU8Encoder(), getStatusU8Decoder());
+}

--- a/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/types.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/types/types.dart
@@ -1,0 +1,7 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'status_u16.dart';
+export 'status_u32.dart';
+export 'status_u64.dart';
+export 'status_u8.dart';

--- a/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/wide_enums.dart
+++ b/packages/codama-renderers-dart/test-generated/lib/src/wide_enums/wide_enums.dart
@@ -1,0 +1,5 @@
+// Auto-generated. Do not edit.
+// ignore_for_file: type=lint
+
+export 'programs/programs.dart';
+export 'types/types.dart';

--- a/packages/codama-renderers-dart/test-generated/test/wide_enums_test.dart
+++ b/packages/codama-renderers-dart/test-generated/test/wide_enums_test.dart
@@ -1,0 +1,64 @@
+// ignore_for_file: type=lint
+
+import 'dart:typed_data';
+
+import 'package:solana_kit_codecs_core/solana_kit_codecs_core.dart';
+import 'package:test/test.dart';
+import 'package:test_generated/src/wide_enums/types/status_u8.dart';
+import 'package:test_generated/src/wide_enums/types/status_u16.dart';
+import 'package:test_generated/src/wide_enums/types/status_u32.dart';
+import 'package:test_generated/src/wide_enums/types/status_u64.dart';
+
+void expectScalarEnumCodec<T>({
+  required Codec<T, T> codec,
+  required T active,
+  required List<int> activeBytes,
+  required List<int> invalidBytes,
+}) {
+  expect(codec.encode(active), orderedEquals(activeBytes));
+  expect(codec.decode(Uint8List.fromList(activeBytes)), active);
+  expect(
+    () => codec.decode(Uint8List.fromList(invalidBytes)),
+    throwsA(isA<RangeError>()),
+  );
+}
+
+void main() {
+  group('wide scalar enum codecs', () {
+    test('u8 uses an int-backed one-byte discriminator', () {
+      expectScalarEnumCodec(
+        codec: getStatusU8Codec(),
+        active: StatusU8.active,
+        activeBytes: const [1],
+        invalidBytes: const [2],
+      );
+    });
+
+    test('u16 uses an int-backed two-byte discriminator', () {
+      expectScalarEnumCodec(
+        codec: getStatusU16Codec(),
+        active: StatusU16.active,
+        activeBytes: const [1, 0],
+        invalidBytes: const [2, 0],
+      );
+    });
+
+    test('u32 uses an int-backed four-byte discriminator', () {
+      expectScalarEnumCodec(
+        codec: getStatusU32Codec(),
+        active: StatusU32.active,
+        activeBytes: const [1, 0, 0, 0],
+        invalidBytes: const [2, 0, 0, 0],
+      );
+    });
+
+    test('u64 uses a BigInt-backed eight-byte discriminator', () {
+      expectScalarEnumCodec(
+        codec: getStatusU64Codec(),
+        active: StatusU64.active,
+        activeBytes: const [1, 0, 0, 0, 0, 0, 0, 0],
+        invalidBytes: const [255, 255, 255, 255, 255, 255, 255, 255],
+      );
+    });
+  });
+}

--- a/packages/codama-renderers-dart/test/e2e/generate-dart.test.ts
+++ b/packages/codama-renderers-dart/test/e2e/generate-dart.test.ts
@@ -3,10 +3,11 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync } fr
 import { join, resolve } from "node:path";
 import { describe, it, expect, beforeAll } from "vitest";
 import { visit } from "@codama/visitors-core";
-import { rootNodeFromAnchor } from "@codama/nodes-from-anchor";
 import {
   arrayTypeNode,
   definedTypeNode,
+  enumEmptyVariantTypeNode,
+  enumTypeNode,
   fixedSizeTypeNode,
   numberTypeNode,
   programNode,
@@ -14,6 +15,7 @@ import {
   rootNode,
   stringTypeNode,
 } from "@codama/nodes";
+import { rootNodeFromAnchor } from "@codama/nodes-from-anchor";
 
 import { renderVisitor } from "../../src/visitors/renderVisitor.js";
 
@@ -27,6 +29,32 @@ const FIXED_CAPACITY_DIR = join(
   TEST_GENERATED_DIR,
   "lib/src/fixed_capacity",
 );
+const WIDE_ENUMS_DIR = join(TEST_GENERATED_DIR, "lib/src/wide_enums");
+
+function buildWideEnumsIdl() {
+  const definedTypes = (["u8", "u16", "u32", "u64"] as const).map(
+    (format) =>
+      definedTypeNode({
+        name: `status${format.toUpperCase()}`,
+        type: enumTypeNode(
+          [
+            enumEmptyVariantTypeNode("inactive"),
+            enumEmptyVariantTypeNode("active"),
+          ],
+          { size: numberTypeNode(format) },
+        ),
+      }),
+  );
+
+  return rootNode(
+    programNode({
+      name: "wideEnums",
+      publicKey: "11111111111111111111111111111111",
+      definedTypes,
+    }),
+  );
+}
+
 
 /**
  * Recursively collect all file paths under a directory.
@@ -95,6 +123,14 @@ describe("Generate Dart code and validate", () => {
       }),
     );
 
+    visit(
+      buildWideEnumsIdl(),
+      renderVisitor(WIDE_ENUMS_DIR, {
+        formatCode: false,
+        deleteFolderBeforeRendering: true,
+      }),
+    );
+
     // The workspace includes Flutter examples, so its shared resolution must
     // use Flutter's pub wrapper even though this generated package is pure Dart.
     execFileSync("flutter", ["pub", "get"], {
@@ -148,6 +184,15 @@ describe("Generate Dart code and validate", () => {
 
     expect(fixedName).toContain("allowTruncation: false");
     expect(fixedValues).toContain("allowTruncation: false");
+  });
+
+  it("should generate scalar enums for every supported unsigned width", () => {
+    const files = collectFiles(WIDE_ENUMS_DIR);
+
+    expect(files).toContain("types/status_u8.dart");
+    expect(files).toContain("types/status_u16.dart");
+    expect(files).toContain("types/status_u32.dart");
+    expect(files).toContain("types/status_u64.dart");
   });
 
   it("should generate valid Dart syntax in error page files", () => {

--- a/packages/codama-renderers-dart/test/fragments/typePage.test.ts
+++ b/packages/codama-renderers-dart/test/fragments/typePage.test.ts
@@ -306,6 +306,55 @@ describe("getTypePageFragment", () => {
       expect(frag.content).toContain("getU8Encoder()");
       expect(frag.content).toContain("getU8Decoder()");
     });
+
+    for (const format of ["u8", "u16", "u32"] as const) {
+      it(`uses int variant indices for ${format} scalar enums`, () => {
+        const node = definedTypeNode({
+          name: `status_${format}`,
+          type: enumTypeNode(
+            [
+              enumEmptyVariantTypeNode("active"),
+              enumEmptyVariantTypeNode("inactive"),
+            ],
+            { size: numberTypeNode(format) },
+          ),
+        });
+        const frag = getTypePageFragment(node, createScope());
+        const codecName = format.toUpperCase();
+
+        expect(frag.content).toContain(`get${codecName}Encoder()`);
+        expect(frag.content).toContain(`get${codecName}Decoder()`);
+        expect(frag.content).toContain("=> value.index");
+        expect(frag.content).toContain(
+          `(int value, Uint8List bytes, int offset) => Status${codecName}.values[value]`,
+        );
+      });
+    }
+
+    it("uses BigInt variant indices for u64 scalar enums", () => {
+      const node = definedTypeNode({
+        name: "status_u64",
+        type: enumTypeNode(
+          [
+            enumEmptyVariantTypeNode("active"),
+            enumEmptyVariantTypeNode("inactive"),
+          ],
+          { size: numberTypeNode("u64") },
+        ),
+      });
+      const frag = getTypePageFragment(node, createScope());
+
+      expect(frag.content).toContain("getU64Encoder()");
+      expect(frag.content).toContain("getU64Decoder()");
+      expect(frag.content).toContain("=> BigInt.from(value.index)");
+      expect(frag.content).toContain(
+        "(BigInt value, Uint8List bytes, int offset)",
+      );
+      expect(frag.content).toContain(
+        "value >= BigInt.from(StatusU64.values.length)",
+      );
+      expect(frag.content).toContain("StatusU64.values[value.toInt()]");
+    });
   });
 
   describe("data enum types (sealed classes)", () => {


### PR DESCRIPTION
## Problem

Generated Dart scalar-enum codecs treated every discriminator as an `int`. A Codama enum backed by `u64` therefore failed static analysis and could not safely validate values before converting them into a Dart enum index.

## Changes

- encode `u64` enum indices as `BigInt`
- decode and bounds-check `BigInt` discriminators before converting to an enum index
- preserve the existing `int` path for `u8`, `u16`, and `u32`
- add generated compile/runtime fixtures for all four unsigned widths and invalid tags

## Validation

- renderer typecheck, build, and 401 Vitest tests
- 100% branch coverage for the new width-specific paths
- 55 generated Dart tests plus fatal-info analysis
- full repository lint, docs, monochange, and `git diff --check`

Created on behalf of Ifiok Jr. (@ifiokjr), using OpenAI GPT-5.6 with high reasoning.